### PR TITLE
Fix double-modal for AdHoc Task + add ProjectPicker for TaskForm (#101)

### DIFF
--- a/src/components/inputs/ProjectPicker.tsx
+++ b/src/components/inputs/ProjectPicker.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, Modal, FlatList, ActivityIndicator } from 'react-native';
+import { useProjects } from '../../hooks/useProjects';
+
+interface Props {
+  value: string;
+  onChange: (val: string) => void;
+}
+
+export const ProjectPicker: React.FC<Props> = ({ value, onChange }) => {
+  const { projects, loading } = useProjects();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        className="h-12 rounded-lg border border-input bg-background px-3 justify-center"
+      >
+        <Text className={`${value ? 'text-foreground' : 'text-muted-foreground'}`}>
+          {value ? (projects.find((p) => p.id === value)?.name ?? value) : 'None'}
+        </Text>
+      </Pressable>
+
+      <Modal visible={open} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setOpen(false)}>
+        <View className="flex-1 p-4 bg-background">
+          <View className="flex-row items-center justify-between mb-4">
+            <Text className="text-lg font-semibold text-foreground">Select Project</Text>
+            <Pressable onPress={() => setOpen(false)}>
+              <Text className="text-primary">Close</Text>
+            </Pressable>
+          </View>
+
+          {loading ? (
+            <ActivityIndicator />
+          ) : (
+            <FlatList
+              data={[{ id: '', name: 'None' }, ...projects.map((p) => ({ id: p.id, name: p.name }))]}
+              keyExtractor={(item) => item.id || 'none'}
+              renderItem={({ item }) => (
+                <Pressable
+                  onPress={() => {
+                    onChange(item.id);
+                    setOpen(false);
+                  }}
+                  className="p-4 border-b border-border"
+                >
+                  <Text className="text-foreground">{item.name}</Text>
+                </Pressable>
+              )}
+            />
+          )}
+        </View>
+      </Modal>
+    </>
+  );
+};
+
+export default ProjectPicker;

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { Task } from '../../domain/entities/Task';
+import ProjectPicker from '../inputs/ProjectPicker';
 import { TaskDraft } from '../../application/services/IVoiceParsingService';
 import DatePickerInput from '../inputs/DatePickerInput';
 import { X, Save } from 'lucide-react-native';
@@ -63,14 +64,8 @@ export function TaskForm({ initialValues, onSubmit, onCancel, isLoading }: Props
         </View>
 
         <View className="gap-2">
-          <Text className="text-sm font-medium text-foreground">Project ID (Optional)</Text>
-          <TextInput
-            className="h-12 rounded-lg border border-input bg-background px-3 text-foreground"
-            placeholder="Associated Project ID"
-            placeholderTextColor="#9ca3af"
-            value={projectId}
-            onChangeText={setProjectId}
-          />
+          <Text className="text-sm font-medium text-foreground">Project (Optional)</Text>
+          <ProjectPicker value={projectId} onChange={(v) => setProjectId(v || '')} />
         </View>
 
         <View className="gap-2">

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -252,20 +252,12 @@ export default function DashboardScreen() {
           pdfConverter={invoicePdfConverter}
         />
       </Modal>
-      {/* Ad Hoc Task Modal */}
+      {/* Ad Hoc Task (TaskScreen manages its own Modal) */}
       {showAdHocTask && (
-        <Modal
-          visible={showAdHocTask}
-          animationType="slide"
-          presentationStyle="pageSheet"
-          onRequestClose={() => setShowAdHocTask(false)}
-        >
-          {/* Lazy-load to avoid circular imports in tests; require inside render */}
-          {(() => {
-            const TaskScreen = require('../tasks/TaskScreen').default;
-            return <TaskScreen onClose={() => setShowAdHocTask(false)} />;
-          })()}
-        </Modal>
+        (() => {
+          const TaskScreen = require('../tasks/TaskScreen').default;
+          return <TaskScreen onClose={() => setShowAdHocTask(false)} />;
+        })()
       )}
       {/* Quotation Modal */}
       <QuotationScreen


### PR DESCRIPTION
This PR fixes issue #101 by removing the nested Modal in the Dashboard that caused a blank modal to appear alongside the `TaskScreen` modal. It also replaces the `projectId` text input with a `ProjectPicker` component (defaults to None) and wires it into the task form. Files changed:

- src/pages/dashboard/index.tsx — remove outer Modal wrapper for Ad Hoc Task
- src/components/tasks/TaskForm.tsx — use `ProjectPicker` for project selection
- src/components/inputs/ProjectPicker.tsx — new component for selecting projects

No behavior changes to voice/camera flows; this change prevents the double-modal stacking bug and provides a better project selector UX.
