### PR TITLE
Invoice module — Phase 3: Lifecycle Operations (mark paid, cancel, actions, audit)

### DIFF
--- a/__tests__/integration/InvoicePayment.integration.test.tsx
+++ b/__tests__/integration/InvoicePayment.integration.test.tsx
@@ -1,0 +1,353 @@
+// Integration test: verify invoice-payment integration and automatic status updates
+jest.mock('react-native-sqlite-storage', () => {
+  function createAdapter(db: any) {
+    return {
+      executeSql: async (sql: string, params: any[] = []) => {
+        const stmt = sql.trim();
+        const upper = stmt.toUpperCase();
+
+        if (upper.startsWith('SELECT')) {
+          const rows = db.prepare(stmt).all(...params);
+          return [ { rows: { length: rows.length, item: (i: number) => rows[i] } } ];
+        }
+
+        if (params && params.length > 0) {
+          try {
+            const prepared = db.prepare(stmt);
+            prepared.run(...params);
+            return [ { rows: { length: 0, item: (_: number) => undefined } } ];
+          } catch (e: any) {
+            if (e.code === 'SQLITE_CONSTRAINT_UNIQUE' || e.message?.includes('UNIQUE constraint failed')) {
+              throw e;
+            }
+          }
+        }
+
+        if (stmt) db.exec(stmt);
+        return [ { rows: { length: 0, item: (_: number) => undefined } } ];
+      },
+      transaction: async (fn: any) => {
+        db.exec('BEGIN');
+        try {
+          const tx = { executeSql: (sql: string, params?: any[]) => createAdapter(db).executeSql(sql, params) };
+          await fn(tx);
+          db.exec('COMMIT');
+        } catch (err) {
+          db.exec('ROLLBACK');
+          throw err;
+        }
+      },
+      close: async () => db.close(),
+    };
+  }
+
+  return {
+    enablePromise: (_: boolean) => {},
+    openDatabase: async (_: any) => {
+      const BetterSqlite3 = require('better-sqlite3');
+      const db = new BetterSqlite3(':memory:');
+      return createAdapter(db);
+    }
+  };
+});
+
+import { DrizzleInvoiceRepository } from '../../src/infrastructure/repositories/DrizzleInvoiceRepository';
+import { DrizzlePaymentRepository } from '../../src/infrastructure/repositories/DrizzlePaymentRepository';
+import { InvoiceEntity } from '../../src/domain/entities/Invoice';
+import { PaymentEntity } from '../../src/domain/entities/Payment';
+import { RecordPaymentUseCase } from '../../src/application/usecases/payment/RecordPaymentUseCase';
+import { closeDatabase, initDatabase } from '../../src/infrastructure/database/connection';
+
+describe('InvoicePayment Integration', () => {
+  let invoiceRepo: DrizzleInvoiceRepository;
+  let paymentRepo: DrizzlePaymentRepository;
+  let recordPaymentUseCase: RecordPaymentUseCase;
+
+  beforeEach(async () => {
+    await closeDatabase();
+    invoiceRepo = new DrizzleInvoiceRepository();
+    paymentRepo = new DrizzlePaymentRepository();
+    recordPaymentUseCase = new RecordPaymentUseCase(paymentRepo, invoiceRepo);
+    
+    // Ensure payments table exists with required columns
+    const { db } = await initDatabase();
+    await db.executeSql(`
+      CREATE TABLE IF NOT EXISTS payments (
+        id TEXT PRIMARY KEY,
+        project_id TEXT,
+        invoice_id TEXT,
+        expense_id TEXT,
+        contact_id TEXT,
+        amount REAL,
+        currency TEXT,
+        payment_date INTEGER,
+        due_date INTEGER,
+        status TEXT,
+        payment_method TEXT,
+        reference TEXT,
+        notes TEXT,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `);
+    // Add columns if they don't exist (for existing test databases)
+    try { await db.executeSql('ALTER TABLE payments ADD COLUMN due_date INTEGER'); } catch(_) {}
+    try { await db.executeSql('ALTER TABLE payments ADD COLUMN status TEXT'); } catch(_) {}
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  describe('payment status updates', () => {
+    it('updates invoice paymentStatus to "paid" when payment equals total', async () => {
+      // Create an invoice with total of 1000
+      const invoice = InvoiceEntity.create({
+        total: 1000,
+        status: 'issued',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record a payment for the full amount
+      const payment = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 1000,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment);
+
+      // Verify invoice status is updated
+      const updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice).toBeDefined();
+      expect(updatedInvoice!.paymentStatus).toBe('paid');
+      expect(updatedInvoice!.status).toBe('paid');
+      expect(updatedInvoice!.paymentDate).toBeDefined();
+    });
+
+    it('updates invoice paymentStatus to "partial" when payment is less than total', async () => {
+      // Create an invoice with total of 1000
+      const invoice = InvoiceEntity.create({
+        total: 1000,
+        status: 'issued',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record a partial payment
+      const payment = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 400,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment);
+
+      // Verify invoice paymentStatus is partial
+      const updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice).toBeDefined();
+      expect(updatedInvoice!.paymentStatus).toBe('partial');
+      expect(updatedInvoice!.status).toBe('issued'); // Status should remain issued
+    });
+
+    it('handles multiple partial payments and marks as paid when total is reached', async () => {
+      // Create an invoice with total of 1500
+      const invoice = InvoiceEntity.create({
+        total: 1500,
+        status: 'issued',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record first partial payment (500)
+      const payment1 = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 500,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment1);
+
+      let updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice!.paymentStatus).toBe('partial');
+
+      // Record second partial payment (500)
+      const payment2 = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 500,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment2);
+
+      updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice!.paymentStatus).toBe('partial');
+
+      // Record final payment (500) to complete
+      const payment3 = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 500,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment3);
+
+      updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice!.paymentStatus).toBe('paid');
+      expect(updatedInvoice!.status).toBe('paid');
+    });
+
+    it('handles overpayment (payment exceeds total)', async () => {
+      // Create an invoice with total of 800
+      const invoice = InvoiceEntity.create({
+        total: 800,
+        status: 'issued',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record a payment exceeding the total
+      const payment = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 1000,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment);
+
+      // Verify invoice is marked as paid
+      const updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice).toBeDefined();
+      expect(updatedInvoice!.paymentStatus).toBe('paid');
+      expect(updatedInvoice!.status).toBe('paid');
+    });
+
+    it('keeps paymentStatus as "unpaid" when no payments are recorded', async () => {
+      // Create an invoice
+      const invoice = InvoiceEntity.create({
+        total: 500,
+        status: 'issued',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Verify invoice remains unpaid
+      const retrievedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(retrievedInvoice).toBeDefined();
+      expect(retrievedInvoice!.paymentStatus).toBe('unpaid');
+      expect(retrievedInvoice!.status).toBe('issued');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles payment with no invoice link gracefully', async () => {
+      // Record a payment without an invoiceId
+      const payment = PaymentEntity.create({
+        amount: 300,
+        projectId: 'proj_1',
+      }).data();
+
+      // Should not throw an error
+      await expect(recordPaymentUseCase.execute(payment)).resolves.not.toThrow();
+    });
+
+    it('handles payment linked to non-existent invoice gracefully', async () => {
+      // Record a payment with a non-existent invoiceId
+      const payment = PaymentEntity.create({
+        invoiceId: 'nonexistent_invoice',
+        amount: 200,
+        projectId: 'proj_1',
+      }).data();
+
+      // Should not throw an error
+      await expect(recordPaymentUseCase.execute(payment)).resolves.not.toThrow();
+    });
+
+    it('correctly accumulates payments from multiple sources', async () => {
+      // Create an invoice
+      const invoice = InvoiceEntity.create({
+        total: 1000,
+        status: 'issued',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record payments with different methods
+      const payment1 = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 400,
+        projectId: 'proj_1',
+        method: 'bank',
+      }).data();
+      await recordPaymentUseCase.execute(payment1);
+
+      const payment2 = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 300,
+        projectId: 'proj_1',
+        method: 'cash',
+      }).data();
+      await recordPaymentUseCase.execute(payment2);
+
+      const payment3 = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 300,
+        projectId: 'proj_1',
+        method: 'card',
+      }).data();
+      await recordPaymentUseCase.execute(payment3);
+
+      // Verify all payments are accumulated correctly
+      const updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice!.paymentStatus).toBe('paid');
+      expect(updatedInvoice!.status).toBe('paid');
+
+      // Verify all payments are stored
+      const payments = await paymentRepo.findByInvoice(invoice.id);
+      expect(payments.length).toBe(3);
+    });
+  });
+
+  describe('status transitions', () => {
+    it('transitions from "overdue" to "paid" when full payment is received', async () => {
+      // Create an overdue invoice
+      const invoice = InvoiceEntity.create({
+        total: 600,
+        status: 'overdue',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record full payment
+      const payment = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 600,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment);
+
+      // Verify transition to paid
+      const updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice!.status).toBe('paid');
+      expect(updatedInvoice!.paymentStatus).toBe('paid');
+    });
+
+    it('does not change status from "draft" when payment is received', async () => {
+      // Create a draft invoice
+      const invoice = InvoiceEntity.create({
+        total: 700,
+        status: 'draft',
+        paymentStatus: 'unpaid',
+      }).data();
+      await invoiceRepo.createInvoice(invoice);
+
+      // Record payment
+      const payment = PaymentEntity.create({
+        invoiceId: invoice.id,
+        amount: 700,
+        projectId: 'proj_1',
+      }).data();
+      await recordPaymentUseCase.execute(payment);
+
+      // Verify paymentStatus is updated but status remains draft
+      const updatedInvoice = await invoiceRepo.getInvoice(invoice.id);
+      expect(updatedInvoice!.paymentStatus).toBe('paid');
+      expect(updatedInvoice!.status).toBe('draft'); // Should remain draft
+    });
+  });
+});

--- a/__tests__/integration/Payment.integration.test.ts
+++ b/__tests__/integration/Payment.integration.test.ts
@@ -96,7 +96,7 @@ describe('RecordPaymentUseCase integration', () => {
   });
 
   it('marks invoice as paid when payments equal total', async () => {
-    const inv = InvoiceEntity.create({ total: 200 }).data();
+    const inv = InvoiceEntity.create({ total: 200, status: 'issued' }).data();
     await invoiceRepo.createInvoice(inv);
 
     const p = PaymentEntity.create({ projectId: inv.projectId ?? 'p', invoiceId: inv.id, amount: 200 }).data();

--- a/__tests__/unit/CancelInvoiceUseCase.test.ts
+++ b/__tests__/unit/CancelInvoiceUseCase.test.ts
@@ -1,0 +1,330 @@
+import { Invoice } from '../../src/domain/entities/Invoice';
+import { InvoiceRepository } from '../../src/domain/repositories/InvoiceRepository';
+import { CancelInvoiceUseCase } from '../../src/application/usecases/invoice/CancelInvoiceUseCase';
+
+describe('CancelInvoiceUseCase', () => {
+  let mockRepo: InvoiceRepository;
+  let useCase: CancelInvoiceUseCase;
+
+  beforeEach(() => {
+    mockRepo = {
+      createInvoice: jest.fn(),
+      getInvoice: jest.fn(),
+      updateInvoice: jest.fn(),
+      deleteInvoice: jest.fn(),
+      findByExternalKey: jest.fn(),
+      listInvoices: jest.fn(),
+      assignProject: jest.fn(),
+    } as unknown as InvoiceRepository;
+    
+    useCase = new CancelInvoiceUseCase(mockRepo);
+  });
+
+  describe('successful cancellations', () => {
+    it('cancels a draft invoice', async () => {
+      const draftInvoice: Invoice = {
+        id: 'inv_1',
+        total: 1000,
+        currency: 'USD',
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      } as Invoice;
+
+      const cancelledInvoice: Invoice = {
+        ...draftInvoice,
+        status: 'cancelled',
+        metadata: expect.objectContaining({
+          cancellationReason: 'No longer needed',
+          statusHistory: expect.arrayContaining([
+            expect.objectContaining({
+              from: 'draft',
+              to: 'cancelled',
+              timestamp: expect.any(String),
+              reason: 'No longer needed',
+            }),
+          ]),
+        }),
+      };
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(draftInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockResolvedValue(cancelledInvoice);
+
+      const result = await useCase.execute('inv_1', { reason: 'No longer needed' });
+
+      expect(mockRepo.getInvoice).toHaveBeenCalledWith('inv_1');
+      expect(mockRepo.updateInvoice).toHaveBeenCalledWith('inv_1', {
+        status: 'cancelled',
+        metadata: expect.objectContaining({
+          cancellationReason: 'No longer needed',
+          statusHistory: expect.any(Array),
+        }),
+      });
+      expect(result.status).toBe('cancelled');
+    });
+
+    it('cancels an issued invoice', async () => {
+      const issuedInvoice: Invoice = {
+        id: 'inv_2',
+        total: 500,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-05T00:00:00Z',
+      } as Invoice;
+
+      const cancelledInvoice: Invoice = {
+        ...issuedInvoice,
+        status: 'cancelled',
+      };
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(issuedInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockResolvedValue(cancelledInvoice);
+
+      const result = await useCase.execute('inv_2', { reason: 'Client requested cancellation' });
+
+      expect(result.status).toBe('cancelled');
+    });
+
+    it('cancels an overdue invoice', async () => {
+      const overdueInvoice: Invoice = {
+        id: 'inv_3',
+        total: 750,
+        currency: 'USD',
+        status: 'overdue',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-15T00:00:00Z',
+      } as Invoice;
+
+      const cancelledInvoice: Invoice = {
+        ...overdueInvoice,
+        status: 'cancelled',
+      };
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(overdueInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockResolvedValue(cancelledInvoice);
+
+      const result = await useCase.execute('inv_3', { reason: 'Payment no longer required' });
+
+      expect(result.status).toBe('cancelled');
+    });
+
+    it('stores cancellation reason in metadata', async () => {
+      const invoice: Invoice = {
+        id: 'inv_4',
+        total: 850,
+        currency: 'USD',
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoice);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoice, ...updates });
+      });
+
+      await useCase.execute('inv_4', { reason: 'Duplicate invoice' });
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.cancellationReason).toBe('Duplicate invoice');
+    });
+
+    it('records timestamp in audit trail', async () => {
+      const invoice: Invoice = {
+        id: 'inv_5',
+        total: 950,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-03T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoice);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoice, ...updates });
+      });
+
+      const beforeExecution = new Date().toISOString();
+      await useCase.execute('inv_5', { reason: 'Error in invoice' });
+      const afterExecution = new Date().toISOString();
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.statusHistory).toBeDefined();
+      expect(updateCall.metadata.statusHistory[0].timestamp).toBeDefined();
+      
+      const recordedTimestamp = updateCall.metadata.statusHistory[0].timestamp;
+      expect(recordedTimestamp >= beforeExecution && recordedTimestamp <= afterExecution).toBe(true);
+    });
+
+    it('accepts optional actor parameter for audit trail', async () => {
+      const invoice: Invoice = {
+        id: 'inv_6',
+        total: 1100,
+        currency: 'USD',
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-04T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoice);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoice, ...updates });
+      });
+
+      await useCase.execute('inv_6', { reason: 'Cancelled by admin', actor: 'admin_456' });
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.statusHistory[0].actor).toBe('admin_456');
+    });
+
+    it('allows cancellation without a reason', async () => {
+      const invoice: Invoice = {
+        id: 'inv_7',
+        total: 600,
+        currency: 'USD',
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-05T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoice);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoice, ...updates });
+      });
+
+      const result = await useCase.execute('inv_7');
+
+      expect(result.status).toBe('cancelled');
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.cancellationReason).toBeUndefined();
+    });
+  });
+
+  describe('validation', () => {
+    it('throws error if invoice does not exist', async () => {
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(null);
+
+      await expect(useCase.execute('inv_nonexistent')).rejects.toThrow(
+        'Invoice with ID inv_nonexistent not found'
+      );
+    });
+
+    it('throws error if invoice is already paid (MVP business rule)', async () => {
+      const paidInvoice: Invoice = {
+        id: 'inv_8',
+        total: 300,
+        currency: 'USD',
+        status: 'paid',
+        paymentStatus: 'paid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-10T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(paidInvoice);
+
+      await expect(useCase.execute('inv_8', { reason: 'Test' })).rejects.toThrow(
+        'Cannot cancel a paid invoice'
+      );
+    });
+
+    it('throws error if invoice is already cancelled', async () => {
+      const cancelledInvoice: Invoice = {
+        id: 'inv_9',
+        total: 450,
+        currency: 'USD',
+        status: 'cancelled',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-12T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(cancelledInvoice);
+
+      await expect(useCase.execute('inv_9', { reason: 'Test' })).rejects.toThrow(
+        'Invoice is already cancelled'
+      );
+    });
+  });
+
+  describe('audit trail', () => {
+    it('preserves existing metadata when adding cancellation info', async () => {
+      const invoiceWithMetadata: Invoice = {
+        id: 'inv_10',
+        total: 700,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        metadata: {
+          customField: 'customValue',
+          existingData: 456,
+        },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-06T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoiceWithMetadata);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoiceWithMetadata, ...updates });
+      });
+
+      await useCase.execute('inv_10', { reason: 'Cancelled' });
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.customField).toBe('customValue');
+      expect(updateCall.metadata.existingData).toBe(456);
+      expect(updateCall.metadata.statusHistory).toBeDefined();
+    });
+
+    it('appends to existing status history', async () => {
+      const invoiceWithHistory: Invoice = {
+        id: 'inv_11',
+        total: 800,
+        currency: 'USD',
+        status: 'overdue',
+        paymentStatus: 'unpaid',
+        metadata: {
+          statusHistory: [
+            {
+              from: 'draft',
+              to: 'issued',
+              timestamp: '2026-01-01T10:00:00Z',
+              actor: 'user_001',
+            },
+            {
+              from: 'issued',
+              to: 'overdue',
+              timestamp: '2026-01-15T00:00:00Z',
+              actor: 'system',
+            },
+          ],
+        },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-15T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoiceWithHistory);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoiceWithHistory, ...updates });
+      });
+
+      await useCase.execute('inv_11', { reason: 'Not needed', actor: 'user_002' });
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.statusHistory.length).toBe(3);
+      expect(updateCall.metadata.statusHistory[2]).toMatchObject({
+        from: 'overdue',
+        to: 'cancelled',
+        actor: 'user_002',
+        reason: 'Not needed',
+      });
+    });
+  });
+});

--- a/__tests__/unit/InvoiceLifecycleActions.test.tsx
+++ b/__tests__/unit/InvoiceLifecycleActions.test.tsx
@@ -1,0 +1,351 @@
+import React from 'react';
+import renderer, { act, ReactTestRenderer } from 'react-test-renderer';
+import { Alert } from 'react-native';
+import { InvoiceLifecycleActions } from '../../src/components/invoices/InvoiceLifecycleActions';
+import { Invoice } from '../../src/domain/entities/Invoice';
+
+// Mock Alert
+jest.spyOn(Alert, 'alert').mockImplementation((title, message, buttons) => {
+  // Auto-click the first button (usually the action button for our tests)
+  if (buttons && buttons.length > 0) {
+    const button = buttons[0];
+    if (button.onPress) {
+      button.onPress();
+    }
+  }
+});
+
+describe('InvoiceLifecycleActions', () => {
+  const mockOnUpdate = jest.fn();
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('draft invoice actions', () => {
+    const draftInvoice: Invoice = {
+      id: 'inv_1',
+      total: 1000,
+      currency: 'USD',
+      status: 'draft',
+      paymentStatus: 'unpaid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    } as Invoice;
+
+    it('renders "Issue" and "Cancel" buttons for draft invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={draftInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const tree = testRenderer!.toJSON();
+      expect(tree).toBeDefined();
+      // Verify buttons are rendered (snapshot test covers this)
+    });
+
+    it('does not render "Mark Paid" button for draft invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={draftInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      // Attempt to find "Mark Paid" button - should not exist
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      const markPaidButton = buttons.find((button: any) => {
+        const text = button.findAllByType(require('react-native').Text);
+        return text.some((t: any) => t.props.children === 'Mark Paid');
+      });
+      
+      expect(markPaidButton).toBeUndefined();
+    });
+  });
+
+  describe('issued invoice actions', () => {
+    const issuedInvoice: Invoice = {
+      id: 'inv_2',
+      total: 500,
+      currency: 'USD',
+      status: 'issued',
+      paymentStatus: 'unpaid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-05T00:00:00Z',
+    } as Invoice;
+
+    it('renders "Mark Paid" and "Cancel" buttons for issued invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={issuedInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const tree = testRenderer!.toJSON();
+      expect(tree).toBeDefined();
+    });
+
+    it('does not render "Issue" button for issued invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={issuedInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      const issueButton = buttons.find((button: any) => {
+        const text = button.findAllByType(require('react-native').Text);
+        return text.some((t: any) => t.props.children === 'Issue');
+      });
+      
+      expect(issueButton).toBeUndefined();
+    });
+  });
+
+  describe('overdue invoice actions', () => {
+    const overdueInvoice: Invoice = {
+      id: 'inv_3',
+      total: 750,
+      currency: 'USD',
+      status: 'overdue',
+      paymentStatus: 'unpaid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-15T00:00:00Z',
+    } as Invoice;
+
+    it('renders "Mark Paid" and "Cancel" buttons for overdue invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={overdueInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const tree = testRenderer!.toJSON();
+      expect(tree).toBeDefined();
+    });
+  });
+
+  describe('paid invoice actions', () => {
+    const paidInvoice: Invoice = {
+      id: 'inv_4',
+      total: 1200,
+      currency: 'USD',
+      status: 'paid',
+      paymentStatus: 'paid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-10T00:00:00Z',
+    } as Invoice;
+
+    it('renders no action buttons for paid invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={paidInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      
+      // Should have no action buttons for paid invoice
+      expect(buttons.length).toBe(0);
+    });
+  });
+
+  describe('cancelled invoice actions', () => {
+    const cancelledInvoice: Invoice = {
+      id: 'inv_5',
+      total: 600,
+      currency: 'USD',
+      status: 'cancelled',
+      paymentStatus: 'unpaid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-12T00:00:00Z',
+    } as Invoice;
+
+    it('renders no action buttons for cancelled invoice', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={cancelledInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      
+      // Should have no action buttons for cancelled invoice
+      expect(buttons.length).toBe(0);
+    });
+  });
+
+  describe('action handlers', () => {
+    const issuedInvoice: Invoice = {
+      id: 'inv_6',
+      total: 850,
+      currency: 'USD',
+      status: 'issued',
+      paymentStatus: 'unpaid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-06T00:00:00Z',
+    } as Invoice;
+
+    it('calls onUpdate when "Mark Paid" is confirmed', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={issuedInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      const markPaidButton = buttons.find((button: any) => {
+        const text = button.findAllByType(require('react-native').Text);
+        return text.some((t: any) => t.props.children === 'Mark Paid');
+      });
+
+      expect(markPaidButton).toBeDefined();
+      
+      // Trigger the button press
+      await act(async () => {
+        markPaidButton!.props.onPress();
+      });
+
+      // Should show confirmation and call onUpdate
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Mark Invoice as Paid',
+        expect.stringContaining('Are you sure'),
+        expect.any(Array)
+      );
+    });
+
+    it('shows confirmation dialog before cancelling', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={issuedInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      const cancelButton = buttons.find((button: any) => {
+        const text = button.findAllByType(require('react-native').Text);
+        return text.some((t: any) => t.props.children === 'Cancel');
+      });
+
+      expect(cancelButton).toBeDefined();
+      
+      // Trigger the button press
+      await act(async () => {
+        cancelButton!.props.onPress();
+      });
+
+      // Should show confirmation dialog
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Cancel Invoice',
+        expect.stringContaining('Are you sure'),
+        expect.any(Array)
+      );
+    });
+  });
+
+  describe('loading states', () => {
+    const issuedInvoice: Invoice = {
+      id: 'inv_7',
+      total: 950,
+      currency: 'USD',
+      status: 'issued',
+      paymentStatus: 'unpaid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-07T00:00:00Z',
+    } as Invoice;
+
+    it('disables buttons during loading', async () => {
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions 
+            invoice={issuedInvoice} 
+            onUpdate={mockOnUpdate}
+            loading={true}
+          />
+        );
+      });
+
+      const instance = testRenderer!.root;
+      const buttons = instance.findAllByType(require('react-native').TouchableOpacity);
+      
+      // All buttons should be disabled during loading
+      buttons.forEach((button: any) => {
+        expect(button.props.disabled).toBe(true);
+      });
+    });
+  });
+
+  describe('snapshot tests', () => {
+    it('matches snapshot for draft invoice', async () => {
+      const draftInvoice: Invoice = {
+        id: 'inv_snap_1',
+        total: 100,
+        currency: 'USD',
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      } as Invoice;
+
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={draftInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const tree = testRenderer!.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('matches snapshot for issued invoice', async () => {
+      const issuedInvoice: Invoice = {
+        id: 'inv_snap_2',
+        total: 200,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-05T00:00:00Z',
+      } as Invoice;
+
+      let testRenderer: ReactTestRenderer | undefined;
+
+      await act(async () => {
+        testRenderer = renderer.create(
+          <InvoiceLifecycleActions invoice={issuedInvoice} onUpdate={mockOnUpdate} />
+        );
+      });
+
+      const tree = testRenderer!.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/__tests__/unit/MarkInvoiceAsPaidUseCase.test.ts
+++ b/__tests__/unit/MarkInvoiceAsPaidUseCase.test.ts
@@ -1,0 +1,282 @@
+import { Invoice } from '../../src/domain/entities/Invoice';
+import { InvoiceRepository } from '../../src/domain/repositories/InvoiceRepository';
+import { MarkInvoiceAsPaidUseCase } from '../../src/application/usecases/invoice/MarkInvoiceAsPaidUseCase';
+
+describe('MarkInvoiceAsPaidUseCase', () => {
+  let mockRepo: InvoiceRepository;
+  let useCase: MarkInvoiceAsPaidUseCase;
+
+  beforeEach(() => {
+    mockRepo = {
+      createInvoice: jest.fn(),
+      getInvoice: jest.fn(),
+      updateInvoice: jest.fn(),
+      deleteInvoice: jest.fn(),
+      findByExternalKey: jest.fn(),
+      listInvoices: jest.fn(),
+      assignProject: jest.fn(),
+    } as unknown as InvoiceRepository;
+    
+    useCase = new MarkInvoiceAsPaidUseCase(mockRepo);
+  });
+
+  describe('successful transitions', () => {
+    it('marks an "issued" invoice as paid', async () => {
+      const issuedInvoice: Invoice = {
+        id: 'inv_1',
+        total: 1000,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      } as Invoice;
+
+      const paidInvoice: Invoice = {
+        ...issuedInvoice,
+        status: 'paid',
+        paymentStatus: 'paid',
+        paymentDate: expect.any(String),
+        metadata: expect.objectContaining({
+          statusHistory: expect.arrayContaining([
+            expect.objectContaining({
+              from: 'issued',
+              to: 'paid',
+              timestamp: expect.any(String),
+            }),
+          ]),
+        }),
+      };
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(issuedInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockResolvedValue(paidInvoice);
+
+      const result = await useCase.execute('inv_1');
+
+      expect(mockRepo.getInvoice).toHaveBeenCalledWith('inv_1');
+      expect(mockRepo.updateInvoice).toHaveBeenCalledWith('inv_1', {
+        status: 'paid',
+        paymentStatus: 'paid',
+        paymentDate: expect.any(String),
+        metadata: expect.objectContaining({
+          statusHistory: expect.any(Array),
+        }),
+      });
+      expect(result.status).toBe('paid');
+      expect(result.paymentStatus).toBe('paid');
+    });
+
+    it('marks an "overdue" invoice as paid', async () => {
+      const overdueInvoice: Invoice = {
+        id: 'inv_2',
+        total: 500,
+        currency: 'USD',
+        status: 'overdue',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-15T00:00:00Z',
+      } as Invoice;
+
+      const paidInvoice: Invoice = {
+        ...overdueInvoice,
+        status: 'paid',
+        paymentStatus: 'paid',
+      };
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(overdueInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockResolvedValue(paidInvoice);
+
+      const result = await useCase.execute('inv_2');
+
+      expect(result.status).toBe('paid');
+      expect(result.paymentStatus).toBe('paid');
+    });
+
+    it('records timestamp in audit trail', async () => {
+      const issuedInvoice: Invoice = {
+        id: 'inv_3',
+        total: 750,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(issuedInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...issuedInvoice, ...updates });
+      });
+
+      const beforeExecution = new Date().toISOString();
+      await useCase.execute('inv_3');
+      const afterExecution = new Date().toISOString();
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.statusHistory).toBeDefined();
+      expect(updateCall.metadata.statusHistory[0].timestamp).toBeDefined();
+      
+      const recordedTimestamp = updateCall.metadata.statusHistory[0].timestamp;
+      expect(recordedTimestamp >= beforeExecution && recordedTimestamp <= afterExecution).toBe(true);
+    });
+
+    it('accepts optional actor parameter for audit trail', async () => {
+      const issuedInvoice: Invoice = {
+        id: 'inv_4',
+        total: 1200,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(issuedInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...issuedInvoice, ...updates });
+      });
+
+      await useCase.execute('inv_4', { actor: 'user_123' });
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.statusHistory[0].actor).toBe('user_123');
+    });
+  });
+
+  describe('validation', () => {
+    it('throws error if invoice does not exist', async () => {
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(null);
+
+      await expect(useCase.execute('inv_nonexistent')).rejects.toThrow(
+        'Invoice with ID inv_nonexistent not found'
+      );
+    });
+
+    it('throws error if invoice is already paid', async () => {
+      const alreadyPaidInvoice: Invoice = {
+        id: 'inv_5',
+        total: 300,
+        currency: 'USD',
+        status: 'paid',
+        paymentStatus: 'paid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-10T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(alreadyPaidInvoice);
+
+      await expect(useCase.execute('inv_5')).rejects.toThrow(
+        'Invoice is already marked as paid'
+      );
+    });
+
+    it('throws error if invoice is cancelled', async () => {
+      const cancelledInvoice: Invoice = {
+        id: 'inv_6',
+        total: 450,
+        currency: 'USD',
+        status: 'cancelled',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-12T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(cancelledInvoice);
+
+      await expect(useCase.execute('inv_6')).rejects.toThrow(
+        'Cannot mark a cancelled invoice as paid'
+      );
+    });
+
+    it('throws error if invoice is in draft status', async () => {
+      const draftInvoice: Invoice = {
+        id: 'inv_7',
+        total: 600,
+        currency: 'USD',
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(draftInvoice);
+
+      await expect(useCase.execute('inv_7')).rejects.toThrow(
+        'Only issued or overdue invoices can be marked as paid'
+      );
+    });
+  });
+
+  describe('audit trail', () => {
+    it('preserves existing metadata when adding status history', async () => {
+      const invoiceWithMetadata: Invoice = {
+        id: 'inv_8',
+        total: 850,
+        currency: 'USD',
+        status: 'issued',
+        paymentStatus: 'unpaid',
+        metadata: {
+          customField: 'customValue',
+          existingData: 123,
+        },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-05T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoiceWithMetadata);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoiceWithMetadata, ...updates });
+      });
+
+      await useCase.execute('inv_8');
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.customField).toBe('customValue');
+      expect(updateCall.metadata.existingData).toBe(123);
+      expect(updateCall.metadata.statusHistory).toBeDefined();
+    });
+
+    it('appends to existing status history', async () => {
+      const invoiceWithHistory: Invoice = {
+        id: 'inv_9',
+        total: 950,
+        currency: 'USD',
+        status: 'overdue',
+        paymentStatus: 'unpaid',
+        metadata: {
+          statusHistory: [
+            {
+              from: 'draft',
+              to: 'issued',
+              timestamp: '2026-01-01T10:00:00Z',
+              actor: 'user_001',
+            },
+            {
+              from: 'issued',
+              to: 'overdue',
+              timestamp: '2026-01-15T00:00:00Z',
+              actor: 'system',
+            },
+          ],
+        },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-15T00:00:00Z',
+      } as Invoice;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(invoiceWithHistory);
+      (mockRepo.updateInvoice as jest.Mock).mockImplementation((id, updates) => {
+        return Promise.resolve({ ...invoiceWithHistory, ...updates });
+      });
+
+      await useCase.execute('inv_9', { actor: 'user_002' });
+
+      const updateCall = (mockRepo.updateInvoice as jest.Mock).mock.calls[0][1];
+      expect(updateCall.metadata.statusHistory.length).toBe(3);
+      expect(updateCall.metadata.statusHistory[2]).toMatchObject({
+        from: 'overdue',
+        to: 'paid',
+        actor: 'user_002',
+      });
+    });
+  });
+});

--- a/__tests__/unit/__snapshots__/InvoiceLifecycleActions.test.tsx.snap
+++ b/__tests__/unit/__snapshots__/InvoiceLifecycleActions.test.tsx.snap
@@ -1,0 +1,241 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InvoiceLifecycleActions snapshot tests matches snapshot for draft invoice 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "row",
+      "flexWrap": "wrap",
+      "gap": 8,
+      "padding": 16,
+    }
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#3b82f6",
+        "borderRadius": 8,
+        "justifyContent": "center",
+        "minWidth": 100,
+        "opacity": 1,
+        "paddingHorizontal": 16,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#ffffff",
+          "fontSize": 14,
+          "fontWeight": "600",
+        }
+      }
+    >
+      Issue
+    </Text>
+  </View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#ef4444",
+        "borderRadius": 8,
+        "justifyContent": "center",
+        "minWidth": 100,
+        "opacity": 1,
+        "paddingHorizontal": 16,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#ffffff",
+          "fontSize": 14,
+          "fontWeight": "600",
+        }
+      }
+    >
+      Cancel
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`InvoiceLifecycleActions snapshot tests matches snapshot for issued invoice 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "row",
+      "flexWrap": "wrap",
+      "gap": 8,
+      "padding": 16,
+    }
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#22c55e",
+        "borderRadius": 8,
+        "justifyContent": "center",
+        "minWidth": 100,
+        "opacity": 1,
+        "paddingHorizontal": 16,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#ffffff",
+          "fontSize": 14,
+          "fontWeight": "600",
+        }
+      }
+    >
+      Mark Paid
+    </Text>
+  </View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#ef4444",
+        "borderRadius": 8,
+        "justifyContent": "center",
+        "minWidth": 100,
+        "opacity": 1,
+        "paddingHorizontal": 16,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#ffffff",
+          "fontSize": 14,
+          "fontWeight": "600",
+        }
+      }
+    >
+      Cancel
+    </Text>
+  </View>
+</View>
+`;

--- a/progress.md
+++ b/progress.md
@@ -436,3 +436,62 @@ Current Milestone: Implement Quotation UI module (Issue #65)
 - Add voice input in future iteration
 
 ---
+
+**Date**: 2026-02-17  
+**Branch**: issue-71  
+**Scope**: Invoice Module Phase 3 — Lifecycle Operations (Issue #71)
+
+**Key Decisions**:
+- Use `Invoice.metadata.statusHistory` array for audit trail (lightweight, no separate table for MVP)
+- Lifecycle transitions: only `issued`/`overdue` → `paid`; prevent cancelling `paid` invoices
+- Payment integration: auto-update `paymentStatus` on payment records; transition to `paid` only for `issued`/`overdue` invoices (not `draft`)
+
+**Completed This Session**:
+- ✅ Implemented `MarkInvoiceAsPaidUseCase` with validation and audit trail
+  - Validates allowed transitions (`issued`/`overdue` → `paid`)
+  - Records timestamp, optional actor, and reason in `metadata.statusHistory`
+  - Unit tests (10/10 passing)
+- ✅ Implemented `CancelInvoiceUseCase` with cancellation rules
+  - Prevents cancelling `paid` invoices (MVP business rule)
+  - Stores cancellation reason and audit trail
+  - Unit tests (12/12 passing)
+- ✅ Implemented `InvoiceLifecycleActions` UI component
+  - Context-aware buttons based on invoice status
+  - Confirmation dialogs for destructive actions
+  - Loading states with disabled buttons
+  - Unit tests (12/12 passing)
+- ✅ Enhanced payment integration
+  - Updated `RecordPaymentUseCase` to only transition `issued`/`overdue` invoices to `paid` status
+  - Auto-calculation of `paymentStatus` (`unpaid`/`partial`/`paid`)
+  - Integration tests (10/10 passing)
+- ✅ Audit trail implementation
+  - Status change history with `{ from, to, timestamp, actor, reason }`
+  - Preserves existing metadata, appends to history array
+  - Fully tested in use case tests
+
+**Files Added**:
+- `src/application/usecases/invoice/MarkInvoiceAsPaidUseCase.ts`
+- `src/application/usecases/invoice/CancelInvoiceUseCase.ts`
+- `src/components/invoices/InvoiceLifecycleActions.tsx`
+- `__tests__/unit/MarkInvoiceAsPaidUseCase.test.ts`
+- `__tests__/unit/CancelInvoiceUseCase.test.ts`
+- `__tests__/unit/InvoiceLifecycleActions.test.tsx`
+- `__tests__/integration/InvoicePayment.integration.test.tsx`
+
+**Files Modified**:
+- `src/application/usecases/payment/RecordPaymentUseCase.ts` (enhanced payment status logic)
+- `__tests__/integration/Payment.integration.test.ts` (updated test fixture)
+
+**Test Status**:
+- All tests passing: 44 tests (4 test suites)
+- TypeScript check: ✅ passes (`npx tsc --noEmit`)
+- TDD workflow followed: tests written before implementation for all features
+
+**Pending Tasks**: None (all Phase 3 acceptance criteria met)
+
+**Next Steps**:
+- Open PR from `issue-71` → `master` with reference to design doc ([design/issue-67-invoice-module.md](design/issue-67-invoice-module.md) Phase 3)
+- Consider adding `InvoiceDetailPage` to display audit trail timeline
+- Wire lifecycle actions into invoice list/detail views when UI is implemented
+
+---

--- a/src/application/usecases/invoice/CancelInvoiceUseCase.ts
+++ b/src/application/usecases/invoice/CancelInvoiceUseCase.ts
@@ -1,0 +1,60 @@
+import { Invoice } from '../../../domain/entities/Invoice';
+import { InvoiceRepository } from '../../../domain/repositories/InvoiceRepository';
+
+export interface CancelInvoiceOptions {
+  reason?: string;
+  actor?: string;
+}
+
+export class CancelInvoiceUseCase {
+  constructor(private readonly repo: InvoiceRepository) {}
+
+  async execute(
+    invoiceId: string,
+    options?: CancelInvoiceOptions
+  ): Promise<Invoice> {
+    // 1. Fetch the invoice
+    const invoice = await this.repo.getInvoice(invoiceId);
+    
+    if (!invoice) {
+      throw new Error(`Invoice with ID ${invoiceId} not found`);
+    }
+
+    // 2. Validate transitions
+    if (invoice.status === 'cancelled') {
+      throw new Error('Invoice is already cancelled');
+    }
+
+    if (invoice.status === 'paid') {
+      throw new Error('Cannot cancel a paid invoice');
+    }
+
+    // 3. Prepare audit trail entry
+    const now = new Date().toISOString();
+    const statusChange = {
+      from: invoice.status,
+      to: 'cancelled' as const,
+      timestamp: now,
+      ...(options?.actor && { actor: options.actor }),
+      ...(options?.reason && { reason: options.reason }),
+    };
+
+    // 4. Preserve existing metadata and append to status history
+    const existingMetadata = invoice.metadata || {};
+    const existingHistory = (existingMetadata.statusHistory as any[]) || [];
+    
+    const updatedMetadata = {
+      ...existingMetadata,
+      statusHistory: [...existingHistory, statusChange],
+      ...(options?.reason && { cancellationReason: options.reason }),
+    };
+
+    // 5. Update the invoice
+    const updates: Partial<Invoice> = {
+      status: 'cancelled',
+      metadata: updatedMetadata,
+    };
+
+    return this.repo.updateInvoice(invoiceId, updates);
+  }
+}

--- a/src/application/usecases/invoice/MarkInvoiceAsPaidUseCase.ts
+++ b/src/application/usecases/invoice/MarkInvoiceAsPaidUseCase.ts
@@ -1,0 +1,65 @@
+import { Invoice } from '../../../domain/entities/Invoice';
+import { InvoiceRepository } from '../../../domain/repositories/InvoiceRepository';
+
+export interface MarkInvoiceAsPaidOptions {
+  actor?: string;
+  reason?: string;
+}
+
+export class MarkInvoiceAsPaidUseCase {
+  constructor(private readonly repo: InvoiceRepository) {}
+
+  async execute(
+    invoiceId: string,
+    options?: MarkInvoiceAsPaidOptions
+  ): Promise<Invoice> {
+    // 1. Fetch the invoice
+    const invoice = await this.repo.getInvoice(invoiceId);
+    
+    if (!invoice) {
+      throw new Error(`Invoice with ID ${invoiceId} not found`);
+    }
+
+    // 2. Validate transitions
+    if (invoice.status === 'paid') {
+      throw new Error('Invoice is already marked as paid');
+    }
+
+    if (invoice.status === 'cancelled') {
+      throw new Error('Cannot mark a cancelled invoice as paid');
+    }
+
+    if (invoice.status !== 'issued' && invoice.status !== 'overdue') {
+      throw new Error('Only issued or overdue invoices can be marked as paid');
+    }
+
+    // 3. Prepare audit trail entry
+    const now = new Date().toISOString();
+    const statusChange = {
+      from: invoice.status,
+      to: 'paid' as const,
+      timestamp: now,
+      ...(options?.actor && { actor: options.actor }),
+      ...(options?.reason && { reason: options.reason }),
+    };
+
+    // 4. Preserve existing metadata and append to status history
+    const existingMetadata = invoice.metadata || {};
+    const existingHistory = (existingMetadata.statusHistory as any[]) || [];
+    
+    const updatedMetadata = {
+      ...existingMetadata,
+      statusHistory: [...existingHistory, statusChange],
+    };
+
+    // 5. Update the invoice
+    const updates: Partial<Invoice> = {
+      status: 'paid',
+      paymentStatus: 'paid',
+      paymentDate: now,
+      metadata: updatedMetadata,
+    };
+
+    return this.repo.updateInvoice(invoiceId, updates);
+  }
+}

--- a/src/application/usecases/payment/RecordPaymentUseCase.ts
+++ b/src/application/usecases/payment/RecordPaymentUseCase.ts
@@ -19,7 +19,9 @@ export class RecordPaymentUseCase {
 
       const newPaymentStatus = paid >= invoice.total ? 'paid' : (paid > 0 ? 'partial' : 'unpaid');
       const updates: any = { paymentStatus: newPaymentStatus };
-      if (newPaymentStatus === 'paid') {
+      
+      // Only change status to 'paid' if invoice is issued or overdue
+      if (newPaymentStatus === 'paid' && (invoice.status === 'issued' || invoice.status === 'overdue')) {
         updates.status = 'paid';
         updates.paymentDate = new Date().toISOString();
       }

--- a/src/components/invoices/InvoiceForm.tsx
+++ b/src/components/invoices/InvoiceForm.tsx
@@ -44,8 +44,8 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({
   const [currency, setCurrency] = useState(initialValues?.currency || 'USD');
   const [subtotal, setSubtotal] = useState(initialValues?.subtotal?.toString() || '');
   const [tax, setTax] = useState(initialValues?.tax?.toString() || '');
-  const [status, setStatus] = useState<Invoice['status']>(initialValues?.status || 'draft');
-  const [paymentStatus, setPaymentStatus] = useState<Invoice['paymentStatus']>(
+  const [status, _setStatus] = useState<Invoice['status']>(initialValues?.status || 'draft');
+  const [paymentStatus, _setPaymentStatus] = useState<Invoice['paymentStatus']>(
     initialValues?.paymentStatus || 'unpaid'
   );
   const [dateIssued, setDateIssued] = useState<Date | null>(
@@ -55,7 +55,7 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({
     initialValues?.dateDue ? new Date(initialValues.dateDue) : null
   );
   const [notes, setNotes] = useState(initialValues?.notes || '');
-  const [lineItems, setLineItems] = useState<InvoiceLineItem[]>(
+  const [lineItems, _setLineItems] = useState<InvoiceLineItem[]>(
     initialValues?.lineItems || []
   );
 
@@ -107,7 +107,6 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({
       }, 0);
 
       const subtotalNum = subtotal ? parseFloat(subtotal) : 0;
-      const totalNum = parseFloat(total);
       const taxNum = tax ? parseFloat(tax) : 0;
       
       const tolerance = 0.01;
@@ -118,6 +117,7 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({
       }
       
       // Check if total matches subtotal + tax, OR matches line items sum if no separate subtotal
+      const totalNum = parseFloat(total);
       const expectedTotal = subtotal ? subtotalNum + taxNum : calculatedSubtotal + taxNum;
       if (!isNaN(totalNum) && Math.abs(totalNum - expectedTotal) > tolerance) {
         newErrors.total = newErrors.total || 'Total does not match line items and tax';

--- a/src/components/invoices/InvoiceLifecycleActions.tsx
+++ b/src/components/invoices/InvoiceLifecycleActions.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, Alert, StyleSheet, ActivityIndicator } from 'react-native';
+import { Invoice } from '../../domain/entities/Invoice';
+
+interface InvoiceLifecycleActionsProps {
+  invoice: Invoice;
+  onUpdate: (action: 'issue' | 'markPaid' | 'cancel', invoiceId: string) => void | Promise<void>;
+  loading?: boolean;
+}
+
+export const InvoiceLifecycleActions: React.FC<InvoiceLifecycleActionsProps> = ({
+  invoice,
+  onUpdate,
+  loading = false,
+}) => {
+  const handleIssue = () => {
+    Alert.alert(
+      'Issue Invoice',
+      'Are you sure you want to issue this invoice?',
+      [
+        {
+          text: 'Issue',
+          onPress: () => onUpdate('issue', invoice.id),
+        },
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+      ]
+    );
+  };
+
+  const handleMarkPaid = () => {
+    Alert.alert(
+      'Mark Invoice as Paid',
+      'Are you sure you want to mark this invoice as paid?',
+      [
+        {
+          text: 'Mark Paid',
+          onPress: () => onUpdate('markPaid', invoice.id),
+        },
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+      ]
+    );
+  };
+
+  const handleCancel = () => {
+    Alert.alert(
+      'Cancel Invoice',
+      'Are you sure you want to cancel this invoice? This action cannot be undone.',
+      [
+        {
+          text: 'Cancel Invoice',
+          style: 'destructive',
+          onPress: () => onUpdate('cancel', invoice.id),
+        },
+        {
+          text: 'Go Back',
+          style: 'cancel',
+        },
+      ]
+    );
+  };
+
+  // Determine which actions to show based on invoice status
+  const showIssue = invoice.status === 'draft';
+  const showMarkPaid = invoice.status === 'issued' || invoice.status === 'overdue';
+  const showCancel = 
+    invoice.status === 'draft' || 
+    invoice.status === 'issued' || 
+    invoice.status === 'overdue';
+
+  // Don't render anything if no actions are available
+  if (!showIssue && !showMarkPaid && !showCancel) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      {showIssue && (
+        <TouchableOpacity
+          style={[styles.button, styles.primaryButton, loading && styles.disabledButton]}
+          onPress={handleIssue}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.primaryButtonText}>Issue</Text>
+          )}
+        </TouchableOpacity>
+      )}
+
+      {showMarkPaid && (
+        <TouchableOpacity
+          style={[styles.button, styles.successButton, loading && styles.disabledButton]}
+          onPress={handleMarkPaid}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.successButtonText}>Mark Paid</Text>
+          )}
+        </TouchableOpacity>
+      )}
+
+      {showCancel && (
+        <TouchableOpacity
+          style={[styles.button, styles.dangerButton, loading && styles.disabledButton]}
+          onPress={handleCancel}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.dangerButtonText}>Cancel</Text>
+          )}
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    padding: 16,
+  },
+  button: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    minWidth: 100,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButton: {
+    backgroundColor: '#3b82f6', // blue-500
+  },
+  successButton: {
+    backgroundColor: '#22c55e', // green-500
+  },
+  dangerButton: {
+    backgroundColor: '#ef4444', // red-500
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  successButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  dangerButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+});

--- a/src/pages/invoices/InvoiceDetailPage.tsx
+++ b/src/pages/invoices/InvoiceDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ArrowLeft, Edit, Trash2 } from 'lucide-react-native';
@@ -26,11 +26,7 @@ export default function InvoiceDetailPage() {
 
   const { getInvoiceById, updateInvoice, deleteInvoice } = useInvoices();
 
-  useEffect(() => {
-    loadInvoice();
-  }, [invoiceId]);
-
-  const loadInvoice = async () => {
+  const loadInvoice = useCallback(async () => {
     try {
       setLoading(true);
       const data = await getInvoiceById(invoiceId);
@@ -38,7 +34,11 @@ export default function InvoiceDetailPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [invoiceId, getInvoiceById]);
+
+  useEffect(() => {
+    loadInvoice();
+  }, [loadInvoice]);
 
   const handleUpdate = async (updatedInvoice: Partial<Invoice>) => {
     const result = await updateInvoice({ ...invoice, ...updatedInvoice } as Invoice);


### PR DESCRIPTION
Implements Phase 3 of the invoice module design (design/issue-67-invoice-module.md).

Summary of changes:
- `MarkInvoiceAsPaidUseCase` with validation and audit trail
- `CancelInvoiceUseCase` with cancellation rules and audit
- `InvoiceLifecycleActions` component with context-aware actions and confirmations
- Payment integration test and update to `RecordPaymentUseCase` to avoid changing `draft` status to `paid`
- Unit and integration tests covering lifecycle flows

All new tests added; TypeScript and linter errors were addressed (no ESLint errors remain).  
Closes: #71
