### PR TITLE
Fix: prevent Payment screen re-render loop by memoizing use case instances (#60)

### DIFF
--- a/src/hooks/usePayments.tsx
+++ b/src/hooks/usePayments.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import container from '../infrastructure/di/registerServices';
 import { PaymentRepository } from '../domain/repositories/PaymentRepository';
 import { ListPaymentsUseCase } from '../application/usecases/payment/ListPaymentsUseCase';
@@ -6,8 +6,8 @@ import { GetPaymentMetricsUseCase } from '../application/usecases/payment/GetPay
 
 export function usePayments(projectId?: string, repoOverride?: PaymentRepository) {
   const repo = repoOverride ?? container.resolve<PaymentRepository>('PaymentRepository' as any);
-  const listUc = new ListPaymentsUseCase(repo);
-  const metricsUc = new GetPaymentMetricsUseCase(repo);
+  const listUc = useMemo(() => new ListPaymentsUseCase(repo), [repo]);
+  const metricsUc = useMemo(() => new GetPaymentMetricsUseCase(repo), [repo]);
 
   const [overdue, setOverdue] = useState<any[]>([]);
   const [upcoming, setUpcoming] = useState<any[]>([]);


### PR DESCRIPTION
This patch fixes an infinite re-render/refresh loop on the Payments screen.

Root cause: `ListPaymentsUseCase` and `GetPaymentMetricsUseCase` were instantiated on every render inside `usePayments`, causing `loadAll` to change on each render and triggering the effect repeatedly.

Fix: memoize the use case instances with `useMemo` so they remain stable across renders unless the repository changes.

This resolves the UIRefreshControl "offscreen beginRefreshing" warnings and stops the continuous refresh behavior.

Files changed:
- src/hooks/usePayments.tsx

Closes #60.