### PR TITLE
Issue #41 — ProjectDetails domain refactor, mappers, repo methods, tests

### DIFF
--- a/__mocks__/nativewind.js
+++ b/__mocks__/nativewind.js
@@ -1,0 +1,14 @@
+const useColorScheme = () => ({ colorScheme: 'light' });
+
+const verifyInstallation = () => {};
+
+const vars = (value) => value;
+
+const cssInterop = () => {};
+
+module.exports = {
+  useColorScheme,
+  verifyInstallation,
+  vars,
+  cssInterop,
+};

--- a/__mocks__/react-native-safe-area-context.js
+++ b/__mocks__/react-native-safe-area-context.js
@@ -1,0 +1,13 @@
+const React = require('react');
+const { View } = require('react-native');
+
+const SafeAreaView = ({ children, ...props }) => React.createElement(View, props, children);
+const SafeAreaProvider = ({ children, ...props }) => React.createElement(View, props, children);
+
+const useSafeAreaInsets = () => ({ top: 0, bottom: 0, left: 0, right: 0 });
+
+module.exports = {
+  SafeAreaView,
+  SafeAreaProvider,
+  useSafeAreaInsets,
+};

--- a/__tests__/integration/DrizzleProjectRepository.integration.test.ts
+++ b/__tests__/integration/DrizzleProjectRepository.integration.test.ts
@@ -56,7 +56,7 @@ jest.mock('react-native-sqlite-storage', () => {
 
 import { DrizzleProjectRepository } from '../../src/infrastructure/repositories/DrizzleProjectRepository';
 import { ProjectEntity, ProjectStatus } from '../../src/domain/entities/Project';
-import { closeDatabase } from '../../src/infrastructure/database/connection';
+import { closeDatabase, getDatabase } from '../../src/infrastructure/database/connection';
 
 describe('DrizzleProjectRepository integration (better-sqlite3 :memory:)', () => {
   it('runs real SQL via Drizzle: create, read, update, delete', async () => {
@@ -148,6 +148,53 @@ describe('DrizzleProjectRepository integration (better-sqlite3 :memory:)', () =>
 
     // cleanup
     await repo.delete?.('int-project-2');
+    await closeDatabase();
+  }, 15000);
+
+  it('returns hydrated project details for owner and property', async () => {
+    const repo = new DrizzleProjectRepository();
+    await repo.init();
+
+    const { db } = getDatabase();
+
+    await db.executeSql(
+      `INSERT INTO contacts (id, name, roles, email, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ['contact-1', 'Owner Person', JSON.stringify(['OWNER']), 'owner@example.com', Date.now(), Date.now()]
+    );
+
+    await db.executeSql(
+      `INSERT INTO properties (id, address, owner_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      ['prop-1', '123 Main St', 'contact-1', Date.now(), Date.now()]
+    );
+
+    const projectEntity = ProjectEntity.create({
+      id: 'details-project-1',
+      name: 'Details Project',
+      status: ProjectStatus.IN_PROGRESS,
+      ownerId: 'contact-1',
+      propertyId: 'prop-1',
+      materials: [],
+      phases: [],
+    });
+
+    await repo.save(projectEntity.data);
+
+    const details = await repo.findDetailsById('details-project-1');
+    expect(details).not.toBeNull();
+    expect(details!.owner.id).toBe('contact-1');
+    expect(details!.owner.name).toBe('Owner Person');
+    expect(details!.property?.id).toBe('prop-1');
+    expect(details!.property?.address).toBe('123 Main St');
+
+    const listDetails = await repo.listDetails({}, { limit: 10 });
+    const listed = listDetails.items.find((item) => item.id === 'details-project-1');
+    expect(listed).toBeDefined();
+    expect(listed!.owner.id).toBe('contact-1');
+    expect(listed!.property?.id).toBe('prop-1');
+
+    await repo.delete('details-project-1');
     await closeDatabase();
   }, 15000);
 

--- a/__tests__/unit/GetProjectDetailsUseCase.test.ts
+++ b/__tests__/unit/GetProjectDetailsUseCase.test.ts
@@ -1,0 +1,26 @@
+import { GetProjectDetailsUseCase } from '../../src/application/usecases/project/GetProjectDetailsUseCase';
+import { ProjectDetails } from '../../src/domain/entities/ProjectDetails';
+import { ProjectStatus } from '../../src/domain/entities/Project';
+
+describe('GetProjectDetailsUseCase', () => {
+  it('returns project details from repository', async () => {
+    const fakeDetails: ProjectDetails = {
+      id: 'proj-1',
+      ownerId: 'owner-1',
+      propertyId: undefined,
+      name: 'Test Project',
+      status: ProjectStatus.IN_PROGRESS,
+      materials: [],
+      phases: [],
+      owner: { id: 'owner-1', name: 'Owner Name' },
+    };
+
+    const repo = { findDetailsById: jest.fn().mockResolvedValue(fakeDetails) };
+
+    const useCase = new GetProjectDetailsUseCase(repo as any);
+    const result = await useCase.execute('proj-1');
+
+    expect(result).toBe(fakeDetails);
+    expect(repo.findDetailsById).toHaveBeenCalledWith('proj-1');
+  });
+});

--- a/__tests__/unit/ManualProjectEntryButton.test.tsx
+++ b/__tests__/unit/ManualProjectEntryButton.test.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import renderer, { act } from 'react-test-renderer';
 import { ManualProjectEntryButton } from '../../src/components/ManualProjectEntryButton';
 
 describe('ManualProjectEntryButton', () => {
-  it('renders without crashing and shows the button', () => {
-    const tree = renderer.create(<ManualProjectEntryButton />).toJSON();
+  it('renders without crashing and shows the button', async () => {
+    let testRenderer: renderer.ReactTestRenderer | undefined;
+
+    await act(async () => {
+      testRenderer = renderer.create(<ManualProjectEntryButton />);
+    });
+
+    const tree = testRenderer!.toJSON();
+    act(() => {
+      testRenderer!.unmount();
+    });
     expect(tree).toMatchSnapshot();
   });
 });

--- a/__tests__/unit/ManualProjectEntryForm.test.tsx
+++ b/__tests__/unit/ManualProjectEntryForm.test.tsx
@@ -4,23 +4,37 @@ import ManualProjectEntryForm from '../../src/components/ManualProjectEntryForm'
 import { TextInput, Button } from 'react-native';
 
 describe('ManualProjectEntryForm', () => {
-  it('renders form when visible', () => {
+  it('renders form when visible', async () => {
     const onSave = jest.fn();
     const onCancel = jest.fn();
 
-    const tree = renderer
-      .create(<ManualProjectEntryForm visible={true} onSave={onSave} onCancel={onCancel} />)
-      .toJSON();
+    let testRenderer: renderer.ReactTestRenderer | undefined;
+
+    await act(async () => {
+      testRenderer = renderer.create(<ManualProjectEntryForm visible={true} onSave={onSave} onCancel={onCancel} />);
+    });
+
+    const tree = testRenderer!.toJSON();
+    act(() => {
+      testRenderer!.unmount();
+    });
     expect(tree).toMatchSnapshot();
   });
 
-  it('does not render when not visible', () => {
+  it('does not render when not visible', async () => {
     const onSave = jest.fn();
     const onCancel = jest.fn();
 
-    const tree = renderer
-      .create(<ManualProjectEntryForm visible={false} onSave={onSave} onCancel={onCancel} />)
-      .toJSON();
+    let testRenderer: renderer.ReactTestRenderer | undefined;
+
+    await act(async () => {
+      testRenderer = renderer.create(<ManualProjectEntryForm visible={false} onSave={onSave} onCancel={onCancel} />);
+    });
+
+    const tree = testRenderer!.toJSON();
+    act(() => {
+      testRenderer!.unmount();
+    });
     expect(tree).toBeNull();
   });
 

--- a/__tests__/unit/ProjectsPage.test.tsx
+++ b/__tests__/unit/ProjectsPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import renderer, { act } from 'react-test-renderer';
 import ProjectsPage from '../../src/pages/projects/ProjectsPage';
 import { useProjects } from '../../src/hooks/useProjects';
 import { ProjectStatus } from '../../src/domain/entities/Project';
@@ -13,7 +13,7 @@ describe('ProjectsPage', () => {
     mockedUseProjects.mockReset();
   });
 
-  it('renders loading state', () => {
+  it('renders loading state', async () => {
     mockedUseProjects.mockReturnValue({
       projects: [],
       loading: true,
@@ -23,11 +23,20 @@ describe('ProjectsPage', () => {
       refreshProjects: async () => {},
     } as any);
 
-    const tree = renderer.create(<ProjectsPage />).toJSON();
+    let testRenderer: renderer.ReactTestRenderer | undefined;
+
+    await act(async () => {
+      testRenderer = renderer.create(<ProjectsPage />);
+    });
+
+    const tree = testRenderer!.toJSON();
+    act(() => {
+      testRenderer!.unmount();
+    });
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders list of projects', () => {
+  it('renders list of projects', async () => {
     mockedUseProjects.mockReturnValue({
       projects: [
         {
@@ -46,7 +55,16 @@ describe('ProjectsPage', () => {
       refreshProjects: async () => {},
     } as any);
 
-    const tree = renderer.create(<ProjectsPage />).toJSON();
+    let testRenderer: renderer.ReactTestRenderer | undefined;
+
+    await act(async () => {
+      testRenderer = renderer.create(<ProjectsPage />);
+    });
+
+    const tree = testRenderer!.toJSON();
+    act(() => {
+      testRenderer!.unmount();
+    });
     expect(tree).toMatchSnapshot();
   });
 });

--- a/__tests__/unit/__snapshots__/ManualProjectEntryButton.test.tsx.snap
+++ b/__tests__/unit/__snapshots__/ManualProjectEntryButton.test.tsx.snap
@@ -1,3 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ManualProjectEntryButton renders without crashing and shows the button 1`] = `null`;
+exports[`ManualProjectEntryButton renders without crashing and shows the button 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  className="bg-card border-2 border-border rounded-xl p-4 mb-4 flex-row items-center justify-center active:opacity-70"
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <RNSVGSvgView
+    align="xMidYMid"
+    bbHeight={20}
+    bbWidth={20}
+    className="text-foreground mr-2"
+    fill="none"
+    focusable={false}
+    height={20}
+    meetOrSlice={0}
+    minX={0}
+    minY={0}
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth={2}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderWidth": 0,
+        },
+        {
+          "flex": 0,
+          "height": 20,
+          "width": 20,
+        },
+      ]
+    }
+    vbHeight={24}
+    vbWidth={24}
+    width={20}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <RNSVGGroup
+      fill={null}
+      propList={
+        [
+          "fill",
+          "stroke",
+          "strokeWidth",
+          "strokeLinecap",
+          "strokeLinejoin",
+        ]
+      }
+      stroke={
+        {
+          "type": 2,
+        }
+      }
+      strokeLinecap={1}
+      strokeLinejoin={1}
+      strokeWidth={2}
+    >
+      <RNSVGPath
+        d="M13 21h8"
+        fill={null}
+        propList={
+          [
+            "fill",
+            "stroke",
+            "strokeWidth",
+            "strokeLinecap",
+            "strokeLinejoin",
+          ]
+        }
+        stroke={
+          {
+            "type": 2,
+          }
+        }
+        strokeLinecap={1}
+        strokeLinejoin={1}
+        strokeWidth={2}
+      />
+      <RNSVGPath
+        d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+        fill={null}
+        propList={
+          [
+            "fill",
+            "stroke",
+            "strokeWidth",
+            "strokeLinecap",
+            "strokeLinejoin",
+          ]
+        }
+        stroke={
+          {
+            "type": 2,
+          }
+        }
+        strokeLinecap={1}
+        strokeLinejoin={1}
+        strokeWidth={2}
+      />
+    </RNSVGGroup>
+  </RNSVGSvgView>
+  <Text
+    className="text-foreground font-semibold text-base"
+  >
+    + Manual Project Entry
+  </Text>
+</View>
+`;

--- a/__tests__/unit/__snapshots__/ManualProjectEntryForm.test.tsx.snap
+++ b/__tests__/unit/__snapshots__/ManualProjectEntryForm.test.tsx.snap
@@ -1,3 +1,486 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ManualProjectEntryForm renders form when visible 1`] = `null`;
+exports[`ManualProjectEntryForm renders form when visible 1`] = `
+<RCTScrollView
+  className="flex-1 p-4 bg-background"
+>
+  <View>
+    <Text
+      className="text-2xl font-bold mb-6 text-foreground"
+    >
+      New Project
+    </Text>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Name *
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        onChangeText={[Function]}
+        placeholder="Project name"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Address *
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        onChangeText={[Function]}
+        placeholder="Property address"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Description
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        multiline={true}
+        numberOfLines={3}
+        onChangeText={[Function]}
+        placeholder="Project description"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Project Owner
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        onChangeText={[Function]}
+        placeholder="Owner name or ID"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Team
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        onChangeText={[Function]}
+        placeholder="Team members"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Start Date
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        onChangeText={[Function]}
+        placeholder="YYYY-MM-DD"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        End Date
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        onChangeText={[Function]}
+        placeholder="YYYY-MM-DD"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Budget
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        keyboardType="numeric"
+        onChangeText={[Function]}
+        placeholder="0.00"
+        value=""
+      />
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Priority
+      </Text>
+      <View
+        className="flex-row gap-2"
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {},
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#007AFF",
+                    "fontSize": 18,
+                    "margin": 8,
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#007AFF",
+                  },
+                ]
+              }
+            >
+              Low
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {},
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#007AFF",
+                    "fontSize": 18,
+                    "margin": 8,
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#8E8E93",
+                  },
+                ]
+              }
+            >
+              Medium
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {},
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#007AFF",
+                    "fontSize": 18,
+                    "margin": 8,
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "#8E8E93",
+                  },
+                ]
+              }
+            >
+              High
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      className="mb-4"
+    >
+      <Text
+        className="mb-1 font-semibold text-foreground"
+      >
+        Notes
+      </Text>
+      <TextInput
+        className="border border-border rounded p-2 bg-card text-foreground"
+        multiline={true}
+        numberOfLines={4}
+        onChangeText={[Function]}
+        placeholder="Additional notes"
+        value=""
+      />
+    </View>
+    <View
+      className="flex-row justify-end mt-6 mb-4"
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {},
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#007AFF",
+                  "fontSize": 18,
+                  "margin": 8,
+                  "textAlign": "center",
+                },
+                {
+                  "color": "#8E8E93",
+                },
+              ]
+            }
+          >
+            Cancel
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "width": 12,
+          }
+        }
+      />
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {},
+              {},
+            ]
+          }
+        >
+          <Text
+            disabled={true}
+            style={
+              [
+                {
+                  "color": "#007AFF",
+                  "fontSize": 18,
+                  "margin": 8,
+                  "textAlign": "center",
+                },
+                {
+                  "color": "#cdcdcd",
+                },
+              ]
+            }
+          >
+            Save
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/__tests__/unit/__snapshots__/ProjectsPage.test.tsx.snap
+++ b/__tests__/unit/__snapshots__/ProjectsPage.test.tsx.snap
@@ -1,5 +1,1089 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProjectsPage renders list of projects 1`] = `null`;
+exports[`ProjectsPage renders list of projects 1`] = `
+<View
+  className="flex-1 bg-background"
+>
+  <View
+    className="px-6 py-4 flex-row items-center justify-between"
+  >
+    <View
+      className="flex-row items-center"
+    >
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={24}
+        bbWidth={24}
+        className="text-primary mr-3"
+        fill="none"
+        focusable={false}
+        height={24}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "flex": 0,
+              "height": 24,
+              "width": 24,
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            [
+              "fill",
+              "stroke",
+              "strokeWidth",
+              "strokeLinecap",
+              "strokeLinejoin",
+            ]
+          }
+          stroke={
+            {
+              "type": 2,
+            }
+          }
+          strokeLinecap={1}
+          strokeLinejoin={1}
+          strokeWidth={2}
+        >
+          <RNSVGPath
+            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+          <RNSVGPath
+            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+          <RNSVGPath
+            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+      <Text
+        className="text-2xl font-bold text-foreground"
+      >
+        Projects
+      </Text>
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "opacity": 1,
+        }
+      }
+    >
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={20}
+        bbWidth={20}
+        fill="none"
+        focusable={false}
+        height={20}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        stroke="#4b5563"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "flex": 0,
+              "height": 20,
+              "width": 20,
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            [
+              "fill",
+              "stroke",
+              "strokeWidth",
+              "strokeLinecap",
+              "strokeLinejoin",
+            ]
+          }
+          stroke={
+            {
+              "payload": 4283127139,
+              "type": 0,
+            }
+          }
+          strokeLinecap={1}
+          strokeLinejoin={1}
+          strokeWidth={2}
+        >
+          <RNSVGPath
+            d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4283127139,
+                "type": 0,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+    </View>
+  </View>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "paddingBottom": 128,
+      }
+    }
+  >
+    <View>
+      <View
+        className="px-6 gap-4"
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          className="bg-card border border-border rounded-2xl p-5 active:opacity-80"
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+        >
+          <View
+            className="flex-row items-start justify-between mb-4"
+          >
+            <View
+              className="flex-1 mr-3"
+            >
+              <Text
+                className="text-lg font-bold text-foreground mb-1"
+              >
+                Test Project
+              </Text>
+              <View
+                className="flex-row items-center"
+              >
+                <RNSVGSvgView
+                  align="xMidYMid"
+                  bbHeight={14}
+                  bbWidth={14}
+                  className="text-muted-foreground mr-1.5"
+                  fill="none"
+                  focusable={false}
+                  height={14}
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      {
+                        "flex": 0,
+                        "height": 14,
+                        "width": 14,
+                      },
+                    ]
+                  }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width={14}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <RNSVGGroup
+                    fill={null}
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                        "strokeLinecap",
+                        "strokeLinejoin",
+                      ]
+                    }
+                    stroke={
+                      {
+                        "type": 2,
+                      }
+                    }
+                    strokeLinecap={1}
+                    strokeLinejoin={1}
+                    strokeWidth={2}
+                  >
+                    <RNSVGPath
+                      d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
+                      fill={null}
+                      propList={
+                        [
+                          "fill",
+                          "stroke",
+                          "strokeWidth",
+                          "strokeLinecap",
+                          "strokeLinejoin",
+                        ]
+                      }
+                      stroke={
+                        {
+                          "type": 2,
+                        }
+                      }
+                      strokeLinecap={1}
+                      strokeLinejoin={1}
+                      strokeWidth={2}
+                    />
+                    <RNSVGCircle
+                      cx="12"
+                      cy="10"
+                      fill={null}
+                      propList={
+                        [
+                          "fill",
+                          "stroke",
+                          "strokeWidth",
+                          "strokeLinecap",
+                          "strokeLinejoin",
+                        ]
+                      }
+                      r="3"
+                      stroke={
+                        {
+                          "type": 2,
+                        }
+                      }
+                      strokeLinecap={1}
+                      strokeLinejoin={1}
+                      strokeWidth={2}
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+                <Text
+                  className="text-muted-foreground text-sm flex-1"
+                  numberOfLines={1}
+                >
+                  A test
+                </Text>
+              </View>
+            </View>
+            <View
+              className="px-2.5 py-1 rounded-full bg-chart-2/10"
+            >
+              <Text
+                className="text-xs font-semibold text-chart-2"
+              >
+                Active
+              </Text>
+            </View>
+          </View>
+          <View
+            className="flex-row items-center mb-4"
+          >
+            <RNSVGSvgView
+              align="xMidYMid"
+              bbHeight={16}
+              bbWidth={16}
+              className="text-muted-foreground mr-2"
+              fill="none"
+              focusable={false}
+              height={16}
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              style={
+                [
+                  {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  {
+                    "flex": 0,
+                    "height": 16,
+                    "width": 16,
+                  },
+                ]
+              }
+              vbHeight={24}
+              vbWidth={24}
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <RNSVGGroup
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                    "strokeLinecap",
+                    "strokeLinejoin",
+                  ]
+                }
+                stroke={
+                  {
+                    "type": 2,
+                  }
+                }
+                strokeLinecap={1}
+                strokeLinejoin={1}
+                strokeWidth={2}
+              >
+                <RNSVGPath
+                  d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  stroke={
+                    {
+                      "type": 2,
+                    }
+                  }
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeWidth={2}
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+            <Text
+              className="text-muted-foreground text-sm"
+            >
+              Unknown
+            </Text>
+          </View>
+          <View
+            className="bg-muted/50 rounded-xl p-3 mb-3"
+          >
+            <View
+              className="flex-row items-center mb-1.5"
+            >
+              <RNSVGSvgView
+                align="xMidYMid"
+                bbHeight={16}
+                bbWidth={16}
+                className="text-chart-2 mr-2"
+                fill="none"
+                focusable={false}
+                height={16}
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    {
+                      "flex": 0,
+                      "height": 16,
+                      "width": 16,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  stroke={
+                    {
+                      "type": 2,
+                    }
+                  }
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeWidth={2}
+                >
+                  <RNSVGPath
+                    d="M21.801 10A10 10 0 1 1 17 3.335"
+                    fill={null}
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                        "strokeLinecap",
+                        "strokeLinejoin",
+                      ]
+                    }
+                    stroke={
+                      {
+                        "type": 2,
+                      }
+                    }
+                    strokeLinecap={1}
+                    strokeLinejoin={1}
+                    strokeWidth={2}
+                  />
+                  <RNSVGPath
+                    d="m9 11 3 3L22 4"
+                    fill={null}
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                        "strokeLinecap",
+                        "strokeLinejoin",
+                      ]
+                    }
+                    stroke={
+                      {
+                        "type": 2,
+                      }
+                    }
+                    strokeLinecap={1}
+                    strokeLinejoin={1}
+                    strokeWidth={2}
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+              <Text
+                className="text-xs font-semibold text-muted-foreground uppercase tracking-wide"
+              >
+                Last Completed
+              </Text>
+            </View>
+            <Text
+              className="text-foreground font-semibold text-sm mb-1"
+            >
+              Initial Setup
+            </Text>
+            <Text
+              className="text-muted-foreground text-xs"
+            >
+              -
+            </Text>
+          </View>
+          <View
+            className="bg-primary/5 rounded-xl p-3"
+          >
+            <View
+              className="flex-row items-center mb-2"
+            >
+              <RNSVGSvgView
+                align="xMidYMid"
+                bbHeight={16}
+                bbWidth={16}
+                className="text-primary mr-2"
+                fill="none"
+                focusable={false}
+                height={16}
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    {
+                      "flex": 0,
+                      "height": 16,
+                      "width": 16,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  stroke={
+                    {
+                      "type": 2,
+                    }
+                  }
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeWidth={2}
+                >
+                  <RNSVGPath
+                    d="M12 6v6l4 2"
+                    fill={null}
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                        "strokeLinecap",
+                        "strokeLinejoin",
+                      ]
+                    }
+                    stroke={
+                      {
+                        "type": 2,
+                      }
+                    }
+                    strokeLinecap={1}
+                    strokeLinejoin={1}
+                    strokeWidth={2}
+                  />
+                  <RNSVGCircle
+                    cx="12"
+                    cy="12"
+                    fill={null}
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                        "strokeLinecap",
+                        "strokeLinejoin",
+                      ]
+                    }
+                    r="10"
+                    stroke={
+                      {
+                        "type": 2,
+                      }
+                    }
+                    strokeLinecap={1}
+                    strokeLinejoin={1}
+                    strokeWidth={2}
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+              <Text
+                className="text-xs font-semibold text-muted-foreground uppercase tracking-wide"
+              >
+                Upcoming Tasks (
+                0
+                )
+              </Text>
+            </View>
+            <View
+              className="gap-2"
+            />
+          </View>
+          <View
+            className="flex-row justify-end mt-4"
+          >
+            <RNSVGSvgView
+              align="xMidYMid"
+              bbHeight={20}
+              bbWidth={20}
+              className="text-muted-foreground"
+              fill="none"
+              focusable={false}
+              height={20}
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              style={
+                [
+                  {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  {
+                    "flex": 0,
+                    "height": 20,
+                    "width": 20,
+                  },
+                ]
+              }
+              vbHeight={24}
+              vbWidth={24}
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <RNSVGGroup
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                    "strokeLinecap",
+                    "strokeLinejoin",
+                  ]
+                }
+                stroke={
+                  {
+                    "type": 2,
+                  }
+                }
+                strokeLinecap={1}
+                strokeLinejoin={1}
+                strokeWidth={2}
+              >
+                <RNSVGPath
+                  d="m9 18 6-6-6-6"
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  stroke={
+                    {
+                      "type": 2,
+                    }
+                  }
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeWidth={2}
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
+        </View>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
 
-exports[`ProjectsPage renders loading state 1`] = `null`;
+exports[`ProjectsPage renders loading state 1`] = `
+<View
+  className="flex-1 bg-background"
+>
+  <View
+    className="px-6 py-4 flex-row items-center justify-between"
+  >
+    <View
+      className="flex-row items-center"
+    >
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={24}
+        bbWidth={24}
+        className="text-primary mr-3"
+        fill="none"
+        focusable={false}
+        height={24}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "flex": 0,
+              "height": 24,
+              "width": 24,
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            [
+              "fill",
+              "stroke",
+              "strokeWidth",
+              "strokeLinecap",
+              "strokeLinejoin",
+            ]
+          }
+          stroke={
+            {
+              "type": 2,
+            }
+          }
+          strokeLinecap={1}
+          strokeLinejoin={1}
+          strokeWidth={2}
+        >
+          <RNSVGPath
+            d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+          <RNSVGPath
+            d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+          <RNSVGPath
+            d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "type": 2,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+      <Text
+        className="text-2xl font-bold text-foreground"
+      >
+        Projects
+      </Text>
+    </View>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "opacity": 1,
+        }
+      }
+    >
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={20}
+        bbWidth={20}
+        fill="none"
+        focusable={false}
+        height={20}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        stroke="#4b5563"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "flex": 0,
+              "height": 20,
+              "width": 20,
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            [
+              "fill",
+              "stroke",
+              "strokeWidth",
+              "strokeLinecap",
+              "strokeLinejoin",
+            ]
+          }
+          stroke={
+            {
+              "payload": 4283127139,
+              "type": 0,
+            }
+          }
+          strokeLinecap={1}
+          strokeLinejoin={1}
+          strokeWidth={2}
+        >
+          <RNSVGPath
+            d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"
+            fill={null}
+            propList={
+              [
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4283127139,
+                "type": 0,
+              }
+            }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+    </View>
+  </View>
+  <View
+    className="px-6 gap-4"
+  >
+    <ActivityIndicator
+      size="large"
+      testID="projects-loading"
+    />
+  </View>
+</View>
+`;

--- a/design/#41-create-project-domain-entities.md
+++ b/design/#41-create-project-domain-entities.md
@@ -1,0 +1,114 @@
+# #41 — Create Domain `Project` and `ProjectDetails`
+
+## Summary
+
+Introduce a domain-centric separation between the write model (`Project`) and
+the read model (`ProjectDetails`) so application use-cases and repositories
+adhere to Clean Architecture and avoid leaking UI DTOs into the domain.
+
+## Acceptance Criteria
+
+- `src/domain/entities/Project.ts` (write model) exists and contains minimal
+  persisted fields and references by ID only.
+- `src/domain/entities/ProjectDetails.ts` (read model) exists and extends or
+  composes `Project` with hydrated references (`owner: User`, `property: Property`).
+- `ProjectRepository` interface updated (backwards-compatible) to expose
+  a `findDetailsById(id: string): Promise<ProjectDetails | null>` and
+  `listDetails(filters?): Promise<{ items: ProjectDetails[]; meta }>` for
+  read-heavy endpoints.
+- Unit tests for a new `GetProjectDetailsUseCase` that depend only on the
+  `ProjectRepository` abstraction (mocked) — tests should be written first.
+- Integration tests for `DrizzleProjectRepository` that verify hydration/join
+  behaviour and map to `ProjectDetails`.
+
+## Proposed Domain Types
+
+- `Project` (src/domain/entities/Project.ts)
+
+```ts
+export interface Project {
+  id: string;
+  ownerId: string;
+  propertyId?: string;
+  name: string;
+  status?: string;
+  archived?: boolean;
+  // minimal fields required for writes
+}
+```
+
+- `ProjectDetails` (src/domain/entities/ProjectDetails.ts)
+
+```ts
+import { Project } from './Project';
+import { User } from './User';
+import { Property } from './Property';
+
+export interface ProjectDetails extends Project {
+  owner: User;
+  property?: Property;
+  // additional hydrated fields useful for reads
+}
+```
+
+## Repository Contract Changes
+
+Update `src/domain/repositories/ProjectRepository.ts` to add new read methods
+while keeping existing write methods for compatibility:
+
+- `findDetailsById(id: string): Promise<ProjectDetails | null>`
+- `listDetails(filters?, options?): Promise<{ items: ProjectDetails[]; meta }>`
+
+Implementation note: adapters that cannot cheaply return hydrated details may
+implement the methods by composing existing queries (perform joins) inside the
+infrastructure layer (Drizzle). The domain interface must remain simple.
+
+## Use Case
+
+Add `GetProjectDetailsUseCase` in
+`src/application/usecases/project/GetProjectDetailsUseCase.ts` with a single
+method `execute(id: string)` that returns `ProjectDetails | null` by calling
+`projectRepository.findDetailsById(id)`.
+
+Test plan (TDD):
+
+1. Write a unit test for `GetProjectDetailsUseCase` that mocks the
+   `ProjectRepository` and expects it to call `findDetailsById` and return the
+   hydrated entity. (Red)
+2. Implement the use case to call the repository. (Green)
+3. Add integration test that uses `DrizzleProjectRepository` and a test DB to
+   verify the returned `ProjectDetails` is hydrated. (Green)
+
+## Drizzle / Migration Notes
+
+- No immediate schema changes required for this refactor if the DB already
+  stores owner and property relationships; repository implementations will
+  perform joins and map rows to `ProjectDetails`.
+- If additional fields are required in the DB, follow the migration workflow:
+  edit `src/infrastructure/database/schema.ts` → `npm run db:generate` → add
+  migration → verify in integration tests.
+
+## Tests to Add
+
+- `__tests__/unit/GetProjectDetailsUseCase.test.ts` — unit test (mock repo)
+- `__tests__/integration/DrizzleProjectRepository.details.integration.test.ts` —
+  integration test verifying hydration and mapping to `ProjectDetails`.
+
+## Implementation Steps (small commits)
+
+1. Add `src/domain/entities/Project.ts` and `ProjectDetails.ts` (interfaces).
+2. Update `src/domain/repositories/ProjectRepository.ts` to add new read methods.
+3. Add `GetProjectDetailsUseCase` with unit test (TDD: test first).
+4. Implement `DrizzleProjectRepository.findDetailsById` and `listDetails`.
+5. Add integration tests for the Drizzle implementation.
+6. Refactor mappers and update any UI-to-domain mappings (e.g., `ProjectCardDto`).
+
+## Design Artifacts
+
+- Link design doc to the ticket and record decisions in `progress.md` after
+  merge.
+
+
+---
+
+End of design plan for issue #41.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -21,3 +21,7 @@ jest.mock('react-native', () => {
   
   return RN;
 });
+
+// Use manual mocks to avoid NativeWind and SafeAreaContext async effects in Jest
+jest.mock('nativewind');
+jest.mock('react-native-safe-area-context');

--- a/progress.md
+++ b/progress.md
@@ -143,20 +143,12 @@ Summary (concise)
 - Repository contract: added `findDetailsById` and `listDetails` to `src/domain/repositories/ProjectRepository.ts`.
 - Infrastructure: added `src/infrastructure/mappers/ProjectMapper.ts`, extended `DrizzleProjectRepository` and `InMemoryProjectRepository` to return hydrated `ProjectDetails`.
 - Tests & TDD: added `__tests__/unit/GetProjectDetailsUseCase.test.ts` and integration coverage under `__tests__/integration/DrizzleProjectRepository.integration.test.ts` following TDD; updated component tests to avoid async `act()` warnings.
-- Test stability: added manual Jest mocks for NativeWind and `react-native-safe-area-context`, and updated `jest.setup.js` to stabilize test runtime.
 
 Completed
-- Created design doc: [design/#41-create-project-domain-entities.md](design/#41-create-project-domain-entities.md)
 - Implemented `ProjectDetails` domain type and use-case `GetProjectDetailsUseCase` (`src/application/usecases/project/GetProjectDetailsUseCase.ts`).
 - Updated repository interface to include read/hydrated methods and implemented them in both Drizzle and in-memory adapters.
 - Added `ProjectMapper` to map prefixed SQL rows into `Contact` and `Property` domain objects.
-- Added and fixed unit & integration tests; ran full test suite locally — all tests pass.
-- Stabilized Jest by adding manual mocks under `__mocks__/` and adjusting tests to wrap renders/unmounts in `act()`.
 
-Next
-- Commit and push branch `issue-41` (this PR).
-- Open PR for review (created by this task); include this summary and link to the design doc and tests.
-- Optional follow-up: silence or fix non-failing SQLite unique-constraint noise during migrations in integration logs.
 
 
 

--- a/src/application/usecases/project/GetProjectDetailsUseCase.ts
+++ b/src/application/usecases/project/GetProjectDetailsUseCase.ts
@@ -1,0 +1,10 @@
+import { ProjectDetails } from '../../../domain/entities/ProjectDetails';
+import { ProjectRepository } from '../../../domain/repositories/ProjectRepository';
+
+export class GetProjectDetailsUseCase {
+  constructor(private readonly repo: ProjectRepository) {}
+
+  async execute(id: string): Promise<ProjectDetails | null> {
+    return (await this.repo.findDetailsById(id)) as ProjectDetails | null;
+  }
+}

--- a/src/domain/entities/ProjectDetails.ts
+++ b/src/domain/entities/ProjectDetails.ts
@@ -1,0 +1,9 @@
+import { Contact } from './Contact';
+import { Project } from './Project';
+import { Property } from './Property';
+
+export interface ProjectDetails extends Project {
+  // hydrated references
+  owner: Contact;
+  property?: Property;
+}

--- a/src/domain/repositories/ProjectRepository.ts
+++ b/src/domain/repositories/ProjectRepository.ts
@@ -7,6 +7,7 @@
  */
 
 import { Project } from '../entities/Project';
+import { ProjectDetails } from '../entities/ProjectDetails';
 
 export type ProjectFilters = {
   status?: string | string[];
@@ -52,6 +53,10 @@ export interface ProjectRepository {
 
   // Hard delete (use with caution)
   delete(id: string): Promise<void>;
+
+  // Read-specific, hydrated domain entities (ProjectDetails)
+  findDetailsById(id: string): Promise<ProjectDetails | null>;
+  listDetails(filters?: ProjectFilters, options?: { limit?: number; offset?: number; cursor?: string; sort?: string }): Promise<{ items: ProjectDetails[]; meta: { total: number; nextCursor?: string } }>;
 
 
   // Provide a transaction-scoped execution wrapper if supported by the adapter

--- a/src/infrastructure/mappers/ProjectMapper.ts
+++ b/src/infrastructure/mappers/ProjectMapper.ts
@@ -1,0 +1,55 @@
+import { Contact } from '../../domain/entities/Contact';
+import { Property } from '../../domain/entities/Property';
+
+const toIsoString = (value?: number | string | null): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value;
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? undefined : date.toISOString();
+};
+
+export const mapContactFromRow = (row: any, prefix: string): Contact | null => {
+  const id = row[`${prefix}id`];
+  if (!id) return null;
+
+  const roles = row[`${prefix}roles`];
+
+  return {
+    id,
+    localId: row[`${prefix}local_id`] ?? undefined,
+    name: row[`${prefix}name`] ?? 'Unknown',
+    roles: roles ? JSON.parse(roles) : undefined,
+    trade: row[`${prefix}trade`] ?? undefined,
+    phone: row[`${prefix}phone`] ?? undefined,
+    email: row[`${prefix}email`] ?? undefined,
+    address: row[`${prefix}address`] ?? undefined,
+    rate: row[`${prefix}rate`] ?? undefined,
+    notes: row[`${prefix}notes`] ?? undefined,
+    createdAt: toIsoString(row[`${prefix}created_at`]),
+    updatedAt: toIsoString(row[`${prefix}updated_at`]),
+  };
+};
+
+export const mapPropertyFromRow = (row: any, prefix: string): Property | null => {
+  const id = row[`${prefix}id`];
+  if (!id) return null;
+
+  return {
+    id,
+    localId: row[`${prefix}local_id`] ?? undefined,
+    street: row[`${prefix}street`] ?? undefined,
+    city: row[`${prefix}city`] ?? undefined,
+    state: row[`${prefix}state`] ?? undefined,
+    postalCode: row[`${prefix}postal_code`] ?? undefined,
+    country: row[`${prefix}country`] ?? undefined,
+    address: row[`${prefix}address`] ?? undefined,
+    propertyType: row[`${prefix}property_type`] ?? undefined,
+    lotSize: row[`${prefix}lot_size`] ?? undefined,
+    lotSizeUnit: row[`${prefix}lot_size_unit`] ?? undefined,
+    yearBuilt: row[`${prefix}year_built`] ?? undefined,
+    ownerId: row[`${prefix}owner_id`] ?? undefined,
+    meta: row[`${prefix}meta`] ? JSON.parse(row[`${prefix}meta`]) : undefined,
+    createdAt: toIsoString(row[`${prefix}created_at`]),
+    updatedAt: toIsoString(row[`${prefix}updated_at`]),
+  };
+};

--- a/src/infrastructure/repositories/DrizzleProjectRepository.ts
+++ b/src/infrastructure/repositories/DrizzleProjectRepository.ts
@@ -1,7 +1,9 @@
 import { drizzle } from 'drizzle-orm/sqlite-proxy';
 import { Project, Material, ProjectPhase } from '../../domain/entities/Project';
+import { ProjectDetails } from '../../domain/entities/ProjectDetails';
 import { ProjectRepository } from '../../domain/repositories/ProjectRepository';
 import { initDatabase, getDatabase } from '../database/connection';
+import { mapContactFromRow, mapPropertyFromRow } from '../mappers/ProjectMapper';
 
 /**
  * Drizzle-based SQLite Project Repository
@@ -41,6 +43,53 @@ export class DrizzleProjectRepository implements ProjectRepository {
     if (result.rows.length === 0) return null;
     const row = result.rows.item(0);
     return await this.mapRowToProject(row);
+  }
+
+  async findDetailsById(id: string): Promise<ProjectDetails | null> {
+    if (!this.drizzle) await this.init();
+    const { db } = getDatabase();
+
+    const [result] = await db.executeSql(
+      `SELECT p.*,
+        c.local_id AS owner_local_id,
+        c.id AS owner_id,
+        c.name AS owner_name,
+        c.roles AS owner_roles,
+        c.trade AS owner_trade,
+        c.phone AS owner_phone,
+        c.email AS owner_email,
+        c.address AS owner_address,
+        c.rate AS owner_rate,
+        c.notes AS owner_notes,
+        c.created_at AS owner_created_at,
+        c.updated_at AS owner_updated_at,
+        pr.local_id AS property_local_id,
+        pr.id AS property_id,
+        pr.street AS property_street,
+        pr.city AS property_city,
+        pr.state AS property_state,
+        pr.postal_code AS property_postal_code,
+        pr.country AS property_country,
+        pr.address AS property_address,
+        pr.property_type AS property_property_type,
+        pr.lot_size AS property_lot_size,
+        pr.lot_size_unit AS property_lot_size_unit,
+        pr.year_built AS property_year_built,
+        pr.owner_id AS property_owner_id,
+        pr.meta AS property_meta,
+        pr.created_at AS property_created_at,
+        pr.updated_at AS property_updated_at
+      FROM projects p
+      LEFT JOIN contacts c ON c.id = p.owner_id
+      LEFT JOIN properties pr ON pr.id = p.property_id
+      WHERE p.id = ?`,
+      [id]
+    );
+
+    if (result.rows.length === 0) return null;
+    const row = result.rows.item(0);
+    const project = await this.mapRowToProject(row);
+    return this.buildProjectDetails(project, row);
   }
 
   async save(project: Project): Promise<void> {
@@ -175,6 +224,71 @@ export class DrizzleProjectRepository implements ProjectRepository {
     return { items, meta: { total } };
   }
 
+  async listDetails(filters: any = {}, options: { limit?: number; offset?: number; cursor?: string; sort?: string } = {}): Promise<{ items: ProjectDetails[]; meta: { total: number; nextCursor?: string } }> {
+    if (!this.drizzle) await this.init();
+    const { db } = getDatabase();
+
+    const where: string[] = [];
+    const params: any[] = [];
+    if (filters.status) {
+      where.push('p.status = ?');
+      params.push(filters.status);
+    }
+
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    const limitSql = options.limit ? `LIMIT ${options.limit}` : '';
+    const offsetSql = options.offset ? `OFFSET ${options.offset}` : '';
+
+    const [rows] = await db.executeSql(
+      `SELECT p.*,
+        c.local_id AS owner_local_id,
+        c.id AS owner_id,
+        c.name AS owner_name,
+        c.roles AS owner_roles,
+        c.trade AS owner_trade,
+        c.phone AS owner_phone,
+        c.email AS owner_email,
+        c.address AS owner_address,
+        c.rate AS owner_rate,
+        c.notes AS owner_notes,
+        c.created_at AS owner_created_at,
+        c.updated_at AS owner_updated_at,
+        pr.local_id AS property_local_id,
+        pr.id AS property_id,
+        pr.street AS property_street,
+        pr.city AS property_city,
+        pr.state AS property_state,
+        pr.postal_code AS property_postal_code,
+        pr.country AS property_country,
+        pr.address AS property_address,
+        pr.property_type AS property_property_type,
+        pr.lot_size AS property_lot_size,
+        pr.lot_size_unit AS property_lot_size_unit,
+        pr.year_built AS property_year_built,
+        pr.owner_id AS property_owner_id,
+        pr.meta AS property_meta,
+        pr.created_at AS property_created_at,
+        pr.updated_at AS property_updated_at
+      FROM projects p
+      LEFT JOIN contacts c ON c.id = p.owner_id
+      LEFT JOIN properties pr ON pr.id = p.property_id
+      ${whereSql} ${limitSql} ${offsetSql}`,
+      params
+    );
+
+    const items: ProjectDetails[] = [];
+    for (let i = 0; i < rows.rows.length; i++) {
+      const row = rows.rows.item(i);
+      const project = await this.mapRowToProject(row);
+      items.push(this.buildProjectDetails(project, row));
+    }
+
+    const [countRows] = await db.executeSql(`SELECT COUNT(*) as cnt FROM projects p ${whereSql}`, params);
+    const total = countRows.rows.length ? countRows.rows.item(0).cnt : 0;
+
+    return { items, meta: { total } };
+  }
+
   async count(filters: any = {}): Promise<number> {
     if (!this.drizzle) await this.init();
     const { db } = getDatabase();
@@ -238,9 +352,11 @@ export class DrizzleProjectRepository implements ProjectRepository {
         // Other methods aren't implemented in this transaction context yet
         
         findById: async (_id: string) => null,
+        findDetailsById: async (_id: string) => null,
         
         findByExternalId: async (_id: string) => null,
         list: async () => ({ items: [], meta: { total: 0 } }),
+        listDetails: async () => ({ items: [], meta: { total: 0 } }),
         count: async () => 0,
         
         findByStatus: async (_s: string) => [],
@@ -378,6 +494,17 @@ export class DrizzleProjectRepository implements ProjectRepository {
   async exists(id: string): Promise<boolean> {
     const project = await this.findById(id);
     return project !== null;
+  }
+
+  private buildProjectDetails(project: Project, row: any): ProjectDetails {
+    const owner = mapContactFromRow(row, 'owner_');
+    const property = mapPropertyFromRow(row, 'property_');
+
+    return {
+      ...project,
+      owner: owner ?? { id: project.ownerId ?? 'unknown', name: 'Unknown' },
+      property: property ?? undefined,
+    };
   }
   private async mapRowToProject(row: any): Promise<Project> {
     if (!this.drizzle) await this.init();

--- a/src/infrastructure/repositories/InMemoryProjectRepository.ts
+++ b/src/infrastructure/repositories/InMemoryProjectRepository.ts
@@ -1,8 +1,20 @@
 import { Project } from '../../domain/entities/Project';
+import { ProjectDetails } from '../../domain/entities/ProjectDetails';
 import { ProjectRepository } from '../../domain/repositories/ProjectRepository';
 
 export class InMemoryProjectRepository implements ProjectRepository {
   private items: Project[] = [];
+
+  private toDetails(project: Project): ProjectDetails {
+    return {
+      ...project,
+      owner: {
+        id: project.ownerId ?? 'unknown',
+        name: 'Unknown',
+      },
+      property: undefined,
+    };
+  }
 
   async save(project: Project): Promise<void> {
     const idx = this.items.findIndex(p => p.id === project.id);
@@ -49,6 +61,19 @@ export class InMemoryProjectRepository implements ProjectRepository {
 
   async delete(id: string): Promise<void> {
     this.items = this.items.filter(i => i.id !== id);
+  }
+
+  async findDetailsById(id: string): Promise<ProjectDetails | null> {
+    const project = await this.findById(id);
+    return project ? this.toDetails(project) : null;
+  }
+
+  async listDetails(filters: any = {}, options: any = {}): Promise<{ items: ProjectDetails[]; meta: { total: number; nextCursor?: string } }> {
+    const listed = await this.list(filters, options);
+    return {
+      items: listed.items.map((project) => this.toDetails(project)),
+      meta: listed.meta,
+    };
   }
 
   async withTransaction<T>(work: (repo: ProjectRepository) => Promise<T>): Promise<T> {


### PR DESCRIPTION
This PR implements the ProjectDetails read-model and associated repository, mappers, tests, and test-stability fixes for issue #41.

Summary of changes
- Domain: Added `ProjectDetails` read-model (hydrated `owner: Contact` + optional `property: Property`).
- Repository: Added `findDetailsById` and `listDetails` to `src/domain/repositories/ProjectRepository.ts`.
- Infrastructure: Implemented `src/infrastructure/mappers/ProjectMapper.ts`, extended `DrizzleProjectRepository` and `InMemoryProjectRepository` to return hydrated `ProjectDetails`.
- Application: Added `GetProjectDetailsUseCase` and unit test at `__tests__/unit/GetProjectDetailsUseCase.test.ts`.
- Tests: Added integration coverage for hydrated details in `__tests__/integration/DrizzleProjectRepository.integration.test.ts` and updated component tests to avoid async `act()` warnings.
- Test stability: Added manual Jest mocks for NativeWind and `react-native-safe-area-context`, and updated `jest.setup.js`.
- Documentation: Added a design doc at `design/#41-create-project-domain-entities.md` and appended the progress summary to `progress.md`.

Recent commits pushed
- a175912: "issue-41: finalize ProjectDetails refactor — repo, mappers, tests, and Jest setup"
- bc67bf8: "Issue #41: ProjectDetails read-model, mappers, repo methods, tests, and Jest mocks; add progress summary"

Status
- All unit & integration tests pass locally.

Notes / Next
- Optional follow-up: silence non-failing SQLite unique-constraint noise during migrations in integration logs.

Design doc: design/#41-create-project-domain-entities.md
Tests: __tests__/unit/GetProjectDetailsUseCase.test.ts, __tests__/integration/DrizzleProjectRepository.integration.test.ts
Progress summary: progress.md

Please review — happy to iterate on naming or mapper details as needed.