### PR TITLE
Payments screen + migrations + db-fix (issue-55)

### DIFF
--- a/src/infrastructure/repositories/DrizzleReceiptRepository.ts
+++ b/src/infrastructure/repositories/DrizzleReceiptRepository.ts
@@ -20,9 +20,13 @@ export class DrizzleReceiptRepository implements ReceiptRepository {
 
     console.log('[DrizzleReceiptRepository] createReceipt - start', { invoiceId: invoice.id, paymentId: payment.id });
     try {
-      await db.transaction(async (tx: any) => {
+      // Use manual transaction handling via executeSql because db.transaction 
+      // does not support async/await callbacks correctly in react-native-sqlite-storage
+      await db.executeSql('BEGIN TRANSACTION');
+
+      try {
         console.log('[DrizzleReceiptRepository] transaction - inserting invoice', { invoiceId: invoice.id });
-        await tx.executeSql(
+        await db.executeSql(
           `INSERT INTO invoices (
           id, project_id, external_id, external_reference,
           issuer_name, issuer_address, issuer_tax_id,
@@ -63,35 +67,44 @@ export class DrizzleReceiptRepository implements ReceiptRepository {
         );
 
         // TEST HOOK: allow tests to simulate a failure after the invoice insert
-        // by setting `metadata.simulateFailure = true` on the invoice object.
-        // This makes it possible to assert that the transaction rolls back.
         if (invoice.metadata && (invoice.metadata as any).simulateFailure) {
           console.log('[DrizzleReceiptRepository] simulate failure requested - throwing');
           throw new Error('SIMULATE_FAIL');
         }
 
         console.log('[DrizzleReceiptRepository] transaction - inserting payment', { paymentId: payment.id });
-        await tx.executeSql(
-          `INSERT INTO payments (
-          id, project_id, invoice_id, amount, currency, payment_date,
-          payment_method, reference, notes, created_at, updated_at
-        ) VALUES (${new Array(11).fill('?').join(',')})`,
-          [
+        const paymentValues = [
             payment.id,
             payment.projectId ?? null,
             payment.invoiceId ?? null,
             payment.amount,
             payment.currency ?? null,
             isoToMillis(payment.date),
+            isoToMillis(payment.dueDate), // New column
+            payment.status ?? null,       // New column
             payment.method ?? null,
             payment.reference ?? null,
             payment.notes ?? null,
             now,
             now,
-          ]
+          ];
+          
+        await db.executeSql(
+          `INSERT INTO payments (
+          id, project_id, invoice_id, amount, currency, payment_date,
+          due_date, status,
+          payment_method, reference, notes, created_at, updated_at
+        ) VALUES (${new Array(13).fill('?').join(',')})`,
+          paymentValues
         );
         console.log('[DrizzleReceiptRepository] transaction - inserts completed');
-      });
+      
+        await db.executeSql('COMMIT');
+      } catch (innerErr) {
+        console.error('[DrizzleReceiptRepository] Transaction failed - rolling back', innerErr);
+        await db.executeSql('ROLLBACK');
+        throw innerErr;
+      }
 
       console.log('[DrizzleReceiptRepository] createReceipt - success', { invoiceId: invoice.id, paymentId: payment.id });
       return { invoice, payment };


### PR DESCRIPTION
This PR bundles the payments screen wiring, migration bundling for 0004/0005, and a fix for transactional behavior when saving receipts.

Summary of changes:
- Bundle migrations 0004 and 0005 so runtime DB receives `due_date` and `status` columns
- Add debug logging to `SnapReceiptScreen`, `useSnapReceipt`, and `DrizzleReceiptRepository`
- Fix `createReceipt` to use manual `BEGIN/COMMIT/ROLLBACK` to avoid swallowed async callbacks in `react-native-sqlite-storage`
- Update docs: `drizzle/migrations/README.md` describing bundling and common pitfalls

Tests:
- Full test suite run locally; integration tests for receipt/payment repo show proper rollback on simulated failure and success on normal path.

Please review and run CI.