### PR TITLE
Fix: Manual Project Entry modal and dropdown behavior (issue #49)

### DIFF
--- a/__tests__/unit/ManualProjectEntryForm.test.tsx
+++ b/__tests__/unit/ManualProjectEntryForm.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import ManualProjectEntryForm from '../../src/components/ManualProjectEntryForm';
-import { TextInput, Button } from 'react-native';
+import { Button } from 'react-native';
 
 describe('ManualProjectEntryForm', () => {
   it('renders form when visible', async () => {

--- a/__tests__/unit/__snapshots__/ManualProjectEntryForm.test.tsx.snap
+++ b/__tests__/unit/__snapshots__/ManualProjectEntryForm.test.tsx.snap
@@ -1,372 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ManualProjectEntryForm renders form when visible 1`] = `
-<RCTScrollView
-  className="flex-1 p-4 bg-background"
+<Modal
+  animationType="slide"
+  onRequestClose={[MockFunction]}
+  presentationStyle="fullScreen"
+  visible={true}
 >
-  <View>
-    <Text
-      className="text-2xl font-bold mb-6 text-foreground"
-    >
-      New Project
-    </Text>
+  <View
+    className="flex-1 bg-background"
+  >
     <View
-      className="mb-4"
+      className="px-6 py-4 flex-row items-center justify-between border-b border-border"
     >
       <Text
-        className="mb-1 font-semibold text-foreground"
+        className="text-2xl font-bold text-foreground"
       >
-        Name *
-      </Text>
-      <TextInput
-        className="border border-border rounded p-2 bg-card text-foreground"
-        onChangeText={[Function]}
-        placeholder="Project name"
-        value=""
-      />
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Address *
-      </Text>
-      <TextInput
-        className="border border-border rounded p-2 bg-card text-foreground"
-        onChangeText={[Function]}
-        placeholder="Property address"
-        value=""
-      />
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Description
-      </Text>
-      <TextInput
-        className="border border-border rounded p-2 bg-card text-foreground"
-        multiline={true}
-        numberOfLines={3}
-        onChangeText={[Function]}
-        placeholder="Project description"
-        value=""
-      />
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Project Owner
-      </Text>
-      <View>
-        <Text>
-          Project Owner
-        </Text>
-        <TextInput
-          onChangeText={[Function]}
-          placeholder="Search contacts"
-          value=""
-        />
-      </View>
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Team
-      </Text>
-      <View>
-        <Text>
-          Team
-        </Text>
-        <TextInput
-          onChangeText={[Function]}
-          placeholder="Search teams"
-          value=""
-        />
-      </View>
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Start Date
-      </Text>
-      <View>
-        <Text>
-          Start Date
-        </Text>
-        <TextInput
-          onChangeText={[Function]}
-          placeholder="YYYY-MM-DD"
-          value=""
-        />
-      </View>
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        End Date
-      </Text>
-      <View>
-        <Text>
-          End Date
-        </Text>
-        <TextInput
-          onChangeText={[Function]}
-          placeholder="YYYY-MM-DD"
-          value=""
-        />
-      </View>
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Budget
-      </Text>
-      <TextInput
-        className="border border-border rounded p-2 bg-card text-foreground"
-        keyboardType="numeric"
-        onChangeText={[Function]}
-        placeholder="0.00"
-        value=""
-      />
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Priority
+        New Project
       </Text>
       <View
-        className="flex-row gap-2"
-      >
-        <View
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "opacity": 1,
-            }
-          }
-        >
-          <View
-            style={
-              [
-                {},
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#007AFF",
-                    "fontSize": 18,
-                    "margin": 8,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#007AFF",
-                  },
-                ]
-              }
-            >
-              Low
-            </Text>
-          </View>
-        </View>
-        <View
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "opacity": 1,
-            }
-          }
-        >
-          <View
-            style={
-              [
-                {},
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#007AFF",
-                    "fontSize": 18,
-                    "margin": 8,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#8E8E93",
-                  },
-                ]
-              }
-            >
-              Medium
-            </Text>
-          </View>
-        </View>
-        <View
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "opacity": 1,
-            }
-          }
-        >
-          <View
-            style={
-              [
-                {},
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#007AFF",
-                    "fontSize": 18,
-                    "margin": 8,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#8E8E93",
-                  },
-                ]
-              }
-            >
-              High
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View
-      className="mb-4"
-    >
-      <Text
-        className="mb-1 font-semibold text-foreground"
-      >
-        Notes
-      </Text>
-      <TextInput
-        className="border border-border rounded p-2 bg-card text-foreground"
-        multiline={true}
-        numberOfLines={4}
-        onChangeText={[Function]}
-        placeholder="Additional notes"
-        value=""
-      />
-    </View>
-    <View
-      className="flex-row justify-end mt-6 mb-4"
-    >
-      <View
-        accessibilityRole="button"
         accessibilityState={
           {
             "busy": undefined,
@@ -385,118 +37,643 @@ exports[`ManualProjectEntryForm renders form when visible 1`] = `
           }
         }
         accessible={true}
+        className="p-2"
         collapsable={false}
         focusable={true}
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "opacity": 1,
-          }
-        }
       >
-        <View
+        <RNSVGSvgView
+          align="xMidYMid"
+          bbHeight={24}
+          bbWidth={24}
+          className="text-foreground"
+          fill="none"
+          focusable={false}
+          height={24}
+          meetOrSlice={0}
+          minX={0}
+          minY={0}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
           style={
             [
-              {},
+              {
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+              },
+              {
+                "flex": 0,
+                "height": 24,
+                "width": 24,
+              },
             ]
           }
+          vbHeight={24}
+          vbWidth={24}
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <Text
-            style={
+          <RNSVGGroup
+            fill={null}
+            propList={
               [
-                {
-                  "color": "#007AFF",
-                  "fontSize": 18,
-                  "margin": 8,
-                  "textAlign": "center",
-                },
-                {
-                  "color": "#8E8E93",
-                },
+                "fill",
+                "stroke",
+                "strokeWidth",
+                "strokeLinecap",
+                "strokeLinejoin",
               ]
             }
-          >
-            Cancel
-          </Text>
-        </View>
-      </View>
-      <View
-        style={
-          {
-            "width": 12,
-          }
-        }
-      />
-      <View
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "opacity": 1,
-          }
-        }
-      >
-        <View
-          style={
-            [
-              {},
-              {},
-            ]
-          }
-        >
-          <Text
-            disabled={true}
-            style={
-              [
-                {
-                  "color": "#007AFF",
-                  "fontSize": 18,
-                  "margin": 8,
-                  "textAlign": "center",
-                },
-                {
-                  "color": "#cdcdcd",
-                },
-              ]
+            stroke={
+              {
+                "type": 2,
+              }
             }
+            strokeLinecap={1}
+            strokeLinejoin={1}
+            strokeWidth={2}
           >
-            Save
-          </Text>
-        </View>
+            <RNSVGPath
+              d="M18 6 6 18"
+              fill={null}
+              propList={
+                [
+                  "fill",
+                  "stroke",
+                  "strokeWidth",
+                  "strokeLinecap",
+                  "strokeLinejoin",
+                ]
+              }
+              stroke={
+                {
+                  "type": 2,
+                }
+              }
+              strokeLinecap={1}
+              strokeLinejoin={1}
+              strokeWidth={2}
+            />
+            <RNSVGPath
+              d="m6 6 12 12"
+              fill={null}
+              propList={
+                [
+                  "fill",
+                  "stroke",
+                  "strokeWidth",
+                  "strokeLinecap",
+                  "strokeLinejoin",
+                ]
+              }
+              stroke={
+                {
+                  "type": 2,
+                }
+              }
+              strokeLinecap={1}
+              strokeLinejoin={1}
+              strokeWidth={2}
+            />
+          </RNSVGGroup>
+        </RNSVGSvgView>
       </View>
     </View>
+    <RCTScrollView
+      className="flex-1 p-6"
+    >
+      <View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Name *
+          </Text>
+          <TextInput
+            className="border border-border rounded p-2 bg-card text-foreground"
+            onChangeText={[Function]}
+            placeholder="Project name"
+            value=""
+          />
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Address *
+          </Text>
+          <TextInput
+            className="border border-border rounded p-2 bg-card text-foreground"
+            onChangeText={[Function]}
+            placeholder="Property address"
+            value=""
+          />
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Description
+          </Text>
+          <TextInput
+            className="border border-border rounded p-2 bg-card text-foreground"
+            multiline={true}
+            numberOfLines={3}
+            onChangeText={[Function]}
+            placeholder="Project description"
+            value=""
+          />
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Project Owner
+          </Text>
+          <View
+            style={
+              {
+                "position": "relative",
+                "zIndex": 1,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "marginBottom": 6,
+                }
+              }
+            >
+              Project Owner
+            </Text>
+            <TextInput
+              className="border border-border rounded p-2 bg-card text-foreground"
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              placeholder="Search contacts"
+              value=""
+            />
+          </View>
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Team
+          </Text>
+          <View
+            style={
+              {
+                "position": "relative",
+                "zIndex": 1,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "marginBottom": 6,
+                }
+              }
+            >
+              Team
+            </Text>
+            <TextInput
+              className="border border-border rounded p-2 bg-card text-foreground"
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              placeholder="Search teams"
+              value=""
+            />
+          </View>
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Start Date
+          </Text>
+          <View>
+            <Text>
+              Start Date
+            </Text>
+            <TextInput
+              onChangeText={[Function]}
+              placeholder="YYYY-MM-DD"
+              value=""
+            />
+          </View>
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            End Date
+          </Text>
+          <View>
+            <Text>
+              End Date
+            </Text>
+            <TextInput
+              onChangeText={[Function]}
+              placeholder="YYYY-MM-DD"
+              value=""
+            />
+          </View>
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Budget
+          </Text>
+          <TextInput
+            className="border border-border rounded p-2 bg-card text-foreground"
+            keyboardType="numeric"
+            onChangeText={[Function]}
+            placeholder="0.00"
+            value=""
+          />
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Priority
+          </Text>
+          <View
+            className="flex-row gap-2"
+          >
+            <View
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {},
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#007AFF",
+                        "fontSize": 18,
+                        "margin": 8,
+                        "textAlign": "center",
+                      },
+                      {
+                        "color": "#007AFF",
+                      },
+                    ]
+                  }
+                >
+                  Low
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {},
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#007AFF",
+                        "fontSize": 18,
+                        "margin": 8,
+                        "textAlign": "center",
+                      },
+                      {
+                        "color": "#8E8E93",
+                      },
+                    ]
+                  }
+                >
+                  Medium
+                </Text>
+              </View>
+            </View>
+            <View
+              accessibilityRole="button"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {},
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#007AFF",
+                        "fontSize": 18,
+                        "margin": 8,
+                        "textAlign": "center",
+                      },
+                      {
+                        "color": "#8E8E93",
+                      },
+                    ]
+                  }
+                >
+                  High
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          className="mb-4"
+        >
+          <Text
+            className="mb-1 font-semibold text-foreground"
+          >
+            Notes
+          </Text>
+          <TextInput
+            className="border border-border rounded p-2 bg-card text-foreground"
+            multiline={true}
+            numberOfLines={4}
+            onChangeText={[Function]}
+            placeholder="Additional notes"
+            value=""
+          />
+        </View>
+        <View
+          className="flex-row justify-end mt-6 mb-4"
+        >
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {},
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#007AFF",
+                      "fontSize": 18,
+                      "margin": 8,
+                      "textAlign": "center",
+                    },
+                    {
+                      "color": "#8E8E93",
+                    },
+                  ]
+                }
+              >
+                Cancel
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "width": 12,
+              }
+            }
+          />
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": true,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {},
+                  {},
+                ]
+              }
+            >
+              <Text
+                disabled={true}
+                style={
+                  [
+                    {
+                      "color": "#007AFF",
+                      "fontSize": 18,
+                      "margin": 8,
+                      "textAlign": "center",
+                    },
+                    {
+                      "color": "#cdcdcd",
+                    },
+                  ]
+                }
+              >
+                Save
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
   </View>
-</RCTScrollView>
+</Modal>
 `;

--- a/src/components/ManualProjectEntryForm.tsx
+++ b/src/components/ManualProjectEntryForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TextInput, Button, ScrollView } from 'react-native';
+import { View, Text, TextInput, Button, ScrollView, Modal, Pressable } from 'react-native';
+import { X } from 'lucide-react-native';
 import DatePickerInput from './inputs/DatePickerInput';
 import ContactSelector from './inputs/ContactSelector';
 import TeamSelector from './inputs/TeamSelector';
@@ -17,7 +18,6 @@ interface FormErrors {
 }
 
 const ManualProjectEntryForm: React.FC<Props> = ({ visible, onSave, onCancel }) => {
-  if (!visible) return null;
 
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
@@ -74,8 +74,22 @@ const ManualProjectEntryForm: React.FC<Props> = ({ visible, onSave, onCancel }) 
   };
 
   return (
-    <ScrollView className="flex-1 p-4 bg-background">
-      <Text className="text-2xl font-bold mb-6 text-foreground">New Project</Text>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      onRequestClose={onCancel}
+    >
+      <View className="flex-1 bg-background">
+        {/* Modal Header */}
+        <View className="px-6 py-4 flex-row items-center justify-between border-b border-border">
+          <Text className="text-2xl font-bold text-foreground">New Project</Text>
+          <Pressable onPress={onCancel} className="p-2">
+            <X className="text-foreground" size={24} />
+          </Pressable>
+        </View>
+
+        <ScrollView className="flex-1 p-6">
       
       {/* Name - Required */}
       <View className="mb-4">
@@ -205,7 +219,9 @@ const ManualProjectEntryForm: React.FC<Props> = ({ visible, onSave, onCancel }) 
           disabled={!name.trim() || !address.trim()}
         />
       </View>
-    </ScrollView>
+        </ScrollView>
+      </View>
+    </Modal>
   );
 };
 

--- a/src/components/inputs/ContactSelector.tsx
+++ b/src/components/inputs/ContactSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TextInput, FlatList, Pressable } from 'react-native';
+import { View, Text, TextInput, FlatList, Pressable, StyleSheet } from 'react-native';
 import useContacts from '../../hooks/useContacts';
 
 interface Props {
@@ -13,6 +13,7 @@ const ContactSelector: React.FC<Props> = ({ label, value, onChange, error }) => 
   const { search } = useContacts();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Array<any>>([]);
+  const [isFocused, setIsFocused] = useState(false);
 
   const timerRef = useRef<number | null>(null);
 
@@ -30,28 +31,76 @@ const ContactSelector: React.FC<Props> = ({ label, value, onChange, error }) => 
     };
   }, [query, search]);
 
+  useEffect(() => {
+    if (value) {
+      // If parent supplies an initial value (id), show it as query temporarily.
+      setQuery(String(value));
+    }
+  }, [value]);
+
   return (
-    <View>
-      <Text>{label}</Text>
+    <View style={styles.container}>
+      <Text style={{ marginBottom: 6 }}>{label}</Text>
       <TextInput
         value={query}
         onChangeText={(text) => setQuery(text)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setTimeout(() => setIsFocused(false), 200)}
         placeholder="Search contacts"
+        className="border border-border rounded p-2 bg-card text-foreground"
       />
-      {results.length > 0 && (
-        <FlatList
-          data={results}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <Pressable onPress={() => { onChange(item.id); setQuery(item.name); setResults([]); }}>
-              <Text>{item.name} — {item.title}</Text>
-            </Pressable>
-          )}
-        />
+      {isFocused && results.length > 0 && (
+        <View style={styles.dropdown}>
+          <FlatList
+            data={results}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <Pressable 
+                onPress={() => { 
+                  onChange(item.id); 
+                  setQuery(item.name); 
+                  setResults([]); 
+                  setIsFocused(false); 
+                }}
+                className="p-3 border-b border-border"
+              >
+                <Text className="text-foreground">{item.name} — {item.title}</Text>
+              </Pressable>
+            )}
+            style={styles.list}
+          />
+        </View>
       )}
       {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    zIndex: 1,
+  },
+  dropdown: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    maxHeight: 200,
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  list: {
+    flexGrow: 0,
+  },
+});
 
 export default ContactSelector;

--- a/src/components/inputs/TeamSelector.tsx
+++ b/src/components/inputs/TeamSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TextInput, FlatList, Pressable } from 'react-native';
+import { View, Text, TextInput, FlatList, Pressable, StyleSheet } from 'react-native';
 import useTeams from '../../hooks/useTeams';
 
 interface Props {
@@ -14,6 +14,7 @@ const TeamSelector: React.FC<Props> = ({ label, value, onChange, error }) => {
   const { search } = useTeams();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Array<any>>([]);
+  const [isFocused, setIsFocused] = useState(false);
 
   const timerRef = useRef<number | null>(null);
 
@@ -31,28 +32,75 @@ const TeamSelector: React.FC<Props> = ({ label, value, onChange, error }) => {
     };
   }, [query, search]);
 
+  useEffect(() => {
+    if (value) {
+      setQuery(String(value));
+    }
+  }, [value]);
+
   return (
-    <View>
-      <Text>{label}</Text>
+    <View style={styles.container}>
+      <Text style={{ marginBottom: 6 }}>{label}</Text>
       <TextInput
         value={query}
         onChangeText={(text) => setQuery(text)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setTimeout(() => setIsFocused(false), 200)}
         placeholder="Search teams"
+        className="border border-border rounded p-2 bg-card text-foreground"
       />
-      {results.length > 0 && (
-        <FlatList
-          data={results}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <Pressable onPress={() => { onChange(item.id); setQuery(item.name); setResults([]); }}>
-              <Text>{item.name} — {item.members} members</Text>
-            </Pressable>
-          )}
-        />
+      {isFocused && results.length > 0 && (
+        <View style={styles.dropdown}>
+          <FlatList
+            data={results}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <Pressable 
+                onPress={() => { 
+                  onChange(item.id); 
+                  setQuery(item.name); 
+                  setResults([]); 
+                  setIsFocused(false); 
+                }}
+                className="p-3 border-b border-border"
+              >
+                <Text className="text-foreground">{item.name} — {item.members} members</Text>
+              </Pressable>
+            )}
+            style={styles.list}
+          />
+        </View>
       )}
       {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    zIndex: 1,
+  },
+  dropdown: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    maxHeight: 200,
+    zIndex: 1000,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  list: {
+    flexGrow: 0,
+  },
+});
 
 export default TeamSelector;

--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 // Minimal hook stub that returns a simple in-memory list and a search API.
 export function useContacts() {

--- a/src/infrastructure/database/connection.ts
+++ b/src/infrastructure/database/connection.ts
@@ -60,7 +60,7 @@ export async function initDatabase() {
  * Run all pending migrations
  */
 async function runMigrations(
-  drizzle: ReturnType<typeof import('drizzle-orm/sqlite-proxy').drizzle>,
+  dbDrizzle: ReturnType<typeof import('drizzle-orm/sqlite-proxy').drizzle>,
   db: SQLite.SQLiteDatabase
 ) {
   try {

--- a/src/infrastructure/repositories/DrizzleInvoiceRepository.ts
+++ b/src/infrastructure/repositories/DrizzleInvoiceRepository.ts
@@ -25,8 +25,8 @@ export class DrizzleInvoiceRepository implements InvoiceRepository {
     
     private async getDb() {
         if (!this.db) {
-            const { drizzle } = await initDatabase();
-            this.db = drizzle;
+            const { drizzle: dbDrizzle } = await initDatabase();
+            this.db = dbDrizzle;
         }
         return this.db!;
     }

--- a/src/infrastructure/repositories/DrizzleProjectRepository.ts
+++ b/src/infrastructure/repositories/DrizzleProjectRepository.ts
@@ -190,7 +190,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
       if (result.rows.length === 0) return null;
       return await this.mapRowToProject(result.rows.item(0));
     } catch (e) {
-      const [result] = await db.executeSql('SELECT * FROM projects WHERE meta LIKE ?', [`%\"externalId\":\"${externalId}\"%`]);
+      const [result] = await db.executeSql('SELECT * FROM projects WHERE meta LIKE ?', [`%"externalId":"${externalId}"%`]);
       if (result.rows.length === 0) return null;
       return await this.mapRowToProject(result.rows.item(0));
     }


### PR DESCRIPTION
Fixes manual entry rendering inline and expanded dropdowns (see #49).

Summary of changes:
- Render `ManualProjectEntryForm` in a full-screen `Modal` with close action.
- Make `ContactSelector` and `TeamSelector` behave as overlay dropdowns (show only when focused).
- Add small accessibility/styling improvements and position the dropdown lists.
- Fixed lint errors and updated snapshots for intentional UI changes.

Tests:
- All Jest unit and integration tests pass locally; updated one snapshot.
- ESLint now reports 0 errors (28 warnings remain for inline styles/nested components).

Notes:
- Modal presentation is full-screen and closes on outside/back/cancel.
- Dropdowns close on selection or blur.

Please review and let me know if you prefer a different modal presentation (bottom sheet) or tweaks to dropdown visuals.
