### PR TITLE
Issue #108: Task detail — Documents, Dependencies, Subcontractor, Delay Reasons

### DIFF
--- a/__tests__/integration/DrizzleTaskRepository.taskDetail.integration.test.ts
+++ b/__tests__/integration/DrizzleTaskRepository.taskDetail.integration.test.ts
@@ -1,0 +1,197 @@
+// Integration tests for DrizzleTaskRepository — dependencies, delay reasons & subcontractor
+
+jest.mock('react-native-sqlite-storage', () => {
+  function createAdapter(db: any) {
+    return {
+      executeSql: async (sql: string, params: any[] = []) => {
+        const stmt = sql.trim();
+        const upper = stmt.toUpperCase();
+        if (upper.startsWith('SELECT')) {
+          const rows = db.prepare(stmt).all(...params);
+          return [{ rows: { length: rows.length, item: (i: number) => rows[i] } }];
+        }
+        if (params && params.length > 0) {
+          try {
+            const prepared = db.prepare(stmt);
+            prepared.run(...params);
+            return [{ rows: { length: 0, item: (_: number) => undefined } }];
+          } catch (e) {
+            // fallthrough to exec
+          }
+        }
+        if (stmt) db.exec(stmt);
+        return [{ rows: { length: 0, item: (_: number) => undefined } }];
+      },
+      transaction: async (fn: any) => {
+        db.exec('BEGIN');
+        try {
+          const tx = { executeSql: (sql: string, params?: any[]) => createAdapter(db).executeSql(sql, params) };
+          await fn(tx);
+          db.exec('COMMIT');
+        } catch (err) {
+          db.exec('ROLLBACK');
+          throw err;
+        }
+      },
+      close: async () => db.close(),
+    };
+  }
+
+  return {
+    enablePromise: (_: boolean) => {},
+    openDatabase: async (_: any) => {
+      const BetterSqlite3 = require('better-sqlite3');
+      const db = new BetterSqlite3(':memory:');
+      return createAdapter(db);
+    },
+  };
+});
+
+import { DrizzleTaskRepository } from '../../src/infrastructure/repositories/DrizzleTaskRepository';
+import { TaskEntity } from '../../src/domain/entities/Task';
+import { initDatabase } from '../../src/infrastructure/database/connection';
+
+describe('DrizzleTaskRepository — task detail extensions (better-sqlite3 :memory:)', () => {
+  let repo: DrizzleTaskRepository;
+
+  beforeAll(async () => {
+    await initDatabase();
+    repo = new DrizzleTaskRepository();
+  });
+
+  // ── Dependencies ───────────────────────────────────────────────────────────
+
+  describe('dependencies', () => {
+    const taskA = TaskEntity.create({ title: 'Task A', status: 'pending' });
+    const taskB = TaskEntity.create({ title: 'Task B', status: 'pending' });
+    const taskC = TaskEntity.create({ title: 'Task C', status: 'completed' });
+
+    beforeAll(async () => {
+      await repo.save(taskA.data());
+      await repo.save(taskB.data());
+      await repo.save(taskC.data());
+    });
+
+    it('adds a dependency', async () => {
+      await repo.addDependency(taskA.data().id, taskB.data().id);
+      const deps = await repo.findDependencies(taskA.data().id);
+      expect(deps).toHaveLength(1);
+      expect(deps[0].id).toBe(taskB.data().id);
+    });
+
+    it('ignores duplicate dependency (unique index)', async () => {
+      // Should not throw — idempotent
+      await repo.addDependency(taskA.data().id, taskB.data().id);
+      const deps = await repo.findDependencies(taskA.data().id);
+      expect(deps).toHaveLength(1);
+    });
+
+    it('adds a second dependency', async () => {
+      await repo.addDependency(taskA.data().id, taskC.data().id);
+      const deps = await repo.findDependencies(taskA.data().id);
+      expect(deps).toHaveLength(2);
+    });
+
+    it('finds dependents (reverse lookup)', async () => {
+      const dependents = await repo.findDependents(taskB.data().id);
+      expect(dependents).toHaveLength(1);
+      expect(dependents[0].id).toBe(taskA.data().id);
+    });
+
+    it('removes a dependency', async () => {
+      await repo.removeDependency(taskA.data().id, taskB.data().id);
+      const deps = await repo.findDependencies(taskA.data().id);
+      expect(deps).toHaveLength(1);
+      expect(deps[0].id).toBe(taskC.data().id);
+    });
+  });
+
+  // ── Delay Reasons ──────────────────────────────────────────────────────────
+
+  describe('delay reasons', () => {
+    const taskD = TaskEntity.create({ title: 'Task D', status: 'pending' });
+
+    beforeAll(async () => {
+      await repo.save(taskD.data());
+    });
+
+    it('adds a delay reason', async () => {
+      const result = await repo.addDelayReason({
+        taskId: taskD.data().id,
+        reasonTypeId: 'WEATHER',
+        notes: 'Heavy rain',
+        delayDurationDays: 3,
+        actor: 'builder-1',
+      });
+
+      expect(result.id).toBeTruthy();
+      expect(result.taskId).toBe(taskD.data().id);
+      expect(result.reasonTypeId).toBe('WEATHER');
+      expect(result.notes).toBe('Heavy rain');
+      expect(result.createdAt).toBeTruthy();
+    });
+
+    it('finds delay reasons for a task', async () => {
+      const reasons = await repo.findDelayReasons(taskD.data().id);
+      expect(reasons).toHaveLength(1);
+      expect(reasons[0].reasonTypeId).toBe('WEATHER');
+      expect(reasons[0].reasonTypeLabel).toBe('Bad weather');
+    });
+
+    it('adds a second delay reason', async () => {
+      await repo.addDelayReason({
+        taskId: taskD.data().id,
+        reasonTypeId: 'MATERIAL_DELAY',
+        notes: 'Tiles backordered',
+      });
+      const reasons = await repo.findDelayReasons(taskD.data().id);
+      expect(reasons).toHaveLength(2);
+    });
+
+    it('removes a delay reason', async () => {
+      const reasons = await repo.findDelayReasons(taskD.data().id);
+      await repo.removeDelayReason(reasons[0].id);
+      const remaining = await repo.findDelayReasons(taskD.data().id);
+      expect(remaining).toHaveLength(1);
+    });
+  });
+
+  // ── Subcontractor ─────────────────────────────────────────────────────────
+
+  describe('subcontractor', () => {
+    it('saves and retrieves subcontractorId', async () => {
+      const task = TaskEntity.create({
+        title: 'Task with subcontractor',
+        status: 'pending',
+        subcontractorId: 'contact-xyz',
+      });
+      await repo.save(task.data());
+
+      const loaded = await repo.findById(task.data().id);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.subcontractorId).toBe('contact-xyz');
+    });
+
+    it('updates subcontractorId', async () => {
+      const task = TaskEntity.create({ title: 'Sub update test', status: 'pending' });
+      await repo.save(task.data());
+
+      await repo.update({ ...task.data(), subcontractorId: 'contact-new' });
+      const loaded = await repo.findById(task.data().id);
+      expect(loaded!.subcontractorId).toBe('contact-new');
+    });
+  });
+
+  // ── Delay Reason Types (seeded) ───────────────────────────────────────────
+
+  describe('delay reason types (seeded)', () => {
+    it('has seeded delay reason types accessible via raw query', async () => {
+      // Directly verify migration seeded the lookup table
+      const { db } = require('../../src/infrastructure/database/connection').getDatabase();
+      const [result] = await db.executeSql('SELECT * FROM delay_reason_types ORDER BY display_order');
+      expect(result.rows.length).toBe(10);
+      expect(result.rows.item(0).id).toBe('WEATHER');
+      expect(result.rows.item(9).id).toBe('OTHER');
+    });
+  });
+});

--- a/__tests__/unit/AddDelayReasonUseCase.test.ts
+++ b/__tests__/unit/AddDelayReasonUseCase.test.ts
@@ -1,0 +1,122 @@
+import { AddDelayReasonUseCase } from '../../src/application/usecases/task/AddDelayReasonUseCase';
+import { Task } from '../../src/domain/entities/Task';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+import { DelayReasonTypeRepository } from '../../src/domain/repositories/DelayReasonTypeRepository';
+import { DelayReason, DelayReasonType } from '../../src/domain/entities/DelayReason';
+
+function makeMockTaskRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn().mockImplementation(async (entry) => ({
+      ...entry,
+      id: 'delay-1',
+      createdAt: new Date().toISOString(),
+    })),
+    removeDelayReason: jest.fn(),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function makeMockTypeRepo(overrides: Partial<DelayReasonTypeRepository> = {}): DelayReasonTypeRepository {
+  const types: DelayReasonType[] = [
+    { id: 'WEATHER', label: 'Bad weather', displayOrder: 1, isActive: true },
+    { id: 'MATERIAL_DELAY', label: 'Material / supply delay', displayOrder: 2, isActive: true },
+    { id: 'OTHER', label: 'Other', displayOrder: 10, isActive: true },
+  ];
+  return {
+    findAll: jest.fn().mockResolvedValue(types),
+    findById: jest.fn().mockImplementation(async (id: string) => types.find(t => t.id === id) ?? null),
+    ...overrides,
+  };
+}
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('AddDelayReasonUseCase', () => {
+  it('adds a delay reason with a valid reasonTypeId', async () => {
+    const task = makeTask('task-1');
+    const taskRepo = makeMockTaskRepo({
+      findById: jest.fn().mockResolvedValue(task),
+    });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new AddDelayReasonUseCase(taskRepo, typeRepo);
+
+    const result = await uc.execute({
+      taskId: 'task-1',
+      reasonTypeId: 'WEATHER',
+      notes: 'Heavy rain all week',
+    });
+
+    expect(result).toBeDefined();
+    expect(result.id).toBeTruthy();
+    expect(taskRepo.addDelayReason).toHaveBeenCalled();
+    // Should also set task to blocked
+    expect(taskRepo.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'blocked' }));
+  });
+
+  it('rejects empty reasonTypeId', async () => {
+    const task = makeTask('task-1');
+    const taskRepo = makeMockTaskRepo({ findById: jest.fn().mockResolvedValue(task) });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new AddDelayReasonUseCase(taskRepo, typeRepo);
+
+    await expect(uc.execute({ taskId: 'task-1', reasonTypeId: '' }))
+      .rejects.toThrow(/reason.*type/i);
+  });
+
+  it('rejects unknown reasonTypeId', async () => {
+    const task = makeTask('task-1');
+    const taskRepo = makeMockTaskRepo({ findById: jest.fn().mockResolvedValue(task) });
+    const typeRepo = makeMockTypeRepo({
+      findById: jest.fn().mockResolvedValue(null),
+    });
+    const uc = new AddDelayReasonUseCase(taskRepo, typeRepo);
+
+    await expect(uc.execute({ taskId: 'task-1', reasonTypeId: 'NONEXISTENT' }))
+      .rejects.toThrow(/reason.*type.*not found/i);
+  });
+
+  it('rejects when task does not exist', async () => {
+    const taskRepo = makeMockTaskRepo({ findById: jest.fn().mockResolvedValue(null) });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new AddDelayReasonUseCase(taskRepo, typeRepo);
+
+    await expect(uc.execute({ taskId: 'missing', reasonTypeId: 'WEATHER' }))
+      .rejects.toThrow(/task.*not found/i);
+  });
+
+  it('does not change status if already blocked', async () => {
+    const task = makeTask('task-1', { status: 'blocked' });
+    const taskRepo = makeMockTaskRepo({
+      findById: jest.fn().mockResolvedValue(task),
+    });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new AddDelayReasonUseCase(taskRepo, typeRepo);
+
+    await uc.execute({ taskId: 'task-1', reasonTypeId: 'WEATHER' });
+
+    // Should NOT have called update to change status since it's already blocked
+    expect(taskRepo.update).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/AddTaskDependencyUseCase.test.ts
+++ b/__tests__/unit/AddTaskDependencyUseCase.test.ts
@@ -1,0 +1,98 @@
+import { AddTaskDependencyUseCase } from '../../src/application/usecases/task/AddTaskDependencyUseCase';
+import { Task } from '../../src/domain/entities/Task';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+import { DelayReason } from '../../src/domain/entities/DelayReason';
+
+function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('AddTaskDependencyUseCase', () => {
+  it('adds a dependency when both tasks exist', async () => {
+    const taskA = makeTask('task-a');
+    const taskB = makeTask('task-b');
+    const repo = makeMockRepo({
+      findById: jest.fn().mockImplementation(async (id: string) => {
+        if (id === 'task-a') return taskA;
+        if (id === 'task-b') return taskB;
+        return null;
+      }),
+      findDependencies: jest.fn().mockResolvedValue([]),
+    });
+    const uc = new AddTaskDependencyUseCase(repo);
+
+    await uc.execute({ taskId: 'task-a', dependsOnTaskId: 'task-b' });
+
+    expect(repo.addDependency).toHaveBeenCalledWith('task-a', 'task-b');
+  });
+
+  it('rejects self-dependency', async () => {
+    const task = makeTask('task-a');
+    const repo = makeMockRepo({
+      findById: jest.fn().mockResolvedValue(task),
+    });
+    const uc = new AddTaskDependencyUseCase(repo);
+
+    await expect(uc.execute({ taskId: 'task-a', dependsOnTaskId: 'task-a' }))
+      .rejects.toThrow(/self-dependency/i);
+  });
+
+  it('rejects when task does not exist', async () => {
+    const repo = makeMockRepo({
+      findById: jest.fn().mockResolvedValue(null),
+    });
+    const uc = new AddTaskDependencyUseCase(repo);
+
+    await expect(uc.execute({ taskId: 'task-a', dependsOnTaskId: 'task-b' }))
+      .rejects.toThrow(/not found/i);
+  });
+
+  it('rejects circular dependency', async () => {
+    const taskA = makeTask('task-a');
+    const taskB = makeTask('task-b');
+    const repo = makeMockRepo({
+      findById: jest.fn().mockImplementation(async (id: string) => {
+        if (id === 'task-a') return taskA;
+        if (id === 'task-b') return taskB;
+        return null;
+      }),
+      // task-b already depends on task-a → adding task-a depends on task-b would be circular
+      findDependencies: jest.fn().mockImplementation(async (id: string) => {
+        if (id === 'task-b') return [taskA];
+        return [];
+      }),
+    });
+    const uc = new AddTaskDependencyUseCase(repo);
+
+    await expect(uc.execute({ taskId: 'task-a', dependsOnTaskId: 'task-b' }))
+      .rejects.toThrow(/circular/i);
+  });
+});

--- a/__tests__/unit/CreateTaskFromPhotoUseCase.test.ts
+++ b/__tests__/unit/CreateTaskFromPhotoUseCase.test.ts
@@ -31,6 +31,13 @@ function makeTaskRepo(): jest.Mocked<TaskRepository> {
     findUpcoming: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue(undefined),
     delete: jest.fn().mockResolvedValue(undefined),
+    addDependency: jest.fn().mockResolvedValue(undefined),
+    removeDependency: jest.fn().mockResolvedValue(undefined),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn().mockResolvedValue({ id: 'dr-1', taskId: '', reasonTypeId: '', createdAt: '' }),
+    removeDelayReason: jest.fn().mockResolvedValue(undefined),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
   };
 }
 

--- a/__tests__/unit/GetTaskDetailUseCase.test.ts
+++ b/__tests__/unit/GetTaskDetailUseCase.test.ts
@@ -1,0 +1,92 @@
+import { GetTaskDetailUseCase, TaskDetail } from '../../src/application/usecases/task/GetTaskDetailUseCase';
+import { Task } from '../../src/domain/entities/Task';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+import { DelayReason } from '../../src/domain/entities/DelayReason';
+
+function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('GetTaskDetailUseCase', () => {
+  it('returns null if task not found', async () => {
+    const repo = makeMockRepo();
+    const uc = new GetTaskDetailUseCase(repo);
+
+    const result = await uc.execute('missing');
+    expect(result).toBeNull();
+  });
+
+  it('returns hydrated task detail with dependencies and delay reasons', async () => {
+    const task = makeTask('task-1', { subcontractorId: 'contact-1' });
+    const depTask = makeTask('dep-1', { status: 'completed' });
+    const delay: DelayReason = {
+      id: 'delay-1',
+      taskId: 'task-1',
+      reasonTypeId: 'WEATHER',
+      reasonTypeLabel: 'Bad weather',
+      notes: 'Rained all day',
+      createdAt: new Date().toISOString(),
+    };
+
+    const repo = makeMockRepo({
+      findById: jest.fn().mockResolvedValue(task),
+      findDependencies: jest.fn().mockResolvedValue([depTask]),
+      findDelayReasons: jest.fn().mockResolvedValue([delay]),
+    });
+    const uc = new GetTaskDetailUseCase(repo);
+
+    const result = await uc.execute('task-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('task-1');
+    expect(result!.dependencyTasks).toHaveLength(1);
+    expect(result!.dependencyTasks[0].id).toBe('dep-1');
+    expect(result!.delayReasons).toHaveLength(1);
+    expect(result!.delayReasons[0].reasonTypeId).toBe('WEATHER');
+    expect(result!.subcontractorId).toBe('contact-1');
+  });
+
+  it('returns empty arrays when task has no dependencies or delays', async () => {
+    const task = makeTask('task-2');
+    const repo = makeMockRepo({
+      findById: jest.fn().mockResolvedValue(task),
+      findDependencies: jest.fn().mockResolvedValue([]),
+      findDelayReasons: jest.fn().mockResolvedValue([]),
+    });
+    const uc = new GetTaskDetailUseCase(repo);
+
+    const result = await uc.execute('task-2');
+
+    expect(result).not.toBeNull();
+    expect(result!.dependencyTasks).toEqual([]);
+    expect(result!.delayReasons).toEqual([]);
+  });
+});

--- a/__tests__/unit/RemoveDelayReasonUseCase.test.ts
+++ b/__tests__/unit/RemoveDelayReasonUseCase.test.ts
@@ -1,0 +1,34 @@
+import { RemoveDelayReasonUseCase } from '../../src/application/usecases/task/RemoveDelayReasonUseCase';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+
+function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe('RemoveDelayReasonUseCase', () => {
+  it('removes a delay reason', async () => {
+    const repo = makeMockRepo();
+    const uc = new RemoveDelayReasonUseCase(repo);
+
+    await uc.execute({ delayReasonId: 'delay-1' });
+
+    expect(repo.removeDelayReason).toHaveBeenCalledWith('delay-1');
+  });
+});

--- a/__tests__/unit/RemoveTaskDependencyUseCase.test.ts
+++ b/__tests__/unit/RemoveTaskDependencyUseCase.test.ts
@@ -1,0 +1,34 @@
+import { RemoveTaskDependencyUseCase } from '../../src/application/usecases/task/RemoveTaskDependencyUseCase';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+
+function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe('RemoveTaskDependencyUseCase', () => {
+  it('removes a dependency', async () => {
+    const repo = makeMockRepo();
+    const uc = new RemoveTaskDependencyUseCase(repo);
+
+    await uc.execute({ taskId: 'task-a', dependsOnTaskId: 'task-b' });
+
+    expect(repo.removeDependency).toHaveBeenCalledWith('task-a', 'task-b');
+  });
+});

--- a/__tests__/unit/TasksScreen.test.tsx
+++ b/__tests__/unit/TasksScreen.test.tsx
@@ -82,6 +82,11 @@ function buildHookReturn(
     updateTask: jest.fn(),
     deleteTask: jest.fn(),
     getTask: jest.fn(),
+    getTaskDetail: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
   };
 }
 

--- a/design/issue-108-task-detail.md
+++ b/design/issue-108-task-detail.md
@@ -1,0 +1,381 @@
+# Design: Issue #108 — Task Detail: Documents, Dependencies, Subcontractor & Delay Reasons
+
+**Status**: APPROVED — ready for implementation  
+**Author**: Copilot  
+**Date**: 2026-03-03  
+**GitHub Issue**: https://github.com/yhua045/builder-assistant/issues/108  
+**Parent**: #107
+
+---
+
+## 1. User Story
+
+As a builder, I want to:
+- **Attach documents** (plans, permits, invoices, photos) to a Task. A task can have multiple documents.
+- **Declare dependency tasks** that must be completed before this Task can start or progress.
+- **Associate a subcontractor** (contact with contractor role) with the Task and see their contact info.
+- **Record delay reasons** (free-text + optional duration/date) against a Task. A task can have multiple delay entries.
+- **View all of the above** on the Task Detail screen.
+
+---
+
+## 2. Acceptance Criteria
+
+| # | Criterion |
+|---|---|
+| AC-1 | Task Detail screen shows attached documents with thumbnail/preview and an action to download/view. |
+| AC-2 | Task Detail screen lists dependency tasks with their current status; each is a link to its own detail. |
+| AC-3 | Task Detail screen shows subcontractor name, trade and phone/email. |
+| AC-4 | Task Detail screen shows a chronological delay history (reason, actor, date). |
+| AC-5 | A task with incomplete dependencies shows a `blocked` indicator in the UI. |
+| AC-6 | CRUD (add/remove document, add/remove dependency, set/clear subcontractor, add delay entry) persists via Drizzle-backed repositories. |
+| AC-7 | Unit tests cover all new use cases; integration tests cover repository persistence. |
+| AC-8 | No TypeScript strict-mode errors. |
+
+---
+
+## 3. Current State Analysis
+
+### What already exists
+
+| Concern | Current state |
+|---|---|
+| `documents` table | Exists; has `task_id TEXT` column and index. Documents can already be linked to tasks. |
+| `Task` domain entity | Has `dependencies?: string[]` (JSON, domain-only) and `assignedTo?: string` (contactId). Neither is persisted properly: `tasks` DB table has no `dependencies` column and no `subcontractor_id`. |
+| `TaskRepository` interface | Basic CRUD only — no methods for dependency or delay management. |
+| `contacts` table | Exists; `trade` column present. Subcontractors are modelled as contacts with role `'subcontractor'` or `'contractor'`. |
+| `TaskDetailsPage` | Minimal — shows title, status, dates. No documents, dependencies, subcontractor, or delays. |
+
+### Gaps to fill
+
+1. Schema: `tasks` table missing `subcontractor_id` column.
+2. Schema: no `task_dependencies` join table in DB (currently only a JSON array on the entity that is never persisted).
+3. Schema: no `task_delay_reasons` table.
+4. Domain entity: `Task` missing `subcontractorId`, `delayReasons` array.
+5. Repository interface: no methods for delays or dependencies.
+6. Use cases: none for delay management.
+7. UI: `TaskDetailsPage` needs complete rebuild.
+
+---
+
+## 4. Database Changes
+
+### 4.1 Alter `tasks` table — add `subcontractor_id`
+
+> SQLite `ALTER TABLE … ADD COLUMN` is safe for nullable columns with no default.
+
+**New column:**
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `subcontractor_id` | `TEXT` | nullable | FK (soft) to `contacts.id`. Subcontractor assigned to this task. |
+
+### 4.2 New table: `task_dependencies`
+
+Junction table tracking which tasks must complete before another.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `local_id` | `INTEGER` | PK AUTOINCREMENT | |
+| `task_id` | `TEXT` | NOT NULL | The task that **has** the dependency. |
+| `depends_on_task_id` | `TEXT` | NOT NULL | The task that must complete **first**. |
+| `created_at` | `INTEGER` | | Unix ms. |
+
+**Index**: `(task_id)` for fast lookup of all dependencies for a task.  
+**Unique constraint**: `(task_id, depends_on_task_id)` — no duplicate edges.
+
+> **Rationale for a join table over JSON array**: Queryability (find all tasks that depend on a given task), integrity (each dependency is a first-class row), and uniform Drizzle access pattern. The JSON array in `Task.dependencies` will be kept as a computed/runtime convenience but will no longer be the source of truth.
+
+### 4.3 New table: `delay_reason_types` (lookup / reference data)
+
+A seed table of predefined delay reason options presented to the user in the UI. Keeping these in a DB table (rather than hardcoding in the app) allows them to be extended without a code release.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | `TEXT` | PK | Short stable code e.g. `'WEATHER'`. |
+| `label` | `TEXT` | NOT NULL | Human-readable label e.g. `'Bad weather'`. |
+| `display_order` | `INTEGER` | NOT NULL | Sort order for picker list. |
+| `is_active` | `INTEGER` (boolean) | NOT NULL DEFAULT 1 | Soft-disable without deleting. |
+
+**Seeded rows (inserted in the migration):**
+
+| id | label | order |
+|---|---|---|
+| `WEATHER` | Bad weather | 1 |
+| `MATERIAL_DELAY` | Material / supply delay | 2 |
+| `SUBCONTRACTOR` | Subcontractor unavailability | 3 |
+| `PERMIT` | Permit / approval delay | 4 |
+| `DESIGN_CHANGE` | Design change | 5 |
+| `EQUIPMENT` | Equipment breakdown | 6 |
+| `ACCESS` | Site access issue | 7 |
+| `LABOUR` | Labour shortage | 8 |
+| `CLIENT` | Client decision pending | 9 |
+| `OTHER` | Other | 10 |
+
+### 4.4 New table: `task_delay_reasons`
+
+One task can have multiple delay entries (ordered by creation time). Each entry references a `delay_reason_types` row so the UI can present a structured picker; an optional `notes` column allows free-text supplemental detail.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `local_id` | `INTEGER` | PK AUTOINCREMENT | |
+| `id` | `TEXT` | NOT NULL UNIQUE | UUID-style app-generated. |
+| `task_id` | `TEXT` | NOT NULL | Owning task. |
+| `reason_type_id` | `TEXT` | NOT NULL | FK (soft) to `delay_reason_types.id`. The selected reason. |
+| `notes` | `TEXT` | nullable | Optional free-text supplemental detail. |
+| `delay_duration_days` | `REAL` | nullable | Optional estimated delay in days. |
+| `delay_date` | `INTEGER` | nullable | Unix ms — when the delay started/was recorded. |
+| `actor` | `TEXT` | nullable | Who recorded it (contact id or free text name). |
+| `created_at` | `INTEGER` | NOT NULL | Wall-clock insert time (Unix ms). |
+
+**Index**: `(task_id)` for fast lookup of all delay entries for a task.
+
+### 4.5 Migration tag
+
+`0012_task_detail_extensions`
+
+SQL statements (in order):
+1. `ALTER TABLE tasks ADD COLUMN subcontractor_id TEXT`
+2. `CREATE TABLE task_dependencies …`
+3. `CREATE TABLE delay_reason_types …`
+4. Seed `delay_reason_types` with 10 rows (INSERT OR IGNORE)
+5. `CREATE TABLE task_delay_reasons …`
+
+---
+
+## 5. Domain Layer Changes
+
+### 5.1 `Task` entity (`src/domain/entities/Task.ts`)
+
+Add fields:
+
+```ts
+subcontractorId?: string;      // contactId of assigned subcontractor
+delayReasons?: DelayReason[];   // populated by repository; not persisted in column
+// Note: `dependencies` stays as string[] but now backed by task_dependencies table
+```
+
+New types:
+
+```ts
+export interface DelayReasonType {
+  id: string;          // e.g. 'WEATHER'
+  label: string;       // e.g. 'Bad weather'
+  displayOrder: number;
+  isActive: boolean;
+}
+
+export interface DelayReason {
+  id: string;
+  taskId: string;
+  reasonTypeId: string;        // FK to DelayReasonType.id
+  reasonTypeLabel?: string;    // denormalised label for display (populated by repo)
+  notes?: string;              // optional supplemental free text
+  delayDurationDays?: number;
+  delayDate?: string;          // ISO date string
+  actor?: string;
+  createdAt: string;
+}
+```
+
+### 5.2 `TaskRepository` interface additions (`src/domain/repositories/TaskRepository.ts`)
+
+```ts
+// Dependencies
+addDependency(taskId: string, dependsOnTaskId: string): Promise<void>;
+removeDependency(taskId: string, dependsOnTaskId: string): Promise<void>;
+findDependencies(taskId: string): Promise<Task[]>;       // tasks this task depends on
+findDependents(taskId: string): Promise<Task[]>;          // tasks that depend on this
+
+// Delay reasons
+addDelayReason(entry: Omit<DelayReason, 'id' | 'createdAt'>): Promise<DelayReason>;
+removeDelayReason(delayReasonId: string): Promise<void>;
+findDelayReasons(taskId: string): Promise<DelayReason[]>;
+```
+
+> **`findById` augmentation**: When fetching a single task, the repository should hydrate `dependencies` (string[] of task IDs), `delayReasons`, and `subcontractorId`. List queries (`findAll`, `findByProjectId`) return shallow tasks **without** these associations for performance.
+
+---
+
+## 6. Application Layer (Use Cases)
+
+New use cases in `src/application/usecases/task/`:
+
+| Use Case | Input | Key Behaviour |
+|---|---|---|
+| `AddTaskDependencyUseCase` | `{ taskId, dependsOnTaskId }` | Validates both tasks exist; rejects self-dependency; rejects circular dependency (depth-limited BFS/DFS up to 10 hops); calls `repo.addDependency`. |
+| `RemoveTaskDependencyUseCase` | `{ taskId, dependsOnTaskId }` | Calls `repo.removeDependency`. |
+| `AddDelayReasonUseCase` | `{ taskId, reasonTypeId, notes?, delayDurationDays?, delayDate?, actor? }` | Validates `reasonTypeId` is non-empty and exists in `delay_reason_types`; generates `id`; calls `repo.addDelayReason`; if task status is not `blocked`, sets it to `blocked`. |
+| `RemoveDelayReasonUseCase` | `{ delayReasonId, taskId }` | Calls `repo.removeDelayReason`. |
+| `GetTaskDetailUseCase` | `{ taskId }` | Returns `Task` with `dependencies` (hydrated as `Task[]`), `delayReasons`, and `subcontractorId` populated. Returns `null` if not found. |
+
+Existing use case updates:
+
+- `UpdateTaskUseCase` — pass `subcontractorId` through (already stored on task, no special logic needed).
+
+---
+
+## 7. Infrastructure Layer (Repository & Mapper)
+
+### 7.1 `DrizzleDelayReasonTypeRepository`
+
+New lightweight read-only repository in `src/infrastructure/repositories/`:
+
+- `findAll(): Promise<DelayReasonType[]>` — returns all active types ordered by `display_order`.
+
+Interface defined at `src/domain/repositories/DelayReasonTypeRepository.ts`.
+
+### 7.2 `DrizzleTaskRepository`
+
+Implement the six new interface methods:
+
+- `addDependency`/`removeDependency` — insert/delete from `task_dependencies`.
+- `findDependencies` — JOIN `task_dependencies` to `tasks` on `depends_on_task_id`.
+- `findDependents` — JOIN `task_dependencies` to `tasks` on `task_id`.
+- `addDelayReason`/`removeDelayReason`/`findDelayReasons` — CRUD on `task_delay_reasons`.
+- Update `findById` to LEFT JOIN `task_delay_reasons` and fetch dependency IDs, then hydrate both on the returned entity.
+- Update `save`/`update` to persist `subcontractorId → subcontractor_id`.
+
+### 7.3 Mapper
+
+Update `TaskMapper` (or inline mapper in `DrizzleTaskRepository`) to map:
+- `subcontractor_id` → `subcontractorId`
+- Include delay reason rows (joined with `delay_reason_types` to populate `reasonTypeLabel`) → `DelayReason[]`
+- Include dependency IDs → `string[]`
+
+---
+
+## 8. Hooks
+
+### 8.1 `useTasks` hook extensions
+
+Add methods:
+
+```ts
+getTaskDetail(taskId: string): Promise<TaskDetail>;
+addDependency(taskId: string, dependsOnTaskId: string): Promise<void>;
+removeDependency(taskId: string, dependsOnTaskId: string): Promise<void>;
+addDelayReason(taskId: string, input: AddDelayReasonInput): Promise<void>;
+removeDelayReason(taskId: string, delayReasonId: string): Promise<void>;
+```
+
+### 8.2 New hook: `useDelayReasonTypes`
+
+A simple hook that resolves `DelayReasonTypeRepository` and returns the list of active types for populating pickers:
+
+```ts
+const { delayReasonTypes } = useDelayReasonTypes();
+// returns DelayReasonType[]
+```
+
+### 8.3 New type `TaskDetail`
+
+```ts
+export interface TaskDetail extends Task {
+  dependencyTasks: Task[];       // full Task objects for each dependency
+  delayReasons: DelayReason[];
+  subcontractor?: Contact;       // hydrated contact if subcontractorId is set
+}
+```
+
+---
+
+## 9. UI Layer
+
+### 9.1 `TaskDetailsPage` (complete rebuild)
+
+Sections:
+
+1. **Header** — title, status badge, priority chip, edit/delete buttons.
+2. **Core Info** — project link, due date, scheduled date, assigned to.
+3. **Subcontractor** — card showing name, trade, phone, email. Tap to edit (opens a contact-picker).
+4. **Documents** — horizontal scroll of document chips (icon + filename). Tap → OS file preview. "Add Document" button triggers file picker → `processInvoiceUpload`-style flow (just file copy + Document record linked to task).
+5. **Dependencies** — list of dependency tasks with status badge. Blocked indicator if any are incomplete. "Add Dependency" button opens task-picker.
+6. **Delay Log** — chronological list of `DelayReason` entries. "Add Delay" button opens a modal form.
+
+### 9.2 New components
+
+| Component | Location | Purpose |
+|---|---|---|
+| `TaskDocumentSection` | `src/components/tasks/` | Documents list + add button |
+| `TaskDependencySection` | `src/components/tasks/` | Dependencies list + blocked badge + add button |
+| `TaskSubcontractorSection` | `src/components/tasks/` | Subcontractor card + picker |
+| `TaskDelaySection` | `src/components/tasks/` | Delay reason history + add form |
+| `AddDelayReasonModal` | `src/components/tasks/` | Modal: **reason type picker** (required, list from `useDelayReasonTypes`), optional notes text input, optional duration (numeric), optional date picker |
+
+### 9.3 Blocked-state rule
+
+A task is shown as `blocked` in the UI if:
+- Its status is `'blocked'`, **or**
+- It has at least one dependency task whose status is not `'completed'`.
+
+The `blocked` visual does not automatically change the persisted `status` field — that remains a manual user action (or `AddDelayReasonUseCase`).
+
+---
+
+## 10. Test Plan
+
+### Unit tests (`__tests__/unit/`)
+
+| File | Tests |
+|---|---|
+| `AddTaskDependencyUseCase.test.ts` | valid add, self-dependency rejected, circular rejected, task-not-found rejected |
+| `RemoveTaskDependencyUseCase.test.ts` | happy path |
+| `AddDelayReasonUseCase.test.ts` | valid add, unknown reasonTypeId rejected, empty reasonTypeId rejected, task not found rejected |
+| `RemoveDelayReasonUseCase.test.ts` | happy path |
+| `GetTaskDetailUseCase.test.ts` | returns hydrated task (dependencies, delay reasons, subcontractor id) |
+
+### Integration tests (`__tests__/integration/`)
+
+| File | Tests |
+|---|---|
+| `DrizzleTaskRepository.dependencies.integration.test.ts` | add dependency, remove dependency, find dependencies, find dependents |
+| `DrizzleTaskRepository.delayReasons.integration.test.ts` | add delay, remove delay, find delay reasons |
+| `DrizzleTaskRepository.subcontractor.integration.test.ts` | save with subcontractorId, findById returns subcontractorId |
+
+### UI tests (light, `__tests__/unit/`)
+
+| File | Tests |
+|---|---|
+| `TaskDetailsPage.test.tsx` | renders sections when task detail is returned, shows blocked indicator when dependency is incomplete |
+
+---
+
+## 11. Migration Plan
+
+Migration file: `drizzle/migrations/` (generated by `npm run db:generate` after schema update).  
+Bundled migration entry: `0012_task_detail_extensions` added to `src/infrastructure/database/migrations.ts`.
+
+Since all new columns / tables are additive:
+- No data loss risk.
+- `ALTER TABLE tasks ADD COLUMN subcontractor_id TEXT` is a no-op on existing rows (value = NULL).
+- Two new tables are created fresh — no row migration needed.
+
+---
+
+## 12. Open Questions
+
+| # | Question | Proposed Answer |
+|---|---|---|
+| OQ-1 | Should removing all delay reasons auto-clear the `blocked` status? | No — status change is always user-driven. The UI can surface a prompt but not auto-change. |
+| OQ-2 | Circular dependency detection depth? | BFS up to 4 hops. Deeper chains are unlikely and silently accepted to avoid expensive DB traversals. |
+| OQ-3 | Document upload flow — same as invoice upload, or simpler? | Simpler: just file-copy to app storage + `Document` record with `taskId`. No OCR needed. Reuse `IFilePickerAdapter` + `IFileSystemAdapter`. |
+| OQ-4 | Should `findAll` / `findByProjectId` hydrate delay reasons? | No — only `GetTaskDetailUseCase` (single task) hydrates the full detail. List views use shallow tasks for performance. |
+| OQ-5 | Subcontractor picker — full contact list or filtered to contractor/subcontractor roles? | Filtered. Only contacts whose `roles` array contains `'contractor'` or `'subcontractor'`. |
+
+---
+
+## 13. Implementation Order (TDD sequence)
+
+1. Schema changes + migration generation.
+2. `DelayReason` type + `Task` entity update.
+3. `TaskRepository` interface additions.
+4. ❌ Write failing unit tests for all new use cases.
+5. ✅ Implement use cases (green).
+6. ❌ Write failing integration tests for `DrizzleTaskRepository`.
+7. ✅ Implement `DrizzleTaskRepository` additions (green).
+8. Update `useTasks` hook.
+9. Build UI sections/components.
+10. Rebuild `TaskDetailsPage`.
+11. TypeCheck (`npx tsc --noEmit`).
+12. Full test run.

--- a/progress.md
+++ b/progress.md
@@ -282,3 +282,65 @@ cd ios && pod install
 - **`NetworkStatusProvider` real implementation**: Wrap `@react-native-community/netinfo` for production. Currently registered as a static `{ isOnline: () => true }` stub.
 - **Backend `/api/projects/nearby` endpoint**: Implement server-side PostGIS query to enable `RemoteLocationAdapter`. Once done, replace `throw not_implemented` with `fetch` call.
 - **UI wiring in TaskScreen**: Consume `GetNearbyProjectsUseCase` to suggest nearest project automatically when creating a new task.
+
+---
+
+## 8. Issue #108 — Task Detail: Documents, Dependencies, Subcontractor, Delay Reason (2026-03-03)
+
+### Key Decisions
+- **Extend `TaskDetailsPage`, not rebuild**: All existing fields (title, status badge, due date, scheduled date, project ID, notes) are preserved in place. The four new sections (Subcontractor, Documents, Dependencies, Delay Log) are appended below existing content inside the same `ScrollView` — zero regression risk to current UI.
+- **`delay_reason_types` as a lookup table (seed data)**: Delay reasons are user-selectable from a fixed lookup table (`delay_reason_types`) rather than free text, enabling consistent reporting. 10 seed rows (Weather, Material delivery, Subcontractor no-show, Permit/council delay, Design change, Equipment failure, Site access, Labour shortage, Client-requested hold, Other) are inserted via `INSERT OR IGNORE` in migration `0012`. The label is denormalised into `task_delay_reasons.reason_type_label` at write time for display without joins.
+- **`INSERT OR IGNORE` for dependency idempotency**: `addDependency` uses `INSERT OR IGNORE` backed by a `UNIQUE(task_id, depends_on_task_id)` constraint — calling it twice for the same pair is silently safe.
+- **BFS circular-dependency guard (depth 10)**: `AddTaskDependencyUseCase` walks the dependency graph with a BFS up to 10 hops before accepting an `addDependency` call. Depth limit chosen to keep the check cheap while covering realistic project task graphs; deeper chains are accepted without complaint.
+- **`AddDelayReasonUseCase` sets task to `blocked`**: When a delay reason is added, the use case auto-transitions the task status to `'blocked'` if it is not already. Status reverts only by explicit user action — removing delay reasons does not auto-clear `blocked`.
+- **`GetTaskDetailUseCase` as a read-model aggregator**: Fetches the base task, its dependency tasks, and delay reasons in parallel (`Promise.all`) and returns a `TaskDetail` type — avoids scattering hydration logic across multiple hooks or components.
+- **`delayReasonTypes` exposed via a dedicated `useDelayReasonTypes` hook**: Keeps separation of concerns — `useTasks` manages task lifecycle; `useDelayReasonTypes` is a simple read-only hook for the lookup table, consumed only by `AddDelayReasonModal`.
+- **Raw SQL pattern maintained**: All new `DrizzleTaskRepository` methods follow the existing `db.executeSql()` pattern (not Drizzle query builder) for consistency with the rest of the infrastructure layer.
+
+### Completed
+- Design doc at `design/issue-108-task-detail.md` (DB changes, domain model, use cases, UI plan, test plan — APPROVED before implementation).
+- **Schema** (`src/infrastructure/database/schema.ts`): Added `subcontractor_id` column to `tasks`; added three new tables: `task_dependencies` (with `UNIQUE` index), `delay_reason_types` (lookup), `task_delay_reasons`.
+- **Migration** `0012_task_detail_extensions` (`src/infrastructure/database/migrations.ts`): 5 SQL DDL statements + 10 `INSERT OR IGNORE` seed rows for delay reason types.
+- **Domain entities**:
+  - `src/domain/entities/DelayReason.ts` — new: `DelayReasonType` + `DelayReason` interfaces.
+  - `src/domain/entities/Task.ts` — added `subcontractorId?: string` and `delayReasons?: DelayReason[]`.
+- **Repository interfaces**:
+  - `src/domain/repositories/TaskRepository.ts` — added 7 new methods: `addDependency`, `removeDependency`, `findDependencies`, `findDependents`, `addDelayReason`, `removeDelayReason`, `findDelayReasons`.
+  - `src/domain/repositories/DelayReasonTypeRepository.ts` — new read-only interface: `findAll()`, `findById()`.
+- **Use cases** (all in `src/application/usecases/task/`):
+  - `AddTaskDependencyUseCase.ts` — validates both tasks exist, rejects self-dependency, BFS circular check, calls `repo.addDependency`.
+  - `RemoveTaskDependencyUseCase.ts` — delegates to `repo.removeDependency`.
+  - `AddDelayReasonUseCase.ts` — validates reason type and task exist, adds delay, sets task status to `'blocked'`.
+  - `RemoveDelayReasonUseCase.ts` — delegates to `repo.removeDelayReason`.
+  - `GetTaskDetailUseCase.ts` — parallel fetch of task + dependencies + delay reasons; exports `TaskDetail` type.
+- **Infrastructure**:
+  - `src/infrastructure/repositories/DrizzleTaskRepository.ts` — updated row mappers and INSERT/UPDATE SQL for `subcontractor_id`; added 7 new methods (dependency and delay CRUD); `findDelayReasons` LEFT JOINs `delay_reason_types` to populate `reasonTypeLabel`.
+  - `src/infrastructure/repositories/DrizzleDelayReasonTypeRepository.ts` — new read-only repo: `findAll` (active, ordered by `display_order`), `findById`.
+  - `src/infrastructure/di/registerServices.ts` — registered `DrizzleDelayReasonTypeRepository` as singleton under token `'DelayReasonTypeRepository'`.
+- **Hooks**:
+  - `src/hooks/useTasks.ts` — added 5 new methods: `getTaskDetail`, `addDependency`, `removeDependency`, `addDelayReason`, `removeDelayReason`; re-exports `TaskDetail` and `AddDelayReasonInput` types.
+  - `src/hooks/useDelayReasonTypes.ts` — new hook returning `delayReasonTypes: DelayReasonType[]` and `loading`.
+- **UI components** (all in `src/components/tasks/`):
+  - `TaskDocumentSection.tsx` — horizontal chip scroll of linked documents.
+  - `TaskDependencySection.tsx` — dependency list with status badges and "Blocked" indicator when any dependency is incomplete.
+  - `TaskSubcontractorSection.tsx` — subcontractor card (name, trade, phone, email) with edit affordance.
+  - `TaskDelaySection.tsx` — chronological delay log with duration, date, actor, and remove action.
+  - `AddDelayReasonModal.tsx` — bottom-sheet modal: reason type picker (required, from `useDelayReasonTypes`), notes text input, duration (numeric), responsible party.
+- **`src/pages/tasks/TaskDetailsPage.tsx`** — extended to use `getTaskDetail`; loads documents via `DocumentRepository.findByTaskId`; appends four new sections below existing content; wires `AddDelayReasonModal`.
+- **Test fixes** for extended interfaces: `__tests__/unit/CreateTaskFromPhotoUseCase.test.ts` mock repo and `__tests__/unit/TasksScreen.test.tsx` mock hook updated with new methods.
+- **26 new tests** — all passing:
+  - `__tests__/unit/AddTaskDependencyUseCase.test.ts` (4 tests) — valid add, self-dependency rejected, circular rejected, task-not-found rejected.
+  - `__tests__/unit/RemoveTaskDependencyUseCase.test.ts` (1 test) — happy path.
+  - `__tests__/unit/AddDelayReasonUseCase.test.ts` (5 tests) — valid add, unknown/empty reason type rejected, task not found rejected, already-blocked task.
+  - `__tests__/unit/RemoveDelayReasonUseCase.test.ts` (1 test) — happy path.
+  - `__tests__/unit/GetTaskDetailUseCase.test.ts` (3 tests) — not found, hydrated detail with dependencies and delays, empty array edge cases.
+  - `__tests__/integration/DrizzleTaskRepository.taskDetail.integration.test.ts` (12 tests) — dependency CRUD (5), delay reason CRUD (4), subcontractor field roundtrip (2), seeded delay types (1).
+- Full Jest suite: **558 tests pass, 0 failures**. TypeScript strict check (`npx tsc --noEmit`) clean.
+
+### Pending / Next Steps
+- **Subcontractor contact lookup**: `TaskSubcontractorSection` currently displays the raw `subcontractorId` string when a subcontractor is assigned. Wire up a contact resolver (filtered to `'contractor'`/`'subcontractor'` roles per OQ-5 in design doc) to show name, trade, phone, and email.
+- **"Add Dependency" task picker**: The `TaskDependencySection` renders existing dependencies and a remove action but the "Add" button has no navigation target yet. Implement a task-picker screen (filtered to same project) and wire `addDependency` on confirm.
+- **Document upload flow**: `TaskDocumentSection` renders existing documents but the "Add Document" button is not yet wired. Implement file-copy + `Document` record creation (reuse `IFilePickerAdapter` + `IFileSystemAdapter`, simpler than invoice upload — no OCR needed).
+- **Remove dependency confirmation UX**: Currently triggers an `Alert.alert` inline in `TaskDetailsPage`. Consider extracting to a reusable confirmation hook.
+- **Cascade delete**: Deleting a task should cascade-delete its `task_dependencies` and `task_delay_reasons` rows. Add `ON DELETE CASCADE` to the FK constraints or handle in `DeleteTaskUseCase`.
+- **On-device QA**: Verify the four new sections render correctly and interactions (add delay, remove dependency) work end-to-end on iOS and Android simulators.

--- a/src/application/usecases/task/AddDelayReasonUseCase.ts
+++ b/src/application/usecases/task/AddDelayReasonUseCase.ts
@@ -1,0 +1,56 @@
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+import { DelayReasonTypeRepository } from '../../../domain/repositories/DelayReasonTypeRepository';
+import { DelayReason } from '../../../domain/entities/DelayReason';
+
+export interface AddDelayReasonInput {
+  taskId: string;
+  reasonTypeId: string;
+  notes?: string;
+  delayDurationDays?: number;
+  delayDate?: string;
+  actor?: string;
+}
+
+export class AddDelayReasonUseCase {
+  constructor(
+    private readonly taskRepository: TaskRepository,
+    private readonly delayReasonTypeRepository: DelayReasonTypeRepository,
+  ) {}
+
+  async execute(input: AddDelayReasonInput): Promise<DelayReason> {
+    const { taskId, reasonTypeId, notes, delayDurationDays, delayDate, actor } = input;
+
+    // Validate reasonTypeId
+    if (!reasonTypeId || reasonTypeId.trim() === '') {
+      throw new Error('Reason type is required');
+    }
+
+    const reasonType = await this.delayReasonTypeRepository.findById(reasonTypeId);
+    if (!reasonType) {
+      throw new Error(`Reason type not found: ${reasonTypeId}`);
+    }
+
+    // Validate task exists
+    const task = await this.taskRepository.findById(taskId);
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+
+    // Create delay reason entry
+    const result = await this.taskRepository.addDelayReason({
+      taskId,
+      reasonTypeId,
+      notes,
+      delayDurationDays,
+      delayDate,
+      actor,
+    });
+
+    // If task is not already blocked, set it to blocked
+    if (task.status !== 'blocked') {
+      await this.taskRepository.update({ ...task, status: 'blocked' });
+    }
+
+    return result;
+  }
+}

--- a/src/application/usecases/task/AddTaskDependencyUseCase.ts
+++ b/src/application/usecases/task/AddTaskDependencyUseCase.ts
@@ -1,0 +1,65 @@
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+import { Task } from '../../../domain/entities/Task';
+
+export interface AddTaskDependencyInput {
+  taskId: string;
+  dependsOnTaskId: string;
+}
+
+export class AddTaskDependencyUseCase {
+  constructor(private readonly taskRepository: TaskRepository) {}
+
+  async execute(input: AddTaskDependencyInput): Promise<void> {
+    const { taskId, dependsOnTaskId } = input;
+
+    // Reject self-dependency
+    if (taskId === dependsOnTaskId) {
+      throw new Error('Cannot add self-dependency');
+    }
+
+    // Validate both tasks exist
+    const task = await this.taskRepository.findById(taskId);
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+    const depTask = await this.taskRepository.findById(dependsOnTaskId);
+    if (!depTask) {
+      throw new Error(`Dependency task not found: ${dependsOnTaskId}`);
+    }
+
+    // Check for circular dependency via BFS (max 10 hops)
+    await this.checkCircular(dependsOnTaskId, taskId, 10);
+
+    await this.taskRepository.addDependency(taskId, dependsOnTaskId);
+  }
+
+  /**
+   * BFS: starting from `startId`, walk its dependencies up to `maxDepth` hops.
+   * If we ever encounter `targetId`, it means adding this edge would create a cycle.
+   */
+  private async checkCircular(startId: string, targetId: string, maxDepth: number): Promise<void> {
+    const visited = new Set<string>();
+    let queue = [startId];
+    let depth = 0;
+
+    while (queue.length > 0 && depth < maxDepth) {
+      const nextQueue: string[] = [];
+      for (const currentId of queue) {
+        if (visited.has(currentId)) continue;
+        visited.add(currentId);
+
+        const deps = await this.taskRepository.findDependencies(currentId);
+        for (const dep of deps) {
+          if (dep.id === targetId) {
+            throw new Error('Circular dependency detected');
+          }
+          if (!visited.has(dep.id)) {
+            nextQueue.push(dep.id);
+          }
+        }
+      }
+      queue = nextQueue;
+      depth++;
+    }
+  }
+}

--- a/src/application/usecases/task/GetTaskDetailUseCase.ts
+++ b/src/application/usecases/task/GetTaskDetailUseCase.ts
@@ -1,0 +1,28 @@
+import { Task } from '../../../domain/entities/Task';
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+import { DelayReason } from '../../../domain/entities/DelayReason';
+
+export interface TaskDetail extends Task {
+  dependencyTasks: Task[];
+  delayReasons: DelayReason[];
+}
+
+export class GetTaskDetailUseCase {
+  constructor(private readonly taskRepository: TaskRepository) {}
+
+  async execute(taskId: string): Promise<TaskDetail | null> {
+    const task = await this.taskRepository.findById(taskId);
+    if (!task) return null;
+
+    const [dependencyTasks, delayReasons] = await Promise.all([
+      this.taskRepository.findDependencies(taskId),
+      this.taskRepository.findDelayReasons(taskId),
+    ]);
+
+    return {
+      ...task,
+      dependencyTasks,
+      delayReasons,
+    };
+  }
+}

--- a/src/application/usecases/task/RemoveDelayReasonUseCase.ts
+++ b/src/application/usecases/task/RemoveDelayReasonUseCase.ts
@@ -1,0 +1,13 @@
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+
+export interface RemoveDelayReasonInput {
+  delayReasonId: string;
+}
+
+export class RemoveDelayReasonUseCase {
+  constructor(private readonly taskRepository: TaskRepository) {}
+
+  async execute(input: RemoveDelayReasonInput): Promise<void> {
+    await this.taskRepository.removeDelayReason(input.delayReasonId);
+  }
+}

--- a/src/application/usecases/task/RemoveTaskDependencyUseCase.ts
+++ b/src/application/usecases/task/RemoveTaskDependencyUseCase.ts
@@ -1,0 +1,14 @@
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+
+export interface RemoveTaskDependencyInput {
+  taskId: string;
+  dependsOnTaskId: string;
+}
+
+export class RemoveTaskDependencyUseCase {
+  constructor(private readonly taskRepository: TaskRepository) {}
+
+  async execute(input: RemoveTaskDependencyInput): Promise<void> {
+    await this.taskRepository.removeDependency(input.taskId, input.dependsOnTaskId);
+  }
+}

--- a/src/components/tasks/AddDelayReasonModal.tsx
+++ b/src/components/tasks/AddDelayReasonModal.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, Modal, ScrollView } from 'react-native';
+import { DelayReasonType } from '../../domain/entities/DelayReason';
+import { X, Check } from 'lucide-react-native';
+import { cssInterop } from 'nativewind';
+
+cssInterop(X, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Check, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+
+export interface AddDelayReasonFormData {
+  reasonTypeId: string;
+  notes?: string;
+  delayDurationDays?: number;
+  delayDate?: string;
+  actor?: string;
+}
+
+interface Props {
+  visible: boolean;
+  delayReasonTypes: DelayReasonType[];
+  onSubmit: (data: AddDelayReasonFormData) => void;
+  onClose: () => void;
+}
+
+export function AddDelayReasonModal({ visible, delayReasonTypes, onSubmit, onClose }: Props) {
+  const [selectedTypeId, setSelectedTypeId] = useState<string>('');
+  const [notes, setNotes] = useState('');
+  const [durationDays, setDurationDays] = useState('');
+  const [actor, setActor] = useState('');
+
+  const handleSubmit = () => {
+    if (!selectedTypeId) return;
+
+    onSubmit({
+      reasonTypeId: selectedTypeId,
+      notes: notes.trim() || undefined,
+      delayDurationDays: durationDays ? parseInt(durationDays, 10) : undefined,
+      actor: actor.trim() || undefined,
+    });
+
+    // Reset form
+    setSelectedTypeId('');
+    setNotes('');
+    setDurationDays('');
+    setActor('');
+  };
+
+  const handleClose = () => {
+    setSelectedTypeId('');
+    setNotes('');
+    setDurationDays('');
+    setActor('');
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View className="flex-1 justify-end bg-black/50">
+        <View className="bg-card rounded-t-2xl p-6 max-h-[80%]">
+          <View className="flex-row justify-between items-center mb-4">
+            <Text className="text-lg font-bold text-foreground">Add Delay Reason</Text>
+            <TouchableOpacity onPress={handleClose} className="p-1">
+              <X size={24} className="text-muted-foreground" />
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView showsVerticalScrollIndicator={false}>
+            {/* Reason Type Picker */}
+            <Text className="text-sm font-medium text-foreground mb-2">Reason Type *</Text>
+            <View className="gap-2 mb-4">
+              {delayReasonTypes.map((type) => (
+                <TouchableOpacity
+                  key={type.id}
+                  onPress={() => setSelectedTypeId(type.id)}
+                  className={`p-3 rounded-lg border ${
+                    selectedTypeId === type.id
+                      ? 'border-primary bg-primary/10'
+                      : 'border-border bg-muted'
+                  }`}
+                >
+                  <View className="flex-row items-center gap-2">
+                    {selectedTypeId === type.id && (
+                      <Check size={16} className="text-primary" />
+                    )}
+                    <Text
+                      className={`text-sm ${
+                        selectedTypeId === type.id
+                          ? 'text-primary font-medium'
+                          : 'text-foreground'
+                      }`}
+                    >
+                      {type.label}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {/* Notes */}
+            <Text className="text-sm font-medium text-foreground mb-2">Notes</Text>
+            <TextInput
+              value={notes}
+              onChangeText={setNotes}
+              placeholder="Additional details..."
+              multiline
+              numberOfLines={3}
+              className="border border-border rounded-lg p-3 bg-muted text-foreground mb-4"
+              placeholderTextColor="#9ca3af"
+            />
+
+            {/* Duration */}
+            <Text className="text-sm font-medium text-foreground mb-2">Delay Duration (days)</Text>
+            <TextInput
+              value={durationDays}
+              onChangeText={setDurationDays}
+              placeholder="e.g. 3"
+              keyboardType="numeric"
+              className="border border-border rounded-lg p-3 bg-muted text-foreground mb-4"
+              placeholderTextColor="#9ca3af"
+            />
+
+            {/* Actor */}
+            <Text className="text-sm font-medium text-foreground mb-2">Responsible Party</Text>
+            <TextInput
+              value={actor}
+              onChangeText={setActor}
+              placeholder="e.g. Builder, Council"
+              className="border border-border rounded-lg p-3 bg-muted text-foreground mb-4"
+              placeholderTextColor="#9ca3af"
+            />
+
+            {/* Submit */}
+            <TouchableOpacity
+              onPress={handleSubmit}
+              disabled={!selectedTypeId}
+              className={`py-3 rounded-lg items-center ${
+                selectedTypeId ? 'bg-primary' : 'bg-muted'
+              }`}
+            >
+              <Text
+                className={`font-semibold ${
+                  selectedTypeId ? 'text-primary-foreground' : 'text-muted-foreground'
+                }`}
+              >
+                Add Delay Reason
+              </Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/tasks/TaskDelaySection.tsx
+++ b/src/components/tasks/TaskDelaySection.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { DelayReason } from '../../domain/entities/DelayReason';
+import { Clock, Plus } from 'lucide-react-native';
+import { cssInterop } from 'nativewind';
+
+cssInterop(Clock, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Plus, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+
+interface Props {
+  delayReasons: DelayReason[];
+  onAddDelay?: () => void;
+  onRemoveDelay?: (id: string) => void;
+}
+
+export function TaskDelaySection({ delayReasons, onAddDelay, onRemoveDelay }: Props) {
+  return (
+    <View className="bg-card p-4 rounded-lg border border-border">
+      <View className="flex-row justify-between items-center mb-3">
+        <Text className="text-sm font-semibold text-muted-foreground">DELAY LOG</Text>
+        {onAddDelay && (
+          <TouchableOpacity onPress={onAddDelay} className="flex-row items-center gap-1">
+            <Plus size={16} className="text-primary" />
+            <Text className="text-sm text-primary font-medium">Add</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {delayReasons.length === 0 ? (
+        <Text className="text-sm text-muted-foreground">No delays recorded</Text>
+      ) : (
+        <View className="gap-3">
+          {delayReasons.map((reason) => (
+            <View key={reason.id} className="bg-muted p-3 rounded-lg">
+              <View className="flex-row justify-between items-start">
+                <View className="flex-row items-center gap-2 flex-1">
+                  <Clock size={14} className="text-muted-foreground" />
+                  <Text className="text-sm font-medium text-foreground">
+                    {reason.reasonTypeLabel || reason.reasonTypeId}
+                  </Text>
+                </View>
+                {reason.delayDurationDays != null && (
+                  <Text className="text-xs text-muted-foreground">
+                    {reason.delayDurationDays}d
+                  </Text>
+                )}
+              </View>
+
+              {reason.notes && (
+                <Text className="text-sm text-muted-foreground mt-1 ml-6">{reason.notes}</Text>
+              )}
+
+              <View className="flex-row items-center gap-3 mt-2 ml-6">
+                {reason.delayDate && (
+                  <Text className="text-xs text-muted-foreground">
+                    {new Date(reason.delayDate).toLocaleDateString()}
+                  </Text>
+                )}
+                {reason.actor && (
+                  <Text className="text-xs text-muted-foreground">{reason.actor}</Text>
+                )}
+                <Text className="text-xs text-muted-foreground">
+                  {new Date(reason.createdAt).toLocaleDateString()}
+                </Text>
+              </View>
+
+              {onRemoveDelay && (
+                <TouchableOpacity
+                  onPress={() => onRemoveDelay(reason.id)}
+                  className="mt-2 ml-6"
+                >
+                  <Text className="text-xs text-destructive">Remove</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/components/tasks/TaskDependencySection.tsx
+++ b/src/components/tasks/TaskDependencySection.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { Task } from '../../domain/entities/Task';
+import { TaskStatusBadge } from './TaskStatusBadge';
+import { Link2, Plus, AlertTriangle } from 'lucide-react-native';
+import { cssInterop } from 'nativewind';
+
+cssInterop(Link2, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Plus, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(AlertTriangle, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+
+interface Props {
+  dependencyTasks: Task[];
+  onAddDependency?: () => void;
+  onRemoveDependency?: (dependsOnTaskId: string) => void;
+  onDependencyPress?: (task: Task) => void;
+}
+
+export function TaskDependencySection({
+  dependencyTasks,
+  onAddDependency,
+  onRemoveDependency,
+  onDependencyPress,
+}: Props) {
+  const hasBlockingDependency = dependencyTasks.some(
+    (t) => t.status !== 'completed' && t.status !== 'cancelled',
+  );
+
+  return (
+    <View className="bg-card p-4 rounded-lg border border-border">
+      <View className="flex-row justify-between items-center mb-3">
+        <View className="flex-row items-center gap-2">
+          <Text className="text-sm font-semibold text-muted-foreground">DEPENDENCIES</Text>
+          {hasBlockingDependency && (
+            <View className="flex-row items-center gap-1 bg-red-100 dark:bg-red-900 px-2 py-0.5 rounded-full">
+              <AlertTriangle size={12} className="text-red-600 dark:text-red-300" />
+              <Text className="text-xs font-medium text-red-600 dark:text-red-300">Blocked</Text>
+            </View>
+          )}
+        </View>
+        {onAddDependency && (
+          <TouchableOpacity onPress={onAddDependency} className="flex-row items-center gap-1">
+            <Plus size={16} className="text-primary" />
+            <Text className="text-sm text-primary font-medium">Add</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {dependencyTasks.length === 0 ? (
+        <Text className="text-sm text-muted-foreground">No dependencies</Text>
+      ) : (
+        <View className="gap-2">
+          {dependencyTasks.map((dep) => (
+            <TouchableOpacity
+              key={dep.id}
+              onPress={() => onDependencyPress?.(dep)}
+              className="flex-row items-center justify-between bg-muted p-3 rounded-lg"
+            >
+              <View className="flex-row items-center gap-2 flex-1 mr-2">
+                <Link2 size={14} className="text-muted-foreground" />
+                <Text className="text-sm text-foreground" numberOfLines={1}>
+                  {dep.title}
+                </Text>
+              </View>
+              <TaskStatusBadge status={dep.status} />
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/components/tasks/TaskDocumentSection.tsx
+++ b/src/components/tasks/TaskDocumentSection.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { Document } from '../../domain/entities/Document';
+import { FileText, Plus } from 'lucide-react-native';
+import { cssInterop } from 'nativewind';
+
+cssInterop(FileText, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Plus, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+
+interface Props {
+  documents: Document[];
+  onAddDocument?: () => void;
+  onDocumentPress?: (doc: Document) => void;
+}
+
+export function TaskDocumentSection({ documents, onAddDocument, onDocumentPress }: Props) {
+  return (
+    <View className="bg-card p-4 rounded-lg border border-border">
+      <View className="flex-row justify-between items-center mb-3">
+        <Text className="text-sm font-semibold text-muted-foreground">DOCUMENTS</Text>
+        {onAddDocument && (
+          <TouchableOpacity onPress={onAddDocument} className="flex-row items-center gap-1">
+            <Plus size={16} className="text-primary" />
+            <Text className="text-sm text-primary font-medium">Add</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {documents.length === 0 ? (
+        <Text className="text-sm text-muted-foreground">No documents attached</Text>
+      ) : (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View className="flex-row gap-3">
+            {documents.map((doc) => (
+              <TouchableOpacity
+                key={doc.id}
+                onPress={() => onDocumentPress?.(doc)}
+                className="flex-row items-center gap-2 bg-muted px-3 py-2 rounded-lg"
+              >
+                <FileText size={16} className="text-muted-foreground" />
+                <Text className="text-sm text-foreground" numberOfLines={1}>
+                  {doc.title || doc.filename || 'Untitled'}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </ScrollView>
+      )}
+    </View>
+  );
+}

--- a/src/components/tasks/TaskSubcontractorSection.tsx
+++ b/src/components/tasks/TaskSubcontractorSection.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { HardHat, Phone, Mail, Edit } from 'lucide-react-native';
+import { cssInterop } from 'nativewind';
+
+cssInterop(HardHat, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Phone, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Mail, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(Edit, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+
+interface SubcontractorInfo {
+  id: string;
+  name: string;
+  trade?: string;
+  phone?: string;
+  email?: string;
+}
+
+interface Props {
+  subcontractor: SubcontractorInfo | null;
+  onEditSubcontractor?: () => void;
+}
+
+export function TaskSubcontractorSection({ subcontractor, onEditSubcontractor }: Props) {
+  return (
+    <View className="bg-card p-4 rounded-lg border border-border">
+      <View className="flex-row justify-between items-center mb-3">
+        <Text className="text-sm font-semibold text-muted-foreground">SUBCONTRACTOR</Text>
+        {onEditSubcontractor && (
+          <TouchableOpacity onPress={onEditSubcontractor} className="p-1">
+            <Edit size={16} className="text-primary" />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {!subcontractor ? (
+        <TouchableOpacity
+          onPress={onEditSubcontractor}
+          className="flex-row items-center gap-2 py-2"
+        >
+          <HardHat size={18} className="text-muted-foreground" />
+          <Text className="text-sm text-muted-foreground">Assign subcontractor</Text>
+        </TouchableOpacity>
+      ) : (
+        <View className="gap-2">
+          <View className="flex-row items-center gap-2">
+            <HardHat size={16} className="text-foreground" />
+            <Text className="text-foreground font-medium">{subcontractor.name}</Text>
+          </View>
+          {subcontractor.trade && (
+            <Text className="text-sm text-muted-foreground ml-6">{subcontractor.trade}</Text>
+          )}
+          {subcontractor.phone && (
+            <View className="flex-row items-center gap-2">
+              <Phone size={14} className="text-muted-foreground" />
+              <Text className="text-sm text-foreground">{subcontractor.phone}</Text>
+            </View>
+          )}
+          {subcontractor.email && (
+            <View className="flex-row items-center gap-2">
+              <Mail size={14} className="text-muted-foreground" />
+              <Text className="text-sm text-foreground">{subcontractor.email}</Text>
+            </View>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/domain/entities/DelayReason.ts
+++ b/src/domain/entities/DelayReason.ts
@@ -1,0 +1,18 @@
+export interface DelayReasonType {
+  id: string;          // e.g. 'WEATHER'
+  label: string;       // e.g. 'Bad weather'
+  displayOrder: number;
+  isActive: boolean;
+}
+
+export interface DelayReason {
+  id: string;
+  taskId: string;
+  reasonTypeId: string;        // FK to DelayReasonType.id
+  reasonTypeLabel?: string;    // denormalised label for display (populated by repo)
+  notes?: string;              // optional supplemental free text
+  delayDurationDays?: number;
+  delayDate?: string;          // ISO date string
+  actor?: string;
+  createdAt: string;
+}

--- a/src/domain/entities/Task.ts
+++ b/src/domain/entities/Task.ts
@@ -1,3 +1,5 @@
+import { DelayReason } from './DelayReason';
+
 export interface Task {
   id: string;
   localId?: number; // SQLite INTEGER PRIMARY KEY
@@ -23,7 +25,13 @@ export interface Task {
   status: 'pending' | 'in_progress' | 'completed' | 'blocked' | 'cancelled';
   priority?: 'low' | 'medium' | 'high' | 'urgent';
   
+  // Subcontractor
+  subcontractorId?: string; // contactId of assigned subcontractor
+
+  // Dependencies & delays (hydrated by repository on single-task fetches)
   dependencies?: string[]; // taskIds
+  delayReasons?: DelayReason[];
+
   createdAt?: string;
   updatedAt?: string;
   completedAt?: string;

--- a/src/domain/repositories/DelayReasonTypeRepository.ts
+++ b/src/domain/repositories/DelayReasonTypeRepository.ts
@@ -1,0 +1,6 @@
+import { DelayReasonType } from '../entities/DelayReason';
+
+export interface DelayReasonTypeRepository {
+  findAll(): Promise<DelayReasonType[]>;
+  findById(id: string): Promise<DelayReasonType | null>;
+}

--- a/src/domain/repositories/TaskRepository.ts
+++ b/src/domain/repositories/TaskRepository.ts
@@ -1,4 +1,5 @@
 import { Task } from '../entities/Task';
+import { DelayReason } from '../entities/DelayReason';
 
 export interface TaskRepository {
   save(task: Task): Promise<void>;
@@ -9,4 +10,15 @@ export interface TaskRepository {
   findUpcoming(projectId?: string, daysAhead?: number): Promise<Task[]>; 
   update(task: Task): Promise<void>;
   delete(id: string): Promise<void>;
+
+  // Dependencies
+  addDependency(taskId: string, dependsOnTaskId: string): Promise<void>;
+  removeDependency(taskId: string, dependsOnTaskId: string): Promise<void>;
+  findDependencies(taskId: string): Promise<Task[]>;
+  findDependents(taskId: string): Promise<Task[]>;
+
+  // Delay reasons
+  addDelayReason(entry: Omit<DelayReason, 'id' | 'createdAt'>): Promise<DelayReason>;
+  removeDelayReason(delayReasonId: string): Promise<void>;
+  findDelayReasons(taskId: string): Promise<DelayReason[]>;
 }

--- a/src/hooks/useDelayReasonTypes.ts
+++ b/src/hooks/useDelayReasonTypes.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { DelayReasonType } from '../domain/entities/DelayReason';
+import { DelayReasonTypeRepository } from '../domain/repositories/DelayReasonTypeRepository';
+import { container } from 'tsyringe';
+import '../infrastructure/di/registerServices';
+
+export interface UseDelayReasonTypesReturn {
+  delayReasonTypes: DelayReasonType[];
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export function useDelayReasonTypes(): UseDelayReasonTypesReturn {
+  const [delayReasonTypes, setDelayReasonTypes] = useState<DelayReasonType[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const repository = useMemo(
+    () => container.resolve<DelayReasonTypeRepository>('DelayReasonTypeRepository'),
+    [],
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const types = await repository.findAll();
+      setDelayReasonTypes(types);
+    } catch (error) {
+      console.error('Failed to load delay reason types', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [repository]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return useMemo(
+    () => ({
+      delayReasonTypes,
+      loading,
+      refresh: load,
+    }),
+    [delayReasonTypes, loading, load],
+  );
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Task } from '../domain/entities/Task';
+import { DelayReason } from '../domain/entities/DelayReason';
 import { TaskRepository } from '../domain/repositories/TaskRepository';
+import { DelayReasonTypeRepository } from '../domain/repositories/DelayReasonTypeRepository';
 import { container } from 'tsyringe';
 import '../infrastructure/di/registerServices';
 import { CreateTaskUseCase } from '../application/usecases/task/CreateTaskUseCase';
@@ -8,6 +10,14 @@ import { UpdateTaskUseCase } from '../application/usecases/task/UpdateTaskUseCas
 import { DeleteTaskUseCase } from '../application/usecases/task/DeleteTaskUseCase';
 import { GetTaskUseCase } from '../application/usecases/task/GetTaskUseCase';
 import { ListTasksUseCase } from '../application/usecases/task/ListTasksUseCase';
+import { GetTaskDetailUseCase, TaskDetail } from '../application/usecases/task/GetTaskDetailUseCase';
+import { AddTaskDependencyUseCase } from '../application/usecases/task/AddTaskDependencyUseCase';
+import { RemoveTaskDependencyUseCase } from '../application/usecases/task/RemoveTaskDependencyUseCase';
+import { AddDelayReasonUseCase, AddDelayReasonInput } from '../application/usecases/task/AddDelayReasonUseCase';
+import { RemoveDelayReasonUseCase } from '../application/usecases/task/RemoveDelayReasonUseCase';
+
+export type { TaskDetail } from '../application/usecases/task/GetTaskDetailUseCase';
+export type { AddDelayReasonInput } from '../application/usecases/task/AddDelayReasonUseCase';
 
 export interface UseTasksReturn {
   tasks: Task[];
@@ -17,6 +27,12 @@ export interface UseTasksReturn {
   updateTask: (task: Task) => Promise<void>;
   deleteTask: (id: string) => Promise<void>;
   getTask: (id: string) => Promise<Task | null>;
+  // Task detail extensions
+  getTaskDetail: (id: string) => Promise<TaskDetail | null>;
+  addDependency: (taskId: string, dependsOnTaskId: string) => Promise<void>;
+  removeDependency: (taskId: string, dependsOnTaskId: string) => Promise<void>;
+  addDelayReason: (taskId: string, input: Omit<AddDelayReasonInput, 'taskId'>) => Promise<DelayReason>;
+  removeDelayReason: (delayReasonId: string) => Promise<void>;
 }
 
 export function useTasks(projectId?: string): UseTasksReturn {
@@ -24,12 +40,18 @@ export function useTasks(projectId?: string): UseTasksReturn {
   const [loading, setLoading] = useState(true);
 
   const taskRepository = useMemo(() => container.resolve<TaskRepository>('TaskRepository'), []);
+  const delayReasonTypeRepository = useMemo(() => container.resolve<DelayReasonTypeRepository>('DelayReasonTypeRepository'), []);
   
   const createUseCase = useMemo(() => new CreateTaskUseCase(taskRepository), [taskRepository]);
   const updateUseCase = useMemo(() => new UpdateTaskUseCase(taskRepository), [taskRepository]);
   const deleteUseCase = useMemo(() => new DeleteTaskUseCase(taskRepository), [taskRepository]);
   const getUseCase = useMemo(() => new GetTaskUseCase(taskRepository), [taskRepository]);
   const listUseCase = useMemo(() => new ListTasksUseCase(taskRepository), [taskRepository]);
+  const getTaskDetailUseCase = useMemo(() => new GetTaskDetailUseCase(taskRepository), [taskRepository]);
+  const addDependencyUseCase = useMemo(() => new AddTaskDependencyUseCase(taskRepository), [taskRepository]);
+  const removeDependencyUseCase = useMemo(() => new RemoveTaskDependencyUseCase(taskRepository), [taskRepository]);
+  const addDelayReasonUseCase = useMemo(() => new AddDelayReasonUseCase(taskRepository, delayReasonTypeRepository), [taskRepository, delayReasonTypeRepository]);
+  const removeDelayReasonUseCase = useMemo(() => new RemoveDelayReasonUseCase(taskRepository), [taskRepository]);
 
   const loadTasks = useCallback(async () => {
     setLoading(true);
@@ -78,6 +100,26 @@ export function useTasks(projectId?: string): UseTasksReturn {
     return getUseCase.execute(id);
   }, [getUseCase]);
 
+  const getTaskDetail = useCallback(async (id: string): Promise<TaskDetail | null> => {
+    return getTaskDetailUseCase.execute(id);
+  }, [getTaskDetailUseCase]);
+
+  const addDependency = useCallback(async (taskId: string, dependsOnTaskId: string) => {
+    await addDependencyUseCase.execute({ taskId, dependsOnTaskId });
+  }, [addDependencyUseCase]);
+
+  const removeDependency = useCallback(async (taskId: string, dependsOnTaskId: string) => {
+    await removeDependencyUseCase.execute({ taskId, dependsOnTaskId });
+  }, [removeDependencyUseCase]);
+
+  const addDelayReason = useCallback(async (taskId: string, input: Omit<AddDelayReasonInput, 'taskId'>): Promise<DelayReason> => {
+    return addDelayReasonUseCase.execute({ taskId, ...input });
+  }, [addDelayReasonUseCase]);
+
+  const removeDelayReason = useCallback(async (delayReasonId: string) => {
+    await removeDelayReasonUseCase.execute({ delayReasonId });
+  }, [removeDelayReasonUseCase]);
+
   return useMemo(() => ({
     tasks,
     loading,
@@ -86,5 +128,10 @@ export function useTasks(projectId?: string): UseTasksReturn {
     updateTask,
     deleteTask,
     getTask,
-  }), [tasks, loading, loadTasks, createTask, updateTask, deleteTask, getTask]);
+    getTaskDetail,
+    addDependency,
+    removeDependency,
+    addDelayReason,
+    removeDelayReason,
+  }), [tasks, loading, loadTasks, createTask, updateTask, deleteTask, getTask, getTaskDetail, addDependency, removeDependency, addDelayReason, removeDelayReason]);
 }

--- a/src/infrastructure/database/migrations.ts
+++ b/src/infrastructure/database/migrations.ts
@@ -648,6 +648,55 @@ const migrations: RNMigration[] = [
       'ALTER TABLE "properties" ADD COLUMN "longitude" real;',
     ],
   },
+  {
+    tag: '0012_task_detail_extensions',
+    hash: '0012_task_detail_extensions',
+    folderMillis: 1772700000000,
+    sql: [
+      // 1. Add subcontractor_id to tasks
+      'ALTER TABLE "tasks" ADD COLUMN "subcontractor_id" text;',
+      // 2. Create task_dependencies join table
+      `CREATE TABLE IF NOT EXISTS "task_dependencies" (
+        "local_id" integer PRIMARY KEY AUTOINCREMENT,
+        "task_id" text NOT NULL,
+        "depends_on_task_id" text NOT NULL,
+        "created_at" integer
+      );`,
+      `CREATE INDEX IF NOT EXISTS "idx_task_deps_task" ON "task_dependencies" ("task_id");`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS "idx_task_deps_unique" ON "task_dependencies" ("task_id", "depends_on_task_id");`,
+      // 3. Create delay_reason_types lookup table
+      `CREATE TABLE IF NOT EXISTS "delay_reason_types" (
+        "id" text PRIMARY KEY,
+        "label" text NOT NULL,
+        "display_order" integer NOT NULL,
+        "is_active" integer NOT NULL DEFAULT 1
+      );`,
+      // 4. Seed delay_reason_types
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('WEATHER', 'Bad weather', 1, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('MATERIAL_DELAY', 'Material / supply delay', 2, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('SUBCONTRACTOR', 'Subcontractor unavailability', 3, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('PERMIT', 'Permit / approval delay', 4, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('DESIGN_CHANGE', 'Design change', 5, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('EQUIPMENT', 'Equipment breakdown', 6, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('ACCESS', 'Site access issue', 7, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('LABOUR', 'Labour shortage', 8, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('CLIENT', 'Client decision pending', 9, 1);`,
+      `INSERT OR IGNORE INTO "delay_reason_types" ("id", "label", "display_order", "is_active") VALUES ('OTHER', 'Other', 10, 1);`,
+      // 5. Create task_delay_reasons table
+      `CREATE TABLE IF NOT EXISTS "task_delay_reasons" (
+        "local_id" integer PRIMARY KEY AUTOINCREMENT,
+        "id" text NOT NULL UNIQUE,
+        "task_id" text NOT NULL,
+        "reason_type_id" text NOT NULL,
+        "notes" text,
+        "delay_duration_days" real,
+        "delay_date" integer,
+        "actor" text,
+        "created_at" integer NOT NULL
+      );`,
+      `CREATE INDEX IF NOT EXISTS "idx_task_delays_task" ON "task_delay_reasons" ("task_id");`,
+    ],
+  },
 ];
 
 export function getBundledMigrations(): RNMigration[] {

--- a/src/infrastructure/database/schema.ts
+++ b/src/infrastructure/database/schema.ts
@@ -285,6 +285,7 @@ export const tasks = sqliteTable('tasks', {
     enum: ['low', 'medium', 'high', 'urgent'] 
   }),
   
+  subcontractorId: text('subcontractor_id'), // FK (soft) to contacts.id
   completedDate: integer('completed_date'), // Unix timestamp
   createdAt: integer('created_at'),
   updatedAt: integer('updated_at'),
@@ -292,6 +293,40 @@ export const tasks = sqliteTable('tasks', {
   projectIdx: index('idx_tasks_project').on(table.projectId),
   scheduledIdx: index('idx_tasks_scheduled').on(table.scheduledAt),
   statusIdx: index('idx_tasks_status').on(table.status),
+}));
+
+// Task Dependencies (join table)
+export const taskDependencies = sqliteTable('task_dependencies', {
+  localId: integer('local_id').primaryKey({ autoIncrement: true }),
+  taskId: text('task_id').notNull(),
+  dependsOnTaskId: text('depends_on_task_id').notNull(),
+  createdAt: integer('created_at'),
+}, (table) => ({
+  taskIdx: index('idx_task_deps_task').on(table.taskId),
+  uniqueDep: uniqueIndex('idx_task_deps_unique').on(table.taskId, table.dependsOnTaskId),
+}));
+
+// Delay Reason Types (lookup / reference data)
+export const delayReasonTypes = sqliteTable('delay_reason_types', {
+  id: text('id').primaryKey(),
+  label: text('label').notNull(),
+  displayOrder: integer('display_order').notNull(),
+  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+});
+
+// Task Delay Reasons
+export const taskDelayReasons = sqliteTable('task_delay_reasons', {
+  localId: integer('local_id').primaryKey({ autoIncrement: true }),
+  id: text('id').notNull().unique(),
+  taskId: text('task_id').notNull(),
+  reasonTypeId: text('reason_type_id').notNull(), // FK (soft) to delay_reason_types.id
+  notes: text('notes'),
+  delayDurationDays: real('delay_duration_days'),
+  delayDate: integer('delay_date'), // Unix ms
+  actor: text('actor'),
+  createdAt: integer('created_at').notNull(),
+}, (table) => ({
+  taskIdx: index('idx_task_delays_task').on(table.taskId),
 }));
 
 // Inspections Table

--- a/src/infrastructure/di/registerServices.ts
+++ b/src/infrastructure/di/registerServices.ts
@@ -14,6 +14,7 @@ import { DrizzlePaymentRepository } from '../repositories/DrizzlePaymentReposito
 import { DrizzleReceiptRepository } from '../repositories/DrizzleReceiptRepository';
 import { DrizzleTaskRepository } from '../repositories/DrizzleTaskRepository';
 import { DrizzleDocumentRepository } from '../repositories/DrizzleDocumentRepository';
+import { DrizzleDelayReasonTypeRepository } from '../repositories/DrizzleDelayReasonTypeRepository';
 import { MobileFileSystemAdapter } from '../files/MobileFileSystemAdapter';
 import { MobileCameraAdapter } from '../camera/MobileCameraAdapter';
 import { MockAudioRecorder } from '../voice/MockAudioRecorder';
@@ -37,6 +38,7 @@ if (typeof (container as any).registerSingleton === 'function') {
 	container.registerSingleton('ReceiptRepository', DrizzleReceiptRepository);
 	container.registerSingleton('TaskRepository', DrizzleTaskRepository);
 	container.registerSingleton('DocumentRepository', DrizzleDocumentRepository);
+	container.registerSingleton('DelayReasonTypeRepository', DrizzleDelayReasonTypeRepository);
 	container.registerSingleton('FileSystemAdapter', MobileFileSystemAdapter);
 	container.registerSingleton('CameraService', MobileCameraAdapter);
 

--- a/src/infrastructure/repositories/DrizzleDelayReasonTypeRepository.ts
+++ b/src/infrastructure/repositories/DrizzleDelayReasonTypeRepository.ts
@@ -1,0 +1,46 @@
+import { DelayReasonType } from '../../domain/entities/DelayReason';
+import { DelayReasonTypeRepository } from '../../domain/repositories/DelayReasonTypeRepository';
+import { getDatabase, initDatabase } from '../database/connection';
+
+export class DrizzleDelayReasonTypeRepository implements DelayReasonTypeRepository {
+  private initialized = false;
+
+  private async ensureInitialized() {
+    if (this.initialized) return;
+    await initDatabase();
+    this.initialized = true;
+  }
+
+  async findAll(): Promise<DelayReasonType[]> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    const [result] = await db.executeSql(
+      'SELECT * FROM delay_reason_types WHERE is_active = 1 ORDER BY display_order ASC',
+    );
+    const types: DelayReasonType[] = [];
+    for (let i = 0; i < result.rows.length; i++) {
+      types.push(this.mapRow(result.rows.item(i)));
+    }
+    return types;
+  }
+
+  async findById(id: string): Promise<DelayReasonType | null> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    const [result] = await db.executeSql(
+      'SELECT * FROM delay_reason_types WHERE id = ?',
+      [id],
+    );
+    if (result.rows.length === 0) return null;
+    return this.mapRow(result.rows.item(0));
+  }
+
+  private mapRow(row: any): DelayReasonType {
+    return {
+      id: row.id,
+      label: row.label,
+      displayOrder: row.display_order,
+      isActive: Boolean(row.is_active),
+    };
+  }
+}

--- a/src/infrastructure/repositories/DrizzleTaskRepository.ts
+++ b/src/infrastructure/repositories/DrizzleTaskRepository.ts
@@ -1,5 +1,6 @@
 import { Task } from '../../domain/entities/Task';
 import { TaskRepository } from '../../domain/repositories/TaskRepository';
+import { DelayReason } from '../../domain/entities/DelayReason';
 import { getDatabase, initDatabase } from '../../infrastructure/database/connection';
 
 export class DrizzleTaskRepository implements TaskRepository {
@@ -23,6 +24,7 @@ export class DrizzleTaskRepository implements TaskRepository {
       scheduledAt: row.scheduled_at ? new Date(row.scheduled_at).toISOString() : undefined,
       dueDate: row.due_date ? new Date(row.due_date).toISOString() : undefined,
       assignedTo: row.assigned_to || undefined,
+      subcontractorId: row.subcontractor_id || undefined,
       status: (row.status as Task['status']) || 'pending',
       priority: row.priority as Task['priority'] || undefined,
       completedAt: row.completed_date ? new Date(row.completed_date).toISOString() : undefined,
@@ -42,6 +44,7 @@ export class DrizzleTaskRepository implements TaskRepository {
       scheduled_at: task.scheduledAt ? new Date(task.scheduledAt).getTime() : null,
       due_date: task.dueDate ? new Date(task.dueDate).getTime() : null,
       assigned_to: task.assignedTo || null,
+      subcontractor_id: task.subcontractorId || null,
       status: task.status || 'pending',
       priority: task.priority || null,
       completed_date: task.completedAt ? new Date(task.completedAt).getTime() : null,
@@ -64,9 +67,9 @@ export class DrizzleTaskRepository implements TaskRepository {
     await db.executeSql(
       `INSERT INTO tasks (
         id, project_id, title, description, notes,
-        is_scheduled, scheduled_at, due_date, assigned_to,
+        is_scheduled, scheduled_at, due_date, assigned_to, subcontractor_id,
         status, priority, completed_date, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       , [
         values.id,
         values.project_id,
@@ -77,6 +80,7 @@ export class DrizzleTaskRepository implements TaskRepository {
         values.scheduled_at,
         values.due_date,
         values.assigned_to,
+        values.subcontractor_id,
         values.status,
         values.priority,
         values.completed_date,
@@ -160,6 +164,7 @@ export class DrizzleTaskRepository implements TaskRepository {
         scheduled_at = ?,
         due_date = ?,
         assigned_to = ?,
+        subcontractor_id = ?,
         status = ?,
         priority = ?,
         completed_date = ?,
@@ -175,6 +180,7 @@ export class DrizzleTaskRepository implements TaskRepository {
         values.scheduled_at,
         values.due_date,
         values.assigned_to,
+        values.subcontractor_id,
         values.status,
         values.priority,
         values.completed_date,
@@ -189,5 +195,130 @@ export class DrizzleTaskRepository implements TaskRepository {
     await this.ensureInitialized();
     const { db } = getDatabase();
     await db.executeSql('DELETE FROM tasks WHERE id = ?', [id]);
+  }
+
+  // ── Dependencies ───────────────────────────────────────────────────────────
+
+  async addDependency(taskId: string, dependsOnTaskId: string): Promise<void> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    await db.executeSql(
+      `INSERT OR IGNORE INTO task_dependencies (task_id, depends_on_task_id, created_at)
+       VALUES (?, ?, ?)`,
+      [taskId, dependsOnTaskId, Date.now()],
+    );
+  }
+
+  async removeDependency(taskId: string, dependsOnTaskId: string): Promise<void> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    await db.executeSql(
+      'DELETE FROM task_dependencies WHERE task_id = ? AND depends_on_task_id = ?',
+      [taskId, dependsOnTaskId],
+    );
+  }
+
+  async findDependencies(taskId: string): Promise<Task[]> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    const [result] = await db.executeSql(
+      `SELECT t.* FROM tasks t
+       INNER JOIN task_dependencies td ON td.depends_on_task_id = t.id
+       WHERE td.task_id = ?`,
+      [taskId],
+    );
+    const tasks: Task[] = [];
+    for (let i = 0; i < result.rows.length; i++) {
+      tasks.push(this.mapRowToEntity(result.rows.item(i)));
+    }
+    return tasks;
+  }
+
+  async findDependents(taskId: string): Promise<Task[]> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    const [result] = await db.executeSql(
+      `SELECT t.* FROM tasks t
+       INNER JOIN task_dependencies td ON td.task_id = t.id
+       WHERE td.depends_on_task_id = ?`,
+      [taskId],
+    );
+    const tasks: Task[] = [];
+    for (let i = 0; i < result.rows.length; i++) {
+      tasks.push(this.mapRowToEntity(result.rows.item(i)));
+    }
+    return tasks;
+  }
+
+  // ── Delay Reasons ──────────────────────────────────────────────────────────
+
+  async addDelayReason(entry: Omit<DelayReason, 'id' | 'createdAt'>): Promise<DelayReason> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    const id = `delay_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const now = Date.now();
+
+    await db.executeSql(
+      `INSERT INTO task_delay_reasons
+        (id, task_id, reason_type_id, notes, delay_duration_days, delay_date, actor, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        entry.taskId,
+        entry.reasonTypeId,
+        entry.notes || null,
+        entry.delayDurationDays ?? null,
+        entry.delayDate ? new Date(entry.delayDate).getTime() : null,
+        entry.actor || null,
+        now,
+      ],
+    );
+
+    return {
+      id,
+      taskId: entry.taskId,
+      reasonTypeId: entry.reasonTypeId,
+      reasonTypeLabel: entry.reasonTypeLabel,
+      notes: entry.notes,
+      delayDurationDays: entry.delayDurationDays,
+      delayDate: entry.delayDate,
+      actor: entry.actor,
+      createdAt: new Date(now).toISOString(),
+    };
+  }
+
+  async removeDelayReason(delayReasonId: string): Promise<void> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    await db.executeSql('DELETE FROM task_delay_reasons WHERE id = ?', [delayReasonId]);
+  }
+
+  async findDelayReasons(taskId: string): Promise<DelayReason[]> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    const [result] = await db.executeSql(
+      `SELECT tdr.*, drt.label AS reason_type_label
+       FROM task_delay_reasons tdr
+       LEFT JOIN delay_reason_types drt ON drt.id = tdr.reason_type_id
+       WHERE tdr.task_id = ?
+       ORDER BY tdr.created_at ASC`,
+      [taskId],
+    );
+    const reasons: DelayReason[] = [];
+    for (let i = 0; i < result.rows.length; i++) {
+      const row = result.rows.item(i);
+      reasons.push({
+        id: row.id,
+        taskId: row.task_id,
+        reasonTypeId: row.reason_type_id,
+        reasonTypeLabel: row.reason_type_label || undefined,
+        notes: row.notes || undefined,
+        delayDurationDays: row.delay_duration_days ?? undefined,
+        delayDate: row.delay_date ? new Date(row.delay_date).toISOString() : undefined,
+        actor: row.actor || undefined,
+        createdAt: new Date(row.created_at).toISOString(),
+      });
+    }
+    return reasons;
   }
 }

--- a/src/pages/tasks/TaskDetailsPage.tsx
+++ b/src/pages/tasks/TaskDetailsPage.tsx
@@ -1,10 +1,20 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
-import { useTasks } from '../../hooks/useTasks';
+import { useTasks, TaskDetail } from '../../hooks/useTasks';
+import { useDelayReasonTypes } from '../../hooks/useDelayReasonTypes';
 import { Task } from '../../domain/entities/Task';
+import { DelayReason } from '../../domain/entities/DelayReason';
+import { Document } from '../../domain/entities/Document';
+import { DocumentRepository } from '../../domain/repositories/DocumentRepository';
+import { container } from 'tsyringe';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TaskStatusBadge } from '../../components/tasks/TaskStatusBadge';
+import { TaskDocumentSection } from '../../components/tasks/TaskDocumentSection';
+import { TaskDependencySection } from '../../components/tasks/TaskDependencySection';
+import { TaskSubcontractorSection } from '../../components/tasks/TaskSubcontractorSection';
+import { TaskDelaySection } from '../../components/tasks/TaskDelaySection';
+import { AddDelayReasonModal, AddDelayReasonFormData } from '../../components/tasks/AddDelayReasonModal';
 import { Edit, Trash2, Calendar, Clock, MapPin, ArrowLeft } from 'lucide-react-native';
 import { cssInterop } from 'nativewind';
 
@@ -18,21 +28,56 @@ export default function TaskDetailsPage() {
   const route = useRoute<any>();
   const navigation = useNavigation<any>();
   const { taskId } = route.params;
-  const { getTask, deleteTask } = useTasks();
+  const {
+    getTask,
+    deleteTask,
+    getTaskDetail,
+    addDependency,
+    removeDependency,
+    addDelayReason,
+    removeDelayReason,
+  } = useTasks();
+  const { delayReasonTypes } = useDelayReasonTypes();
+
   const [task, setTask] = useState<Task | null>(null);
+  const [taskDetail, setTaskDetail] = useState<TaskDetail | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showDelayModal, setShowDelayModal] = useState(false);
+
+  const documentRepository = useMemo(() => {
+    try {
+      return container.resolve<DocumentRepository>('DocumentRepository');
+    } catch {
+      return null;
+    }
+  }, []);
 
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const t = await getTask(taskId);
+      const [t, detail] = await Promise.all([
+        getTask(taskId),
+        getTaskDetail(taskId),
+      ]);
       setTask(t);
+      setTaskDetail(detail);
+
+      // Load documents linked to this task
+      if (documentRepository) {
+        try {
+          const docs = await documentRepository.findByTaskId(taskId);
+          setDocuments(docs);
+        } catch {
+          setDocuments([]);
+        }
+      }
     } catch (e) {
       console.error(e);
     } finally {
       setLoading(false);
     }
-  }, [taskId, getTask]);
+  }, [taskId, getTask, getTaskDetail, documentRepository]);
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('focus', () => {
@@ -64,6 +109,57 @@ export default function TaskDetailsPage() {
       ]
     );
   };
+
+  const handleAddDelayReason = async (data: AddDelayReasonFormData) => {
+    try {
+      await addDelayReason(taskId, data);
+      setShowDelayModal(false);
+      await loadData();
+    } catch (e: any) {
+      Alert.alert('Error', e?.message || 'Failed to add delay reason');
+    }
+  };
+
+  const handleRemoveDelayReason = async (delayReasonId: string) => {
+    Alert.alert('Remove Delay', 'Remove this delay reason entry?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await removeDelayReason(delayReasonId);
+            await loadData();
+          } catch (e: any) {
+            Alert.alert('Error', e?.message || 'Failed to remove delay reason');
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleRemoveDependency = async (dependsOnTaskId: string) => {
+    Alert.alert('Remove Dependency', 'Remove this dependency?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await removeDependency(taskId, dependsOnTaskId);
+            await loadData();
+          } catch (e: any) {
+            Alert.alert('Error', e?.message || 'Failed to remove dependency');
+          }
+        },
+      },
+    ]);
+  };
+
+  // Subcontractor display (stub — full contact lookup will come when contacts system is fleshed out)
+  const subcontractorInfo = task?.subcontractorId
+    ? { id: task.subcontractorId, name: task.subcontractorId }
+    : null;
 
   if (loading) {
     return (
@@ -125,12 +221,41 @@ export default function TaskDetailsPage() {
         </View>
         
         {task.notes && (
-          <View className="bg-card p-4 rounded-lg border border-border">
+          <View className="bg-card p-4 rounded-lg border border-border mb-4">
             <Text className="text-sm font-semibold text-muted-foreground mb-2">NOTES</Text>
             <Text className="text-foreground leading-6">{task.notes}</Text>
           </View>
         )}
+
+        {/* === Task Detail Extension Sections === */}
+        <View className="gap-4 mb-6">
+          <TaskSubcontractorSection
+            subcontractor={subcontractorInfo}
+          />
+
+          <TaskDocumentSection
+            documents={documents}
+          />
+
+          <TaskDependencySection
+            dependencyTasks={taskDetail?.dependencyTasks ?? []}
+            onRemoveDependency={handleRemoveDependency}
+          />
+
+          <TaskDelaySection
+            delayReasons={taskDetail?.delayReasons ?? []}
+            onAddDelay={() => setShowDelayModal(true)}
+            onRemoveDelay={handleRemoveDelayReason}
+          />
+        </View>
       </ScrollView>
+
+      <AddDelayReasonModal
+        visible={showDelayModal}
+        delayReasonTypes={delayReasonTypes}
+        onSubmit={handleAddDelayReason}
+        onClose={() => setShowDelayModal(false)}
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Summary

Implements Issue #108: Task detail enhancements — documents, dependency tasks, subcontractor link, and delay reasons.

This PR contains schema changes (migration `0012_task_detail_extensions`), domain entities, repository updates, use cases, hooks, UI components, tests, and DI wiring required to support task detail features.

High level

- DB: Add `subcontractor_id` column on `tasks`; add `task_dependencies`, `delay_reason_types`, `task_delay_reasons` tables, with seed rows for delay reason types.
- Domain: `DelayReason` types + `Task` updated with `subcontractorId` and delay reasons.
- Repositories: `DrizzleTaskRepository` updated + `DrizzleDelayReasonTypeRepository` added.
- Use cases: Add/Remove dependency, Add/Remove delay reason, GetTaskDetail.
- Hooks/UI: `useTasks` extended, `useDelayReasonTypes` added, five new UI components, `TaskDetailsPage` extended.
- Tests: 26 new unit/integration tests. Full test suite passes locally (558 tests).

Follow-ups

Remaining tasks collected in issue #111: subcontractor lookup UI wiring, task picker for adding dependencies, document upload flow, confirmation hook, and cascade-delete handling.

Testing

Run:

```bash
npx tsc --noEmit
npx jest
```

Notes

- All changes follow project CLAUDE.md conventions (Clean Architecture, Drizzle for DB work, DI registration).
- See `design/issue-108-task-detail.md` for the design and acceptance criteria.
