### PR TITLE
Fix: avoid nested VirtualizedList warning in Manual Project Entry (#52)

### DIFF
--- a/src/components/inputs/ContactSelector.tsx
+++ b/src/components/inputs/ContactSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TextInput, FlatList, Pressable, StyleSheet } from 'react-native';
+import { View, Text, TextInput, ScrollView, Pressable, StyleSheet } from 'react-native';
 import useContacts from '../../hooks/useContacts';
 
 interface Props {
@@ -51,11 +51,10 @@ const ContactSelector: React.FC<Props> = ({ label, value, onChange, error }) => 
       />
       {isFocused && results.length > 0 && (
         <View style={styles.dropdown}>
-          <FlatList
-            data={results}
-            keyExtractor={(item) => item.id}
-            renderItem={({ item }) => (
+          <ScrollView style={styles.list} nestedScrollEnabled>
+            {results.map((item) => (
               <Pressable 
+                key={item.id}
                 onPress={() => { 
                   onChange(item.id); 
                   setQuery(item.name); 
@@ -66,9 +65,8 @@ const ContactSelector: React.FC<Props> = ({ label, value, onChange, error }) => 
               >
                 <Text className="text-foreground">{item.name} — {item.title}</Text>
               </Pressable>
-            )}
-            style={styles.list}
-          />
+            ))}
+          </ScrollView>
         </View>
       )}
       {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}

--- a/src/components/inputs/TeamSelector.tsx
+++ b/src/components/inputs/TeamSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TextInput, FlatList, Pressable, StyleSheet } from 'react-native';
+import { View, Text, TextInput, ScrollView, Pressable, StyleSheet } from 'react-native';
 import useTeams from '../../hooks/useTeams';
 
 interface Props {
@@ -51,11 +51,10 @@ const TeamSelector: React.FC<Props> = ({ label, value, onChange, error }) => {
       />
       {isFocused && results.length > 0 && (
         <View style={styles.dropdown}>
-          <FlatList
-            data={results}
-            keyExtractor={(item) => item.id}
-            renderItem={({ item }) => (
+          <ScrollView style={styles.list} nestedScrollEnabled>
+            {results.map((item) => (
               <Pressable 
+                key={item.id}
                 onPress={() => { 
                   onChange(item.id); 
                   setQuery(item.name); 
@@ -66,9 +65,8 @@ const TeamSelector: React.FC<Props> = ({ label, value, onChange, error }) => {
               >
                 <Text className="text-foreground">{item.name} — {item.members} members</Text>
               </Pressable>
-            )}
-            style={styles.list}
-          />
+            ))}
+          </ScrollView>
         </View>
       )}
       {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}


### PR DESCRIPTION
Fixes issue #52 by replacing `FlatList` dropdowns in `ContactSelector` and `TeamSelector` with non-virtualized `ScrollView`-based lists. This prevents nesting a `VirtualizedList` inside the form `ScrollView`, removing the React Native warning and preserving dropdown behavior for small result sets.

Changes:
- src/components/inputs/ContactSelector.tsx
- src/components/inputs/TeamSelector.tsx

All relevant unit tests still pass.

Please review and merge into `master`.