### PR TITLE
Issue #10: Project repository updates — queries, projectId FK, date normalization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "chat.tools.terminal.autoApprove": {
+        "npx tsc": true
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,6 @@ This project implements Clean Architecture with strict separation of concerns:
 
 ### Key Dependencies
 - React Native 0.81.1 with React 19.1.0
-- AsyncStorage for local persistence
 - Safe Area Context for proper device handling
 - TypeScript for type safety
 - Jest for testing

--- a/design/#9-Plan.md
+++ b/design/#9-Plan.md
@@ -1,0 +1,241 @@
+# Issue #9 Architecture Plan: Receipt OCR & AI Validation
+
+**Issue**: MVP: Manual upload → OCR → Draft expense → User review → Local save  
+**Created**: 2026-02-02  
+**Status**: Architecture Planning Phase
+
+## 1. Executive Summary
+
+This document outlines the architectural decisions for implementing receipt OCR and AI validation for the Builder Assistant app. The core challenge is to design a cost-effective, privacy-preserving solution that works reliably across iOS and Android platforms.
+
+## 2. Requirements Analysis
+
+### Functional Requirements
+- Manual photo upload (camera or gallery)
+- OCR extraction of: amounts, vendor names, dates
+- AI validation to structure and validate extracted data
+- Draft expense creation with confidence scores
+- User review/edit/accept workflow
+- Encrypted local storage (SQLite)
+
+### Non-Functional Requirements
+- **Cost**: Minimize or eliminate cloud costs (MVP constraint)
+- **Privacy**: User data should remain on-device when possible
+- **Performance**: Acceptable processing time (<5 seconds ideal)
+- **Accuracy**: Sufficient for draft creation (human review step provides safety)
+- **Cross-platform**: Work on both iOS and Android
+
+## 3. Key Architecture Decisions
+
+### Decision 1: Where to Run OCR?
+
+#### Option A: On-Device OCR (RECOMMENDED ✅)
+**Technology**: Google ML Kit Text Recognition v2
+
+
+**Implementation**:
+```javascript
+// React Native ML Kit
+@react-native-ml-kit/text-recognition
+```
+
+**Technical Details**:
+- Uses on-device neural network models
+- Supports Latin, Chinese, Japanese, Korean scripts
+- Returns bounding boxes and confidence scores
+- No device GPU required (CPU optimized)
+
+
+
+**DECISION**: Start with **Option A (On-Device ML Kit)** for MVP
+- Aligns with cost constraints
+- Privacy-first approach
+- Sufficient accuracy for human-reviewed drafts
+- Can add cloud fallback in future iterations
+
+---
+
+### Decision 2: Where to Run AI Validation?
+
+#### Option A: On-Device Lightweight Model (RECOMMENDED ✅)
+**Technology**: TensorFlow Lite or Rule-Based Parser
+
+**Implementation Strategies**:
+
+##### Strategy 2: TensorFlow Lite Model (Future Enhancement)
+```javascript
+// @tensorflow/tfjs-react-native
+// Custom trained model for receipt field classification
+```
+
+**Model Options**:
+- Train custom model on receipt dataset
+- Fine-tune existing NER (Named Entity Recognition) model
+- Use pre-trained models: MobileBERT, DistilBERT (quantized)
+
+
+**DECISION**: Start with **Strategy 2 (TensorFlow Lite Model)** for MVP
+- Zero cost
+- Immediate implementation
+- Sufficient for human-reviewed workflow
+- Easy to enhance with TF Lite later
+- Add cloud AI as optional premium feature in future
+
+---
+
+## 4. Recommended Architecture (MVP)
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Mobile App (React Native)           │
+├─────────────────────────────────────────────────────┤
+│                                                      │
+│  ┌──────────────┐         ┌─────────────────────┐  │
+│  │ Camera/Gallery│────────▶│  Image Capture      │  │
+│  │  Component   │         │  Component          │  │
+│  └──────────────┘         └─────────────────────┘  │
+│                                    │                │
+│                                    ▼                │
+│                           ┌─────────────────────┐  │
+│                           │  ML Kit OCR         │  │
+│                           │  (On-Device)        │  │
+│                           │  @react-native-ml-  │  │
+│                           │  kit/text-recog     │  │
+│                           └─────────────────────┘  │
+│                                    │                │
+│                                    ▼                │
+│                           ┌─────────────────────┐  │
+│                           │  TensorFlow Lite    │  │
+│                           │  Model (On-Device)  │  │
+│                           │  - Field extraction │  │
+│                           │  - Amount / Date /  │  │
+│                           │    Vendor NER       │  │
+│                           │  - Confidence score │  │
+│                           └─────────────────────┘  │
+│                                    │                │
+│                                    ▼                │
+│                           ┌─────────────────────┐  │
+│                           │  Draft Expense      │  │
+│                           │  Creator            │  │
+│                           └─────────────────────┘  │
+│                                    │                │
+│                                    ▼                │
+│                           ┌─────────────────────┐  │
+│                           │  Review UI          │  │
+│                           │  (User Edit/Accept) │  │
+│                           └─────────────────────┘  │
+│                                    │                │
+│                                    ▼                │
+│                           ┌─────────────────────┐  │
+│                           │  Encrypted SQLite   │  │
+│                           │  @op-engineering/   │  │
+│                           │  react-native-quick │  │
+│                           │  -sqlite            │  │
+│                           └─────────────────────┘  │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+
+ALL PROCESSING ON-DEVICE - NO CLOUD COSTS
+```
+
+---
+
+## 5. Technology Stack
+
+### OCR Layer
+**Library**: `@react-native-ml-kit/text-recognition`
+- **Version**: Latest stable
+- **License**: Apache 2.0
+- **Bundle Size**: ~8MB (iOS), ~5MB (Android)
+- **Documentation**: https://github.com/a7medev/react-native-ml-kit
+
+**Alternative** (if ML Kit has issues):
+- `react-native-vision-camera` + `vision-camera-ocr` plugin
+
+### AI Validation Layer (MVP)
+
+**Approach**: TensorFlow Lite model running on-device
+
+**Implementation**:
+- Use a lightweight NER / field-classification model (MobileBERT, DistilBERT or a small transformer) converted to TensorFlow Lite and quantized for mobile.
+- Prototype with `@tensorflow/tfjs-react-native` or native TF Lite bindings for production inference.
+- Model responsibilities: classify OCR tokens, extract amounts/dates/vendors, output structured fields and confidence scores.
+- Training: fine-tune on receipt datasets (SROIE, internal samples) for NER/sequence classification; convert and quantize to TFLite.
+- Inference: run on-device; typical latency <200ms on modern devices. Provide rule-based fallback for very low-confidence cases.
+
+
+### Storage Layer
+**Library**: `@op-engineering/react-native-quick-sqlite`
+- Built-in encryption support
+- High performance
+- React Native optimized
+
+**Schema**:
+```sql
+CREATE TABLE expenses (
+  id TEXT PRIMARY KEY,
+  propertyId TEXT,
+  sourceType TEXT,
+  sourceUri TEXT,
+  rawText TEXT,
+  vendor TEXT,
+  amount REAL,
+  currency TEXT,
+  date TEXT,
+  category TEXT,
+  trade TEXT,
+  confidence REAL,
+  validatedByAI INTEGER,
+  createdAt TEXT,
+  updatedAt TEXT
+);
+```
+
+---
+
+
+
+## 8. Risk Analysis
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Low OCR accuracy on blurry photos | High | Add image quality check, suggest retake |
+| Parser fails on uncommon receipt formats | Medium | Human review step, collect edge cases |
+| ML Kit library compatibility issues | High | Have fallback to vision-camera-ocr |
+| App size increase | Low | Use dynamic feature modules |
+| Privacy concerns with future cloud | Medium | Make cloud features opt-in, transparent |
+
+---
+
+
+## 11. Open Questions
+
+1. **Image Quality**: Should we enforce minimum image quality before OCR?
+2. **Vendor Database**: Build initial vendor-to-category mapping database?
+3. **Multi-language**: Support receipts in languages other than English?
+4. **Receipt Templates**: Pre-define templates for common vendor formats?
+5. **Cloud Strategy**: When/how to introduce optional cloud features?
+
+---
+
+## 12. References & Resources
+
+### Libraries
+- ML Kit: https://developers.google.com/ml-kit/vision/text-recognition
+- React Native ML Kit: https://github.com/a7medev/react-native-ml-kit
+- Quick SQLite: https://github.com/margelo/react-native-quick-sqlite
+
+### Documentation
+- Receipt OCR Best Practices: https://cloud.google.com/vision/docs/ocr
+- TensorFlow Lite: https://www.tensorflow.org/lite
+- Privacy Guidelines: GDPR/CCPA compliance for on-device processing
+
+### Sample Datasets (for testing)
+- SROIE (Scanned Receipts OCR and IE): https://rrc.cvc.uab.es/?ch=13
+- Cordts Receipt Dataset: Public receipt images for testing
+
+
+
+**Document Status**: Draft for Review  
+**Last Updated**: 2026-02-02  
+**Next Review**: After technical spike completion

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,16 @@
+Date: 2026-02-03
+
+Summary (concise)
+- Architecture: On-device ML Kit OCR + TensorFlow Lite validation for receipt → draft expense flow (#9).
+- Domain model: normalized `contacts` (with `RoleType`), `properties`, `projects`, and `work_variations` added.
+
+Completed
+- Created `design/#9-Plan.md` and updated it to reflect ML Kit + TF Lite decisions.
+- Opened and updated GitHub issue #10 (domain model: `projects`, `properties`, `contacts`, `work_variations`).
+- Implemented TypeScript domain entities and repository interfaces under `src/domain/{entities,repositories}` for core models.
+
+Next steps
+- Draft encrypted SQLite DDL for core tables and implement `Local*Repository` adapters (start with `projects`/`properties`).
+- Add unit tests for repository queries (pending payments, upcoming schedule, property queries).
+
+Status: Domain models and interfaces created — ready to draft DDL and repository implementations.

--- a/src/application/usecases/CreateProjectUseCase.ts
+++ b/src/application/usecases/CreateProjectUseCase.ts
@@ -60,14 +60,16 @@ export class CreateProjectUseCase {
 
       // Generate warnings for potential issues
       const warnings: string[] = [];
-      const timelineDuration = project.expectedEndDate.getTime() - project.startDate.getTime();
-      const daysDuration = timelineDuration / (1000 * 60 * 60 * 24);
+      if (project.expectedEndDate && project.startDate) {
+        const timelineDuration = project.expectedEndDate.getTime() - project.startDate.getTime();
+        const daysDuration = timelineDuration / (1000 * 60 * 60 * 24);
 
-      if (daysDuration < 30) {
-        warnings.push('Project timeline is very short - ensure adequate planning time');
+        if (daysDuration < 30) {
+          warnings.push('Project timeline is very short - ensure adequate planning time');
+        }
       }
 
-      if (project.budget < 10000) {
+      if (project.budget !== undefined && project.budget < 10000) {
         warnings.push('Project budget seems low - double-check cost estimates');
       }
 

--- a/src/application/usecases/GetProjectAnalysisUseCase.ts
+++ b/src/application/usecases/GetProjectAnalysisUseCase.ts
@@ -60,7 +60,7 @@ export class GetProjectAnalysisUseCase {
       
       // Calculate budget utilization
       const totalMaterialCost = projectEntity.getTotalMaterialCost();
-      const budgetUtilization = (totalMaterialCost / project.budget) * 100;
+      const budgetUtilization = project.budget ? (totalMaterialCost / project.budget) * 100 : 0;
       
       // Generate recommendations based on analysis
       const recommendations: string[] = [];
@@ -73,7 +73,7 @@ export class GetProjectAnalysisUseCase {
         recommendations.push('Project is over budget - consider cost reduction strategies');
       }
       
-      if (materialAnalysis.wasteEstimate > project.budget * 0.1) {
+      if (project.budget !== undefined && materialAnalysis.wasteEstimate > project.budget * 0.1) {
         recommendations.push('Material waste estimate is high - implement waste reduction strategies');
       }
       

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -81,14 +81,14 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
       <View style={styles.infoRow}>
         <Text style={styles.label}>Budget:</Text>
         <Text style={styles.value}>
-          {CurrencyUtils.formatCurrency(project.budget)}
+          {CurrencyUtils.formatCurrency(project.budget ?? 0)}
         </Text>
       </View>
 
       <View style={styles.infoRow}>
         <Text style={styles.label}>Duration:</Text>
         <Text style={styles.value}>
-          {DateUtils.formatDate(project.startDate)} - {DateUtils.formatDate(project.expectedEndDate)}
+          {project.startDate ? DateUtils.formatDate(project.startDate) : '—'} - {project.expectedEndDate ? DateUtils.formatDate(project.expectedEndDate) : '—'}
         </Text>
       </View>
 

--- a/src/domain/entities/ChangeOrder.ts
+++ b/src/domain/entities/ChangeOrder.ts
@@ -1,0 +1,24 @@
+export interface ChangeOrder {
+  id: string;
+  projectId: string;
+  description?: string;
+  requestedBy?: string; // contactId
+  approvedBy?: string; // contactId
+  amountDelta?: number;
+  status?: 'proposed' | 'approved' | 'rejected';
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class ChangeOrderEntity {
+  constructor(private readonly _data: ChangeOrder) {}
+
+  static create(payload: Omit<ChangeOrder, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): ChangeOrderEntity {
+    const id = payload.id ?? `co_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const c: ChangeOrder = { ...payload, id, createdAt: now, updatedAt: now } as ChangeOrder;
+    return new ChangeOrderEntity(c);
+  }
+
+  data(): ChangeOrder { return { ...this._data }; }
+}

--- a/src/domain/entities/Contact.ts
+++ b/src/domain/entities/Contact.ts
@@ -1,0 +1,28 @@
+export type RoleType = 'INSPECTOR' | 'CONTRACTOR' | 'VENDOR' | 'OWNER' | 'OTHER';
+
+export interface Contact {
+  id: string;
+  name: string;
+  roles?: RoleType[];
+  trade?: string;
+  phone?: string;
+  email?: string;
+  address?: string;
+  rate?: number;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class ContactEntity {
+  constructor(private readonly contact: Contact) {}
+
+  static create(payload: Omit<Contact, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): ContactEntity {
+    const id = payload.id ?? `contact_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const contact: Contact = { ...payload, id, createdAt: now, updatedAt: now } as Contact;
+    return new ContactEntity(contact);
+  }
+
+  data(): Contact { return { ...this.contact }; }
+}

--- a/src/domain/entities/Document.ts
+++ b/src/domain/entities/Document.ts
@@ -1,0 +1,26 @@
+export interface Document {
+  id: string;
+  projectId: string;
+  type?: 'plan' | 'permit' | 'invoice' | 'photo' | string;
+  title?: string;
+  uri?: string;
+  issuedBy?: string; // contact id or string
+  issuedDate?: string;
+  expiresAt?: string;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class DocumentEntity {
+  constructor(private readonly _data: Document) {}
+
+  static create(payload: Omit<Document, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): DocumentEntity {
+    const id = payload.id ?? `doc_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const d: Document = { ...payload, id, createdAt: now, updatedAt: now } as Document;
+    return new DocumentEntity(d);
+  }
+
+  data(): Document { return { ...this._data }; }
+}

--- a/src/domain/entities/Expense.ts
+++ b/src/domain/entities/Expense.ts
@@ -1,0 +1,31 @@
+export interface Expense {
+  id: string;
+  projectId: string;
+  sourceType?: string;
+  sourceUri?: string;
+  rawText?: string;
+  vendorId?: string; // contacts.id
+  amount?: number;
+  currency?: string;
+  date?: string;
+  category?: string;
+  trade?: string;
+  confidence?: number;
+  validatedByAI?: boolean;
+  status?: 'draft' | 'accepted' | 'rejected';
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class ExpenseEntity {
+  constructor(private readonly _data: Expense) {}
+
+  static create(payload: Omit<Expense, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): ExpenseEntity {
+    const id = payload.id ?? `exp_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const exp: Expense = { ...payload, id, createdAt: now, updatedAt: now } as Expense;
+    return new ExpenseEntity(exp);
+  }
+
+  data(): Expense { return { ...this._data }; }
+}

--- a/src/domain/entities/Inspection.ts
+++ b/src/domain/entities/Inspection.ts
@@ -1,0 +1,25 @@
+export interface Inspection {
+  id: string;
+  projectId: string;
+  scheduledDate?: string;
+  inspectorId?: string; // contacts.id
+  status?: 'pending' | 'passed' | 'failed';
+  findings?: string;
+  photos?: string[]; // URIs
+  relatedTaskIds?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class InspectionEntity {
+  constructor(private readonly _data: Inspection) {}
+
+  static create(payload: Omit<Inspection, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): InspectionEntity {
+    const id = payload.id ?? `insp_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const insp: Inspection = { ...payload, id, createdAt: now, updatedAt: now } as Inspection;
+    return new InspectionEntity(insp);
+  }
+
+  data(): Inspection { return { ...this._data }; }
+}

--- a/src/domain/entities/Invoice.ts
+++ b/src/domain/entities/Invoice.ts
@@ -1,0 +1,37 @@
+export interface InvoiceLineItem {
+  id?: string;
+  description: string;
+  quantity?: number;
+  unitCost?: number;
+  total?: number;
+}
+
+export interface Invoice {
+  id: string;
+  projectId: string;
+  vendorId?: string; // contacts.id
+  amount?: number;
+  currency?: string;
+  issueDate?: string;
+  dueDate?: string;
+  paidAmount?: number;
+  status?: 'unpaid' | 'partially_paid' | 'paid' | 'overdue';
+  lineItems?: InvoiceLineItem[];
+  relatedExpenseIds?: string[];
+  attachments?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class InvoiceEntity {
+  constructor(private readonly _data: Invoice) {}
+
+  static create(payload: Omit<Invoice, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): InvoiceEntity {
+    const id = payload.id ?? `inv_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const inv: Invoice = { ...payload, id, createdAt: now, updatedAt: now } as Invoice;
+    return new InvoiceEntity(inv);
+  }
+
+  data(): Invoice { return { ...this._data }; }
+}

--- a/src/domain/entities/Milestone.ts
+++ b/src/domain/entities/Milestone.ts
@@ -1,0 +1,23 @@
+export interface Milestone {
+  id: string;
+  projectId: string;
+  title: string;
+  targetDate?: string;
+  status?: 'planned' | 'in_progress' | 'done' | 'blocked';
+  linkedTaskIds?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class MilestoneEntity {
+  constructor(private readonly _data: Milestone) {}
+
+  static create(payload: Omit<Milestone, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): MilestoneEntity {
+    const id = payload.id ?? `ms_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const m: Milestone = { ...payload, id, createdAt: now, updatedAt: now } as Milestone;
+    return new MilestoneEntity(m);
+  }
+
+  data(): Milestone { return { ...this._data }; }
+}

--- a/src/domain/entities/Payment.ts
+++ b/src/domain/entities/Payment.ts
@@ -1,0 +1,26 @@
+export interface Payment {
+  id: string;
+  projectId: string;
+  invoiceId?: string;
+  expenseId?: string;
+  amount: number;
+  date?: string;
+  method?: 'bank' | 'cash' | 'check' | 'other';
+  status?: 'pending' | 'settled';
+  reference?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class PaymentEntity {
+  constructor(private readonly _data: Payment) {}
+
+  static create(payload: Omit<Payment, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): PaymentEntity {
+    const id = payload.id ?? `pay_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const p: Payment = { ...payload, id, createdAt: now, updatedAt: now } as Payment;
+    return new PaymentEntity(p);
+  }
+
+  data(): Payment { return { ...this._data }; }
+}

--- a/src/domain/entities/Project.ts
+++ b/src/domain/entities/Project.ts
@@ -7,15 +7,22 @@
 
 export interface Project {
   id: string;
+  propertyId?: string;
+  ownerId?: string;
   name: string;
-  description: string;
+  description?: string;
   status: ProjectStatus;
-  startDate: Date;
-  expectedEndDate: Date;
-  budget: number;
+  startDate?: Date; // Date object
+  expectedEndDate?: Date; // Date object
+  budget?: number;
+  currency?: string;
   materials: Material[];
   phases: ProjectPhase[];
+  meta?: Record<string, any>;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
+
 
 export enum ProjectStatus {
   PLANNING = 'planning',
@@ -31,19 +38,28 @@ export interface Material {
   quantity: number;
   unit: string;
   unitCost: number;
-  supplier?: string;
-  estimatedDeliveryDate?: Date;
+  supplier?: string; // contact id or name
+  estimatedDeliveryDate?: Date; // Date
+  projectId?: string; // parent project id (foreign key)
 }
 
 export interface ProjectPhase {
   id: string;
   name: string;
-  description: string;
-  startDate: Date;
-  endDate: Date;
-  dependencies: string[]; // IDs of phases that must complete first
-  isCompleted: boolean;
-  materialsRequired: string[]; // Material IDs
+  description?: string;
+  startDate?: Date; // Date
+  endDate?: Date; // Date
+  dependencies?: string[]; // IDs of phases that must complete first
+  isCompleted?: boolean;
+  materialsRequired?: string[]; // Material IDs
+  projectId?: string; // parent project id (foreign key)
+}
+
+function toDate(v?: string | Date): Date | undefined {
+  if (!v) return undefined;
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  return isNaN(d.getTime()) ? undefined : d;
 }
 
 /**
@@ -52,20 +68,64 @@ export interface ProjectPhase {
 export class ProjectEntity {
   private constructor(private readonly project: Project) {}
 
-  static create(projectData: Omit<Project, 'id'>): ProjectEntity {
-    const id = this.generateId();
+  static create(projectData: Omit<Project, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): ProjectEntity {
+    const id = projectData.id ?? this.generateId();
+    const now = new Date();
+
+    const mappedMaterials = (projectData.materials ?? []).map(m => ({
+      ...m,
+      projectId: m.projectId ?? id,
+      estimatedDeliveryDate: m.estimatedDeliveryDate ? toDate(m.estimatedDeliveryDate) : undefined
+    }));
+
+    const mappedPhases = (projectData.phases ?? []).map(p => ({
+      ...p,
+      projectId: p.projectId ?? id,
+      startDate: p.startDate ? toDate(p.startDate) : undefined,
+      endDate: p.endDate ? toDate(p.endDate) : undefined
+    }));
+
     const project: Project = {
       id,
-      ...projectData
-    };
-    
+      createdAt: now,
+      updatedAt: now,
+      ...projectData,
+      startDate: projectData.startDate ? toDate(projectData.startDate) : undefined,
+      expectedEndDate: projectData.expectedEndDate ? toDate(projectData.expectedEndDate) : undefined,
+      materials: mappedMaterials,
+      phases: mappedPhases
+    } as Project;
+
     this.validateProject(project);
     return new ProjectEntity(project);
   }
 
   static fromData(project: Project): ProjectEntity {
-    this.validateProject(project);
-    return new ProjectEntity(project);
+    const normalizedMaterials = (project.materials ?? []).map(m => ({
+      ...m,
+      projectId: m.projectId ?? project.id,
+      estimatedDeliveryDate: m.estimatedDeliveryDate ? toDate(m.estimatedDeliveryDate) : undefined
+    }));
+
+    const normalizedPhases = (project.phases ?? []).map(p => ({
+      ...p,
+      projectId: p.projectId ?? project.id,
+      startDate: p.startDate ? toDate(p.startDate) : undefined,
+      endDate: p.endDate ? toDate(p.endDate) : undefined
+    }));
+
+    const normalized: Project = {
+      ...project,
+      startDate: project.startDate ? toDate(project.startDate) : undefined,
+      expectedEndDate: project.expectedEndDate ? toDate(project.expectedEndDate) : undefined,
+      createdAt: project.createdAt ? toDate(project.createdAt) : undefined,
+      updatedAt: project.updatedAt ? toDate(project.updatedAt) : undefined,
+      materials: normalizedMaterials,
+      phases: normalizedPhases
+    };
+
+    this.validateProject(normalized);
+    return new ProjectEntity(normalized);
   }
 
   private static validateProject(project: Project): void {
@@ -73,13 +133,32 @@ export class ProjectEntity {
       throw new Error('Project name is required');
     }
 
-    if (project.budget < 0) {
+    if (project.budget !== undefined && project.budget < 0) {
       throw new Error('Project budget cannot be negative');
     }
 
-    if (project.startDate >= project.expectedEndDate) {
-      throw new Error('Expected end date must be after start date');
+    if (project.startDate && project.expectedEndDate) {
+      if (!(project.startDate instanceof Date) || isNaN(project.startDate.getTime()) ||
+          !(project.expectedEndDate instanceof Date) || isNaN(project.expectedEndDate.getTime())) {
+        throw new Error('Invalid date for startDate or expectedEndDate');
+      }
+      if (project.startDate.getTime() >= project.expectedEndDate.getTime()) {
+        throw new Error('Expected end date must be after start date');
+      }
     }
+
+    // Ensure phases/materials reference the same parent project id when present
+    (project.phases || []).forEach(phase => {
+      if (phase.projectId && phase.projectId !== project.id) {
+        throw new Error('Phase projectId must match parent project id');
+      }
+    });
+
+    (project.materials || []).forEach(material => {
+      if (material.projectId && material.projectId !== project.id) {
+        throw new Error('Material projectId must match parent project id');
+      }
+    });
   }
 
   private static generateId(): string {
@@ -93,7 +172,8 @@ export class ProjectEntity {
   updateStatus(newStatus: ProjectStatus): ProjectEntity {
     const updatedProject = {
       ...this.project,
-      status: newStatus
+      status: newStatus,
+      updatedAt: new Date()
     };
     return new ProjectEntity(updatedProject);
   }
@@ -101,29 +181,32 @@ export class ProjectEntity {
   addMaterial(material: Material): ProjectEntity {
     const updatedProject = {
       ...this.project,
-      materials: [...this.project.materials, material]
+      materials: [...(this.project.materials || []), { ...material, projectId: material.projectId ?? this.project.id }],
+      updatedAt: new Date()
     };
     return new ProjectEntity(updatedProject);
   }
 
   getTotalMaterialCost(): number {
-    return this.project.materials.reduce(
+    return (this.project.materials || []).reduce(
       (total, material) => total + (material.quantity * material.unitCost),
       0
     );
   }
 
   isOverBudget(): boolean {
-    return this.getTotalMaterialCost() > this.project.budget;
+    if (this.project.budget === undefined) return false;
+    return this.getTotalMaterialCost() > (this.project.budget ?? 0);
   }
 
   getCompletedPhases(): ProjectPhase[] {
-    return this.project.phases.filter(phase => phase.isCompleted);
+    return (this.project.phases || []).filter(phase => phase.isCompleted);
   }
 
   getProgressPercentage(): number {
-    if (this.project.phases.length === 0) return 0;
+    const phases = this.project.phases || [];
+    if (phases.length === 0) return 0;
     const completedPhases = this.getCompletedPhases().length;
-    return (completedPhases / this.project.phases.length) * 100;
+    return (completedPhases / phases.length) * 100;
   }
 }

--- a/src/domain/entities/Property.ts
+++ b/src/domain/entities/Property.ts
@@ -1,0 +1,30 @@
+export interface Property {
+  id: string;
+  street?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+  address?: string; // full address string
+  propertyType?: 'residential' | 'commercial' | 'mixed';
+  lotSize?: number;
+  lotSizeUnit?: string;
+  yearBuilt?: number;
+  ownerId?: string; // contacts.id
+  meta?: Record<string, any>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class PropertyEntity {
+  constructor(private readonly data: Property) {}
+
+  static create(payload: Omit<Property, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): PropertyEntity {
+    const id = payload.id ?? `prop_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const prop: Property = { ...payload, id, createdAt: now, updatedAt: now } as Property;
+    return new PropertyEntity(prop);
+  }
+
+  dataPlain(): Property { return { ...this.data }; }
+}

--- a/src/domain/entities/Task.ts
+++ b/src/domain/entities/Task.ts
@@ -1,0 +1,29 @@
+export interface Task {
+  id: string;
+  projectId: string;
+  title: string;
+  description?: string;
+  assignedTo?: string; // contactId
+  trade?: string;
+  scheduledStart?: string;
+  scheduledEnd?: string;
+  durationEstimate?: number; // in hours
+  status?: 'pending' | 'in_progress' | 'done' | 'cancelled';
+  priority?: number;
+  dependencies?: string[]; // taskIds
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class TaskEntity {
+  constructor(private readonly task: Task) {}
+
+  static create(payload: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): TaskEntity {
+    const id = payload.id ?? `task_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const t: Task = { ...payload, id, createdAt: now, updatedAt: now } as Task;
+    return new TaskEntity(t);
+  }
+
+  data(): Task { return { ...this.task }; }
+}

--- a/src/domain/entities/WorkVariation.ts
+++ b/src/domain/entities/WorkVariation.ts
@@ -1,0 +1,28 @@
+export interface WorkVariation {
+  id: string;
+  projectId: string;
+  inspectionId?: string;
+  description?: string;
+  requestedBy?: string; // contactId
+  assignedTo?: string; // contactId
+  estimatedCost?: number;
+  approvedBy?: string;
+  status?: 'proposed' | 'approved' | 'in_progress' | 'completed' | 'rejected';
+  relatedTaskIds?: string[];
+  relatedExpenseIds?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class WorkVariationEntity {
+  constructor(private readonly _data: WorkVariation) {}
+
+  static create(payload: Omit<WorkVariation, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }): WorkVariationEntity {
+    const id = payload.id ?? `wv_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    const now = new Date().toISOString();
+    const w: WorkVariation = { ...payload, id, createdAt: now, updatedAt: now } as WorkVariation;
+    return new WorkVariationEntity(w);
+  }
+
+  data(): WorkVariation { return { ...this._data }; }
+}

--- a/src/domain/repositories/ChangeOrderRepository.ts
+++ b/src/domain/repositories/ChangeOrderRepository.ts
@@ -1,0 +1,10 @@
+import { ChangeOrder } from '../entities/ChangeOrder';
+
+export interface ChangeOrderRepository {
+  save(changeOrder: ChangeOrder): Promise<void>;
+  findById(id: string): Promise<ChangeOrder | null>;
+  findAll(): Promise<ChangeOrder[]>;
+  findByProjectId(projectId: string): Promise<ChangeOrder[]>;
+  update(changeOrder: ChangeOrder): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/ContactRepository.ts
+++ b/src/domain/repositories/ContactRepository.ts
@@ -1,0 +1,11 @@
+import { Contact } from '../entities/Contact';
+
+export interface ContactRepository {
+  save(contact: Contact): Promise<void>;
+  findById(id: string): Promise<Contact | null>;
+  findAll(): Promise<Contact[]>;
+  findByRole(role: string): Promise<Contact[]>;
+  findByName(name: string): Promise<Contact[]>;
+  update(contact: Contact): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/DocumentRepository.ts
+++ b/src/domain/repositories/DocumentRepository.ts
@@ -1,0 +1,10 @@
+import { Document } from '../entities/Document';
+
+export interface DocumentRepository {
+  save(document: Document): Promise<void>;
+  findById(id: string): Promise<Document | null>;
+  findAll(): Promise<Document[]>;
+  findByProjectId(projectId: string): Promise<Document[]>;
+  update(document: Document): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/ExpenseRepository.ts
+++ b/src/domain/repositories/ExpenseRepository.ts
@@ -1,0 +1,11 @@
+import { Expense } from '../entities/Expense';
+
+export interface ExpenseRepository {
+  save(expense: Expense): Promise<void>;
+  findById(id: string): Promise<Expense | null>;
+  findAll(): Promise<Expense[]>;
+  findByProjectId(projectId: string): Promise<Expense[]>;
+  findDraftsByProject(projectId: string): Promise<Expense[]>;
+  update(expense: Expense): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/InspectionRepository.ts
+++ b/src/domain/repositories/InspectionRepository.ts
@@ -1,0 +1,11 @@
+import { Inspection } from '../entities/Inspection';
+
+export interface InspectionRepository {
+  save(inspection: Inspection): Promise<void>;
+  findById(id: string): Promise<Inspection | null>;
+  findAll(): Promise<Inspection[]>;
+  findByProjectId(projectId: string): Promise<Inspection[]>;
+  findPendingByProject(projectId: string): Promise<Inspection[]>;
+  update(inspection: Inspection): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/InvoiceRepository.ts
+++ b/src/domain/repositories/InvoiceRepository.ts
@@ -1,0 +1,11 @@
+import { Invoice } from '../entities/Invoice';
+
+export interface InvoiceRepository {
+  save(invoice: Invoice): Promise<void>;
+  findById(id: string): Promise<Invoice | null>;
+  findAll(): Promise<Invoice[]>;
+  findByProjectId(projectId: string): Promise<Invoice[]>;
+  findUnpaidByProject(projectId: string): Promise<Invoice[]>;
+  update(invoice: Invoice): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/MilestoneRepository.ts
+++ b/src/domain/repositories/MilestoneRepository.ts
@@ -1,0 +1,10 @@
+import { Milestone } from '../entities/Milestone';
+
+export interface MilestoneRepository {
+  save(milestone: Milestone): Promise<void>;
+  findById(id: string): Promise<Milestone | null>;
+  findAll(): Promise<Milestone[]>;
+  findByProjectId(projectId: string): Promise<Milestone[]>;
+  update(milestone: Milestone): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/PaymentRepository.ts
+++ b/src/domain/repositories/PaymentRepository.ts
@@ -1,0 +1,11 @@
+import { Payment } from '../entities/Payment';
+
+export interface PaymentRepository {
+  save(payment: Payment): Promise<void>;
+  findById(id: string): Promise<Payment | null>;
+  findAll(): Promise<Payment[]>;
+  findByProjectId(projectId: string): Promise<Payment[]>;
+  findPendingByProject(projectId: string): Promise<Payment[]>;
+  update(payment: Payment): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/ProjectRepository.ts
+++ b/src/domain/repositories/ProjectRepository.ts
@@ -30,6 +30,27 @@ export interface ProjectRepository {
   findByStatus(status: string): Promise<Project[]>;
 
   /**
+   * Find projects for a given property id
+   */
+  findByPropertyId(propertyId: string): Promise<Project[]>;
+
+  /**
+   * Find projects for a given owner/contact id
+   */
+  findByOwnerId(ownerId: string): Promise<Project[]>;
+
+  /**
+   * Find projects that have any phases starting or ending within the given date range (ISO strings)
+   */
+  findByPhaseDateRange(startDate?: string, endDate?: string): Promise<Project[]>;
+
+  /**
+   * Find projects that contain phases with upcoming start dates on or before the provided ISO date
+   * Useful for building upcoming schedule queries.
+   */
+  findWithUpcomingPhases(untilDate: string): Promise<Project[]>;
+
+  /**
    * Update an existing project
    */
   update(project: Project): Promise<void>;

--- a/src/domain/repositories/PropertyRepository.ts
+++ b/src/domain/repositories/PropertyRepository.ts
@@ -1,0 +1,11 @@
+import { Property } from '../entities/Property';
+
+export interface PropertyRepository {
+  save(property: Property): Promise<void>;
+  findById(id: string): Promise<Property | null>;
+  findAll(): Promise<Property[]>;
+  findByAddress(address: string): Promise<Property | null>;
+  findByOwnerId(ownerId: string): Promise<Property[]>;
+  update(property: Property): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/TaskRepository.ts
+++ b/src/domain/repositories/TaskRepository.ts
@@ -1,0 +1,11 @@
+import { Task } from '../entities/Task';
+
+export interface TaskRepository {
+  save(task: Task): Promise<void>;
+  findById(id: string): Promise<Task | null>;
+  findAll(): Promise<Task[]>;
+  findByProjectId(projectId: string): Promise<Task[]>;
+  findUpcoming(projectId: string, daysAhead?: number): Promise<Task[]>;
+  update(task: Task): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/repositories/WorkVariationRepository.ts
+++ b/src/domain/repositories/WorkVariationRepository.ts
@@ -1,0 +1,11 @@
+import { WorkVariation } from '../entities/WorkVariation';
+
+export interface WorkVariationRepository {
+  save(wv: WorkVariation): Promise<void>;
+  findById(id: string): Promise<WorkVariation | null>;
+  findAll(): Promise<WorkVariation[]>;
+  findByProjectId(projectId: string): Promise<WorkVariation[]>;
+  findOpenByProject(projectId: string): Promise<WorkVariation[]>;
+  update(wv: WorkVariation): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/services/ProjectValidationService.ts
+++ b/src/domain/services/ProjectValidationService.ts
@@ -13,8 +13,8 @@ export class ProjectValidationService {
    */
   static canStartPhase(phase: ProjectPhase, completedPhases: ProjectPhase[]): boolean {
     const completedPhaseIds = new Set(completedPhases.map(p => p.id));
-    
-    return phase.dependencies.every(depId => completedPhaseIds.has(depId));
+
+    return (phase.dependencies ?? []).every(depId => completedPhaseIds.has(depId));
   }
 
   /**
@@ -22,8 +22,8 @@ export class ProjectValidationService {
    */
   static areMaterialsAvailable(phase: ProjectPhase, availableMaterials: Material[]): boolean {
     const availableMaterialIds = new Set(availableMaterials.map(m => m.id));
-    
-    return phase.materialsRequired.every(materialId => 
+
+    return (phase.materialsRequired ?? []).every(materialId =>
       availableMaterialIds.has(materialId)
     );
   }
@@ -35,28 +35,30 @@ export class ProjectValidationService {
     const issues: string[] = [];
     
     // Check for overlapping phases that shouldn't overlap
-    const phases = project.phases.sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
-    
+    const phases = project.phases
+      .filter(p => p.startDate && p.endDate)
+      .sort((a, b) => (a.startDate!.getTime() - b.startDate!.getTime()));
+
     for (let i = 0; i < phases.length - 1; i++) {
       const currentPhase = phases[i];
       const nextPhase = phases[i + 1];
-      
-      // If next phase starts before current phase ends and has no dependency on current phase
-      if (nextPhase.startDate < currentPhase.endDate && 
-          !nextPhase.dependencies.includes(currentPhase.id)) {
+
+      if (nextPhase.startDate! < currentPhase.endDate! &&
+          !(nextPhase.dependencies ?? []).includes(currentPhase.id)) {
         issues.push(`Phase "${nextPhase.name}" overlaps with "${currentPhase.name}" without proper dependency`);
       }
     }
-    
+
     // Check for unrealistic phase durations
     phases.forEach(phase => {
+      if (!phase.startDate || !phase.endDate) return;
       const duration = phase.endDate.getTime() - phase.startDate.getTime();
       const daysDuration = duration / (1000 * 60 * 60 * 24);
-      
+
       if (daysDuration < 1) {
         issues.push(`Phase "${phase.name}" has unrealistically short duration (less than 1 day)`);
       }
-      
+
       if (daysDuration > 365) {
         issues.push(`Phase "${phase.name}" has very long duration (over 1 year) - consider breaking into sub-phases`);
       }

--- a/src/services/LocalStorageProjectRepository.ts
+++ b/src/services/LocalStorageProjectRepository.ts
@@ -55,6 +55,52 @@ export class LocalStorageProjectRepository implements ProjectRepository {
     }
   }
 
+  async findByPropertyId(propertyId: string): Promise<Project[]> {
+    try {
+      const projects = await this.findAll();
+      return projects.filter(p => p.propertyId === propertyId);
+    } catch (error) {
+      throw new Error(`Failed to find projects by propertyId: ${error}`);
+    }
+  }
+
+  async findByOwnerId(ownerId: string): Promise<Project[]> {
+    try {
+      const projects = await this.findAll();
+      return projects.filter(p => p.ownerId === ownerId);
+    } catch (error) {
+      throw new Error(`Failed to find projects by ownerId: ${error}`);
+    }
+  }
+
+  async findByPhaseDateRange(startDate?: string, endDate?: string): Promise<Project[]> {
+    try {
+      const s = startDate ? new Date(startDate) : undefined;
+      const e = endDate ? new Date(endDate) : undefined;
+      const projects = await this.findAll();
+      return projects.filter(p => (p.phases || []).some(phase => {
+        const ps = phase.startDate;
+        const pe = phase.endDate;
+        if (!ps && !pe) return false;
+        if (s && ps && ps < s) return false;
+        if (e && pe && pe > e) return false;
+        return true;
+      }));
+    } catch (error) {
+      throw new Error(`Failed to find projects by phase date range: ${error}`);
+    }
+  }
+
+  async findWithUpcomingPhases(untilDate: string): Promise<Project[]> {
+    try {
+      const until = new Date(untilDate);
+      const projects = await this.findAll();
+      return projects.filter(p => (p.phases || []).some(phase => phase.startDate && phase.startDate <= until));
+    } catch (error) {
+      throw new Error(`Failed to find projects with upcoming phases: ${error}`);
+    }
+  }
+
   async update(project: Project): Promise<void> {
     try {
       const projects = await this.findAll();


### PR DESCRIPTION
Closes #10

Summary
- Add project-relevant queries to `ProjectRepository` (by propertyId, ownerId, phase date range, upcoming phases).
- Add `projectId` foreign key to `ProjectPhase` and `Material` and auto-fill/validate in `ProjectEntity`.
- Normalize date fields to `Date` in `Project` entity and conversion helpers.
- Fix validation and optional-field guards in services and use-cases.
- Implement new queries in `LocalStorageProjectRepository`.

Files changed: entity updates, repository interface, local storage adapter, validation/use-cases, and related entity fixes.

Notes
- This prepares the domain model and local adapter for migrating to a SQLite-backed repository.
- CI/tests: Jest suite passes locally (1 suite).

Please review and assign reviewers. Thanks!