### PR TITLE
Issue #110: Task Delay Reasons — resolve, stats, migration, and tests

### DIFF
--- a/__tests__/integration/DrizzleDelayReasonTypeRepository.integration.test.ts
+++ b/__tests__/integration/DrizzleDelayReasonTypeRepository.integration.test.ts
@@ -1,0 +1,90 @@
+// Integration test: DrizzleDelayReasonTypeRepository reads the seeded catalog
+
+jest.mock('react-native-sqlite-storage', () => {
+  function createAdapter(db: any) {
+    return {
+      executeSql: async (sql: string, params: any[] = []) => {
+        const stmt = sql.trim();
+        const upper = stmt.toUpperCase();
+        if (upper.startsWith('SELECT')) {
+          const rows = db.prepare(stmt).all(...params);
+          return [{ rows: { length: rows.length, item: (i: number) => rows[i] } }];
+        }
+        if (params && params.length > 0) {
+          try {
+            const prepared = db.prepare(stmt);
+            prepared.run(...params);
+            return [{ rows: { length: 0, item: (_: number) => undefined } }];
+          } catch {
+            // fallthrough
+          }
+        }
+        if (stmt) db.exec(stmt);
+        return [{ rows: { length: 0, item: (_: number) => undefined } }];
+      },
+      transaction: async (fn: any) => {
+        db.exec('BEGIN');
+        try {
+          const tx = { executeSql: (sql: string, params?: any[]) => createAdapter(db).executeSql(sql, params) };
+          await fn(tx);
+          db.exec('COMMIT');
+        } catch (err) {
+          db.exec('ROLLBACK');
+          throw err;
+        }
+      },
+      close: async () => db.close(),
+    };
+  }
+  return {
+    enablePromise: (_: boolean) => {},
+    openDatabase: async (_: any) => {
+      const BetterSqlite3 = require('better-sqlite3');
+      const db = new BetterSqlite3(':memory:');
+      return createAdapter(db);
+    },
+  };
+});
+
+import { initDatabase } from '../../src/infrastructure/database/connection';
+import { DrizzleDelayReasonTypeRepository } from '../../src/infrastructure/repositories/DrizzleDelayReasonTypeRepository';
+
+describe('DrizzleDelayReasonTypeRepository (integration)', () => {
+  let repo: DrizzleDelayReasonTypeRepository;
+
+  beforeAll(async () => {
+    await initDatabase();
+    repo = new DrizzleDelayReasonTypeRepository();
+  });
+
+  it('findAll() returns the 10 seeded reason types ordered by display_order', async () => {
+    const types = await repo.findAll();
+
+    expect(types).toHaveLength(10);
+    // Ordered by displayOrder
+    expect(types[0].id).toBe('WEATHER');
+    expect(types[0].label).toBe('Bad weather');
+    expect(types[0].displayOrder).toBe(1);
+    expect(types[0].isActive).toBe(true);
+
+    expect(types[9].id).toBe('OTHER');
+    expect(types[9].displayOrder).toBe(10);
+  });
+
+  it('findAll() includes only active entries', async () => {
+    const types = await repo.findAll();
+    expect(types.every((t) => t.isActive)).toBe(true);
+  });
+
+  it('findById() returns the correct entry', async () => {
+    const weather = await repo.findById('WEATHER');
+    expect(weather).not.toBeNull();
+    expect(weather!.label).toBe('Bad weather');
+    expect(weather!.displayOrder).toBe(1);
+  });
+
+  it('findById() returns null for unknown id', async () => {
+    const missing = await repo.findById('NONEXISTENT');
+    expect(missing).toBeNull();
+  });
+});

--- a/__tests__/integration/DrizzleTaskRepository.delayStats.integration.test.ts
+++ b/__tests__/integration/DrizzleTaskRepository.delayStats.integration.test.ts
@@ -1,0 +1,129 @@
+// Integration test: DrizzleTaskRepository — resolveDelayReason & summarizeDelayReasons
+
+jest.mock('react-native-sqlite-storage', () => {
+  function createAdapter(db: any) {
+    return {
+      executeSql: async (sql: string, params: any[] = []) => {
+        const stmt = sql.trim();
+        const upper = stmt.toUpperCase();
+        if (upper.startsWith('SELECT')) {
+          const rows = db.prepare(stmt).all(...params);
+          return [{ rows: { length: rows.length, item: (i: number) => rows[i] } }];
+        }
+        if (params && params.length > 0) {
+          try {
+            const prepared = db.prepare(stmt);
+            prepared.run(...params);
+            return [{ rows: { length: 0, item: (_: number) => undefined } }];
+          } catch {
+            // fallthrough
+          }
+        }
+        if (stmt) db.exec(stmt);
+        return [{ rows: { length: 0, item: (_: number) => undefined } }];
+      },
+      transaction: async (fn: any) => {
+        db.exec('BEGIN');
+        try {
+          const tx = { executeSql: (sql: string, params?: any[]) => createAdapter(db).executeSql(sql, params) };
+          await fn(tx);
+          db.exec('COMMIT');
+        } catch (err) {
+          db.exec('ROLLBACK');
+          throw err;
+        }
+      },
+      close: async () => db.close(),
+    };
+  }
+  return {
+    enablePromise: (_: boolean) => {},
+    openDatabase: async (_: any) => {
+      const BetterSqlite3 = require('better-sqlite3');
+      const db = new BetterSqlite3(':memory:');
+      return createAdapter(db);
+    },
+  };
+});
+
+import { DrizzleTaskRepository } from '../../src/infrastructure/repositories/DrizzleTaskRepository';
+import { TaskEntity } from '../../src/domain/entities/Task';
+import { initDatabase } from '../../src/infrastructure/database/connection';
+
+describe('DrizzleTaskRepository — resolveDelayReason & summarizeDelayReasons (integration)', () => {
+  let repo: DrizzleTaskRepository;
+
+  // Create two tasks with several delay entries
+  const taskA = TaskEntity.create({ title: 'Task for resolve', status: 'pending' });
+  const taskB = TaskEntity.create({ title: 'Task for stats', status: 'pending' });
+
+  beforeAll(async () => {
+    await initDatabase();
+    repo = new DrizzleTaskRepository();
+
+    await repo.save(taskA.data());
+    await repo.save(taskB.data());
+
+    // Add 2 WEATHER + 1 MATERIAL_DELAY to taskA
+    await repo.addDelayReason({ taskId: taskA.data().id, reasonTypeId: 'WEATHER' });
+    await repo.addDelayReason({ taskId: taskA.data().id, reasonTypeId: 'WEATHER' });
+    await repo.addDelayReason({ taskId: taskA.data().id, reasonTypeId: 'MATERIAL_DELAY' });
+
+    // Add 1 OTHER to taskB
+    await repo.addDelayReason({ taskId: taskB.data().id, reasonTypeId: 'OTHER' });
+  });
+
+  describe('resolveDelayReason', () => {
+    it('sets resolvedAt on the delay record', async () => {
+      const reasons = await repo.findDelayReasons(taskA.data().id);
+      const first = reasons[0];
+      expect(first.resolvedAt).toBeUndefined();
+
+      const ts = new Date().toISOString();
+      await repo.resolveDelayReason(first.id, ts, 'Rain stopped');
+
+      const updated = await repo.findDelayReasons(taskA.data().id);
+      const resolved = updated.find((r) => r.id === first.id);
+      expect(resolved).toBeDefined();
+      expect(resolved!.resolvedAt).toBeTruthy();
+      expect(resolved!.mitigationNotes).toBe('Rain stopped');
+    });
+
+    it('does not affect other delay records on the same task', async () => {
+      const reasons = await repo.findDelayReasons(taskA.data().id);
+      const unresolvedCount = reasons.filter((r) => !r.resolvedAt).length;
+      expect(unresolvedCount).toBe(2); // two remaining unresolved
+    });
+  });
+
+  describe('summarizeDelayReasons', () => {
+    it('returns counts grouped by reason type, sorted descending by count', async () => {
+      const summary = await repo.summarizeDelayReasons(taskA.data().id);
+
+      expect(summary).toHaveLength(2);
+      // WEATHER appears twice; MATERIAL_DELAY once
+      expect(summary[0].reasonTypeId).toBe('WEATHER');
+      expect(summary[0].count).toBe(2);
+      expect(summary[1].reasonTypeId).toBe('MATERIAL_DELAY');
+      expect(summary[1].count).toBe(1);
+    });
+
+    it('returns global summary when taskId is omitted', async () => {
+      const summary = await repo.summarizeDelayReasons();
+
+      // Across both tasks: WEATHER×2, MATERIAL_DELAY×1, OTHER×1
+      expect(summary.length).toBeGreaterThanOrEqual(3);
+      const weatherRow = summary.find((r) => r.reasonTypeId === 'WEATHER');
+      expect(weatherRow).toBeDefined();
+      expect(weatherRow!.count).toBe(2);
+    });
+
+    it('returns empty array for a task with no delay reasons', async () => {
+      const emptyTask = TaskEntity.create({ title: 'No delays', status: 'pending' });
+      await repo.save(emptyTask.data());
+
+      const summary = await repo.summarizeDelayReasons(emptyTask.data().id);
+      expect(summary).toEqual([]);
+    });
+  });
+});

--- a/__tests__/unit/AddDelayReasonUseCase.test.ts
+++ b/__tests__/unit/AddDelayReasonUseCase.test.ts
@@ -27,6 +27,8 @@ function makeMockTaskRepo(overrides: Partial<TaskRepository> = {}): TaskReposito
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/__tests__/unit/AddTaskDependencyUseCase.test.ts
+++ b/__tests__/unit/AddTaskDependencyUseCase.test.ts
@@ -22,6 +22,8 @@ function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/__tests__/unit/CreateTaskFromPhotoUseCase.test.ts
+++ b/__tests__/unit/CreateTaskFromPhotoUseCase.test.ts
@@ -40,6 +40,8 @@ function makeTaskRepo(): jest.Mocked<TaskRepository> {
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
   };
 }
 

--- a/__tests__/unit/DeleteTaskUseCase.test.ts
+++ b/__tests__/unit/DeleteTaskUseCase.test.ts
@@ -20,6 +20,8 @@ function makeMockTaskRepo(overrides: Partial<TaskRepository> = {}): TaskReposito
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/__tests__/unit/GetDelayStatisticsUseCase.test.ts
+++ b/__tests__/unit/GetDelayStatisticsUseCase.test.ts
@@ -1,0 +1,105 @@
+import { GetDelayStatisticsUseCase } from '../../src/application/usecases/task/GetDelayStatisticsUseCase';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+import { DelayReasonTypeRepository } from '../../src/domain/repositories/DelayReasonTypeRepository';
+import { DelayReasonType } from '../../src/domain/entities/DelayReason';
+
+function makeMockTaskRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
+    deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
+    deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeMockTypeRepo(
+  types: DelayReasonType[] = [
+    { id: 'WEATHER', label: 'Bad weather', displayOrder: 1, isActive: true },
+    { id: 'MATERIAL_DELAY', label: 'Material / supply delay', displayOrder: 2, isActive: true },
+    { id: 'OTHER', label: 'Other', displayOrder: 10, isActive: true },
+  ],
+): DelayReasonTypeRepository {
+  return {
+    findAll: jest.fn().mockResolvedValue(types),
+    findById: jest.fn().mockImplementation(async (id: string) => types.find((t) => t.id === id) ?? null),
+  };
+}
+
+describe('GetDelayStatisticsUseCase', () => {
+  it('returns empty array when no delay reasons exist', async () => {
+    const taskRepo = makeMockTaskRepo({ summarizeDelayReasons: jest.fn().mockResolvedValue([]) });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new GetDelayStatisticsUseCase(taskRepo, typeRepo);
+
+    const result = await uc.execute();
+    expect(result).toEqual([]);
+  });
+
+  it('merges summary counts with human-readable labels', async () => {
+    const taskRepo = makeMockTaskRepo({
+      summarizeDelayReasons: jest.fn().mockResolvedValue([
+        { reasonTypeId: 'WEATHER', count: 5 },
+        { reasonTypeId: 'MATERIAL_DELAY', count: 2 },
+      ]),
+    });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new GetDelayStatisticsUseCase(taskRepo, typeRepo);
+
+    const result = await uc.execute();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ reasonTypeId: 'WEATHER', label: 'Bad weather', count: 5 });
+    expect(result[1]).toEqual({ reasonTypeId: 'MATERIAL_DELAY', label: 'Material / supply delay', count: 2 });
+  });
+
+  it('uses reasonTypeId as fallback label if not found in type catalog', async () => {
+    const taskRepo = makeMockTaskRepo({
+      summarizeDelayReasons: jest.fn().mockResolvedValue([
+        { reasonTypeId: 'UNKNOWN_CUSTOM', count: 1 },
+      ]),
+    });
+    const typeRepo = makeMockTypeRepo(); // does not contain UNKNOWN_CUSTOM
+    const uc = new GetDelayStatisticsUseCase(taskRepo, typeRepo);
+
+    const result = await uc.execute();
+    expect(result[0].label).toBe('UNKNOWN_CUSTOM');
+  });
+
+  it('passes taskId filter through to the repository', async () => {
+    const summarizeDelayReasons = jest.fn().mockResolvedValue([]);
+    const taskRepo = makeMockTaskRepo({ summarizeDelayReasons });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new GetDelayStatisticsUseCase(taskRepo, typeRepo);
+
+    await uc.execute({ taskId: 'task-42' });
+
+    expect(summarizeDelayReasons).toHaveBeenCalledWith('task-42');
+  });
+
+  it('calls summarizeDelayReasons with undefined when no taskId provided', async () => {
+    const summarizeDelayReasons = jest.fn().mockResolvedValue([]);
+    const taskRepo = makeMockTaskRepo({ summarizeDelayReasons });
+    const typeRepo = makeMockTypeRepo();
+    const uc = new GetDelayStatisticsUseCase(taskRepo, typeRepo);
+
+    await uc.execute({});
+
+    expect(summarizeDelayReasons).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/__tests__/unit/GetTaskDetailUseCase.test.ts
+++ b/__tests__/unit/GetTaskDetailUseCase.test.ts
@@ -22,6 +22,8 @@ function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/__tests__/unit/RemoveDelayReasonUseCase.test.ts
+++ b/__tests__/unit/RemoveDelayReasonUseCase.test.ts
@@ -20,6 +20,8 @@ function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/__tests__/unit/RemoveTaskDependencyUseCase.test.ts
+++ b/__tests__/unit/RemoveTaskDependencyUseCase.test.ts
@@ -20,6 +20,8 @@ function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
     findDelayReasons: jest.fn().mockResolvedValue([]),
     deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
     deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/__tests__/unit/ResolveDelayReasonUseCase.test.ts
+++ b/__tests__/unit/ResolveDelayReasonUseCase.test.ts
@@ -1,0 +1,65 @@
+import { ResolveDelayReasonUseCase } from '../../src/application/usecases/task/ResolveDelayReasonUseCase';
+import { TaskRepository } from '../../src/domain/repositories/TaskRepository';
+
+function makeMockRepo(overrides: Partial<TaskRepository> = {}): TaskRepository {
+  return {
+    save: jest.fn(),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+    addDependency: jest.fn(),
+    removeDependency: jest.fn(),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn(),
+    removeDelayReason: jest.fn(),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
+    deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
+    deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('ResolveDelayReasonUseCase', () => {
+  it('calls resolveDelayReason with the provided id and timestamp', async () => {
+    const repo = makeMockRepo();
+    const uc = new ResolveDelayReasonUseCase(repo);
+    const ts = '2026-03-03T12:00:00.000Z';
+
+    await uc.execute({ delayReasonId: 'delay-1', resolvedAt: ts });
+
+    expect(repo.resolveDelayReason).toHaveBeenCalledWith('delay-1', ts, undefined);
+  });
+
+  it('defaults resolvedAt to now when not provided', async () => {
+    const before = Date.now();
+    const repo = makeMockRepo();
+    const uc = new ResolveDelayReasonUseCase(repo);
+
+    await uc.execute({ delayReasonId: 'delay-2' });
+
+    const [, calledTs] = (repo.resolveDelayReason as jest.Mock).mock.calls[0];
+    const calledMs = new Date(calledTs).getTime();
+    expect(calledMs).toBeGreaterThanOrEqual(before);
+    expect(calledMs).toBeLessThanOrEqual(Date.now() + 50);
+  });
+
+  it('passes mitigationNotes through', async () => {
+    const repo = makeMockRepo();
+    const uc = new ResolveDelayReasonUseCase(repo);
+
+    await uc.execute({ delayReasonId: 'delay-3', mitigationNotes: 'Ordered from backup supplier' });
+
+    expect(repo.resolveDelayReason).toHaveBeenCalledWith(
+      'delay-3',
+      expect.any(String),
+      'Ordered from backup supplier',
+    );
+  });
+});

--- a/__tests__/unit/TasksScreen.test.tsx
+++ b/__tests__/unit/TasksScreen.test.tsx
@@ -87,6 +87,7 @@ function buildHookReturn(
     removeDependency: jest.fn(),
     addDelayReason: jest.fn(),
     removeDelayReason: jest.fn(),
+    resolveDelayReason: jest.fn(),
   };
 }
 

--- a/__tests__/unit/useDelayReasonTypes.test.tsx
+++ b/__tests__/unit/useDelayReasonTypes.test.tsx
@@ -1,0 +1,101 @@
+import renderer, { act } from 'react-test-renderer';
+import React, { useEffect } from 'react';
+import { container } from 'tsyringe';
+import { useDelayReasonTypes } from '../../src/hooks/useDelayReasonTypes';
+import { DelayReasonType } from '../../src/domain/entities/DelayReason';
+
+const seededTypes: DelayReasonType[] = [
+  { id: 'WEATHER', label: 'Bad weather', displayOrder: 1, isActive: true },
+  { id: 'MATERIAL_DELAY', label: 'Material / supply delay', displayOrder: 2, isActive: true },
+  { id: 'OTHER', label: 'Other', displayOrder: 10, isActive: true },
+];
+
+describe('useDelayReasonTypes hook', () => {
+  const mockRepo = {
+    findAll: jest.fn(),
+    findById: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(container, 'resolve').mockReturnValue(mockRepo);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads delay reason types on mount', async () => {
+    mockRepo.findAll.mockResolvedValueOnce(seededTypes);
+
+    let latest: any = null;
+
+    function TestHarness() {
+      const state = useDelayReasonTypes();
+      useEffect(() => { latest = state; }, [state]);
+      return null;
+    }
+
+    await act(async () => {
+      renderer.create(<TestHarness />);
+      for (let i = 0; i < 20; i++) {
+        if (latest && latest.loading === false) break;
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+      }
+    });
+
+    expect(latest.loading).toBe(false);
+    expect(latest.delayReasonTypes).toHaveLength(3);
+    expect(latest.delayReasonTypes[0].id).toBe('WEATHER');
+    expect(mockRepo.findAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array and loading=false when repository throws', async () => {
+    mockRepo.findAll.mockRejectedValueOnce(new Error('DB error'));
+
+    let latest: any = null;
+
+    function TestHarness() {
+      const state = useDelayReasonTypes();
+      useEffect(() => { latest = state; }, [state]);
+      return null;
+    }
+
+    await act(async () => {
+      renderer.create(<TestHarness />);
+      for (let i = 0; i < 20; i++) {
+        if (latest && latest.loading === false) break;
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+      }
+    });
+
+    expect(latest.loading).toBe(false);
+    expect(latest.delayReasonTypes).toEqual([]);
+  });
+
+  it('refresh() re-fetches types from the repository', async () => {
+    mockRepo.findAll.mockResolvedValue(seededTypes);
+
+    let latest: any = null;
+
+    function TestHarness() {
+      const state = useDelayReasonTypes();
+      useEffect(() => { latest = state; }, [state]);
+      return null;
+    }
+
+    await act(async () => {
+      renderer.create(<TestHarness />);
+      for (let i = 0; i < 20; i++) {
+        if (latest && latest.loading === false) break;
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+      }
+    });
+
+    await act(async () => {
+      await latest.refresh();
+    });
+
+    expect(mockRepo.findAll).toHaveBeenCalledTimes(2);
+  });
+});

--- a/design/issue-110-delay-reasons.md
+++ b/design/issue-110-delay-reasons.md
@@ -1,0 +1,322 @@
+# Design: Issue #110 — Capture Task Delay Reasons
+
+**Status**: DRAFT — Awaiting Approval  
+**Date**: 2026-03-03  
+**Branch**: `issue-110-delay-reasons`  
+**Parent issue**: #107
+
+---
+
+## 1. User Story
+
+> As a builder, I can record one or more delay reasons for a Task so that the project history reflects why work was postponed.  
+> As a manager, I can view the delay history on the Task Detail screen and understand the most common causes of delays.  
+> As a scheduler, I can mark a Task as "postponed" with a primary reason and optional mitigation notes.
+
+---
+
+## 2. Current State (What Already Exists)
+
+| Area | Current state |
+|---|---|
+| `Task.status` | `'pending' \| 'in_progress' \| 'completed' \| 'blocked' \| 'cancelled'` — **no `postponed` status** |
+| `TaskDelay` entity | **Does not exist** |
+| `task_delays` table | **Does not exist** |
+| `ITaskDelayRepository` | **Does not exist** |
+| Delay-related use cases | **None** |
+| UI components | **None** |
+| Latest migration | `0011_add_property_coords` → next is `0012` |
+
+Everything in this design is **net-new**. No existing code will be removed; only additive changes are made.
+
+---
+
+## 3. Domain Model
+
+### 3.1 `DelayReason` enum
+
+A canonical string-enum defined in the domain layer. This is the **exhaustive catalog** described in the issue; `OTHER` enables free-text fallback.
+
+```typescript
+// src/domain/entities/TaskDelay.ts
+export type DelayReason =
+  | 'WEATHER'
+  | 'SICKNESS'
+  | 'MATERIAL_SHORTAGE'
+  | 'SUPPLY_CHAIN'
+  | 'UTILITY_DISCOVERY'
+  | 'NO_SHOW'
+  | 'REGULATORY_HOLD'
+  | 'CLIENT_DECISION_DELAY'
+  | 'INSPECTION_FAILURE'
+  | 'EQUIPMENT_FAILURE'
+  | 'ACCESS_RESTRICTION'
+  | 'SAFETY_INCIDENT'
+  | 'DESIGN_CHANGE'
+  | 'LABOR_SHORTAGE'
+  | 'TRANSPORT_DISRUPTION'
+  | 'FINANCIAL_ISSUE'
+  | 'THEFT_VANDALISM'
+  | 'ENVIRONMENTAL_DISCOVERY'
+  | 'ARCHAEOLOGICAL_FIND'
+  | 'PUBLIC_HOLIDAY'
+  | 'EPIDEMIC'
+  | 'OTHER';
+```
+
+A human-readable label mapping (`DELAY_REASON_LABELS`) will also be exported for UI display.
+
+### 3.2 `TaskDelay` entity
+
+```typescript
+export interface TaskDelay {
+  id: string;
+  localId?: number;            // SQLite autoincrement PK
+  taskId: string;              // FK → tasks.id
+  reason: DelayReason;
+  reasonDetails?: string;      // free-text; required when reason = 'OTHER'
+  reportedBy?: string;         // contactId or free-text name
+  reportedAt: string;          // ISO timestamp — defaults to now()
+  estimatedDelayDays?: number; // optional forecast
+  resolvedAt?: string;         // ISO timestamp — filled when delay is lifted
+  mitigationNotes?: string;    // optional resolution / workaround notes
+  createdAt?: string;
+  updatedAt?: string;
+}
+```
+
+A task can have **many** `TaskDelay` records (one per delay event).
+
+### 3.3 `Task` status extension
+
+Add `'postponed'` to the existing status union:
+
+```typescript
+// src/domain/entities/Task.ts
+status: 'pending' | 'in_progress' | 'completed' | 'blocked' | 'cancelled' | 'postponed';
+```
+
+A task is set to `postponed` when `PostponeTaskUseCase` is called. It transitions back to the previous active status (or `pending`) when a delay is resolved.
+
+---
+
+## 4. Repository Interface
+
+```typescript
+// src/domain/repositories/ITaskDelayRepository.ts
+export interface ITaskDelayRepository {
+  save(delay: TaskDelay): Promise<void>;
+  findByTaskId(taskId: string): Promise<TaskDelay[]>;
+  findById(id: string): Promise<TaskDelay | null>;
+  update(delay: TaskDelay): Promise<void>;
+  delete(id: string): Promise<void>;
+  findUnresolved(taskId: string): Promise<TaskDelay[]>;
+  summarizeByReason(taskId?: string): Promise<{ reason: DelayReason; count: number }[]>;
+}
+```
+
+---
+
+## 5. Database Schema
+
+### 5.1 `task_delays` table (new)
+
+```typescript
+// Addition to src/infrastructure/database/schema.ts
+export const taskDelays = sqliteTable('task_delays', {
+  localId: integer('local_id').primaryKey({ autoIncrement: true }),
+  id: text('id').notNull().unique(),
+  taskId: text('task_id').notNull(),
+  reason: text('reason').notNull(),         // DelayReason string
+  reasonDetails: text('reason_details'),
+  reportedBy: text('reported_by'),
+  reportedAt: integer('reported_at').notNull(), // Unix timestamp ms
+  estimatedDelayDays: real('estimated_delay_days'),
+  resolvedAt: integer('resolved_at'),           // Unix timestamp ms, nullable
+  mitigationNotes: text('mitigation_notes'),
+  createdAt: integer('created_at'),
+  updatedAt: integer('updated_at'),
+}, (table) => ({
+  taskIdx: index('idx_task_delays_task').on(table.taskId),
+  reasonIdx: index('idx_task_delays_reason').on(table.reason),
+  resolvedIdx: index('idx_task_delays_resolved').on(table.resolvedAt),
+}));
+```
+
+### 5.2 `tasks` table — `'postponed'` status column update
+
+SQLite `text` columns with `enum` metadata are enforced only at the application layer; no migration DDL is needed to add a new status string. However, we document the expected migration entry (a no-op migration) to preserve migration alignment across environments.
+
+### 5.3 Migration `0012_add_task_delays`
+
+```sql
+CREATE TABLE `task_delays` (
+  `local_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `id` TEXT NOT NULL,
+  `task_id` TEXT NOT NULL,
+  `reason` TEXT NOT NULL,
+  `reason_details` TEXT,
+  `reported_by` TEXT,
+  `reported_at` INTEGER NOT NULL,
+  `estimated_delay_days` REAL,
+  `resolved_at` INTEGER,
+  `mitigation_notes` TEXT,
+  `created_at` INTEGER,
+  `updated_at` INTEGER
+);
+CREATE UNIQUE INDEX `task_delays_id_unique` ON `task_delays` (`id`);
+CREATE INDEX `idx_task_delays_task` ON `task_delays` (`task_id`);
+CREATE INDEX `idx_task_delays_reason` ON `task_delays` (`reason`);
+CREATE INDEX `idx_task_delays_resolved` ON `task_delays` (`resolved_at`);
+```
+
+---
+
+## 6. Use Cases
+
+All in `src/application/usecases/task/`.
+
+### 6.1 `RecordTaskDelayUseCase`
+
+**Input**: `{ taskId, reason, reasonDetails?, reportedBy?, reportedAt?, estimatedDelayDays?, mitigationNotes? }`  
+**Behaviour**:
+- Validates that `taskId` resolves to an existing task.
+- Validates `reasonDetails` is non-empty when `reason === 'OTHER'`.
+- Creates a `TaskDelay` record and persists via `ITaskDelayRepository.save()`.
+- Does **not** auto-change task status (status change is `PostponeTaskUseCase`'s concern).
+
+### 6.2 `PostponeTaskUseCase`
+
+**Input**: `{ taskId, reason, reasonDetails?, reportedBy?, estimatedDelayDays?, mitigationNotes? }`  
+**Behaviour**:
+- Changes `Task.status` to `'postponed'` via `TaskRepository.update()`.
+- Creates a `TaskDelay` record (calls `RecordTaskDelayUseCase` internally or inline).
+- Idempotent: calling on an already-postponed task records an additional delay entry without error.
+
+### 6.3 `ResolveTaskDelayUseCase`
+
+**Input**: `{ delayId, resolvedAt?, mitigationNotes? }`  
+**Behaviour**:
+- Sets `TaskDelay.resolvedAt` and optionally `mitigationNotes`.
+- If all delays for the task are resolved, optionally transitions the task's status back to `pending` (configurable flag `resumeTask: boolean`, default `true`).
+
+### 6.4 `ListTaskDelaysUseCase`
+
+**Input**: `{ taskId }`  
+**Output**: `TaskDelay[]` ordered by `reportedAt` descending.
+
+### 6.5 `GetDelayStatisticsUseCase`
+
+**Input**: `{ taskId?: string }` — omitting `taskId` returns global summary.  
+**Output**: `{ reason: DelayReason; label: string; count: number }[]` sorted by count descending.  
+Used by the reporting / analytics screen.
+
+---
+
+## 7. Hook
+
+```typescript
+// src/hooks/useTaskDelays.ts
+export interface UseTaskDelaysReturn {
+  delays: TaskDelay[];
+  loading: boolean;
+  recordDelay: (input: RecordDelayInput) => Promise<void>;
+  postponeTask: (input: PostponeInput) => Promise<void>;
+  resolveDelay: (delayId: string, opts?: ResolveOptions) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useTaskDelays(taskId: string): UseTaskDelaysReturn { ... }
+```
+
+---
+
+## 8. UI Components
+
+### 8.1 `TaskDelayHistoryList`
+
+- `src/components/tasks/TaskDelayHistoryList.tsx`
+- Renders an ordered list of `TaskDelay` entries: reason label + optional details, reporter, date, resolved badge.
+- Empty state: "No delays recorded."
+
+### 8.2 `RecordDelayModal`
+
+- `src/components/tasks/RecordDelayModal.tsx`
+- Full-screen modal (RN `Modal`) or bottom sheet.
+- Fields: reason picker (scrollable list or dropdown), details text input (required for OTHER), reporter name field, estimated delay days, mitigation notes.
+- CTA: "Record Delay" (calls `recordDelay`) and "Postpone Task" (calls `postponeTask`).
+
+### 8.3 Task Detail integration
+
+- In the task detail / edit page (`src/pages/tasks/EditTaskPage.tsx`), add:
+  - "Add Delay" button → opens `RecordDelayModal`.
+  - `<TaskDelayHistoryList taskId={task.id} />` section beneath task details.
+  - Task status badge renders `postponed` with a distinct colour (e.g. amber).
+
+### 8.4 Task Card (optional — nice-to-have)
+
+- Show a small "🚫 Postponed" chip on the task list card when `status === 'postponed'`.
+
+---
+
+## 9. DI Registration
+
+```typescript
+// src/infrastructure/di/registerServices.ts additions
+container.registerSingleton('TaskDelayRepository', DrizzleTaskDelayRepository);
+```
+
+---
+
+## 10. Test Plan
+
+### Unit tests (`__tests__/unit/`)
+
+| File | Coverage |
+|---|---|
+| `RecordTaskDelayUseCase.test.ts` | Validates `OTHER` requires details; creates delay; rejects unknown taskId. |
+| `PostponeTaskUseCase.test.ts` | Sets status to `postponed`; records delay; idempotent second call. |
+| `ResolveTaskDelayUseCase.test.ts` | Sets `resolvedAt`; resumes task if all delays resolved; respects `resumeTask: false`. |
+| `GetDelayStatisticsUseCase.test.ts` | Groups by reason, sorts by count, includes unresolved only option. |
+| `useTaskDelays.test.tsx` | Hook state transitions; `recordDelay`, `postponeTask`, `resolveDelay` calls. |
+
+### Integration tests (`__tests__/integration/`)
+
+| File | Coverage |
+|---|---|
+| `DrizzleTaskDelayRepository.integration.test.ts` | Migration applied; save→findByTaskId roundtrip; `summarizeByReason`; unresolved filter. |
+| `TaskDelayFlow.integration.test.tsx` | Full postpone → resolve flow through hooks + in-memory DB. |
+
+---
+
+## 11. Out of Scope (This Ticket)
+
+- Export / reporting screen UI (delay summary report) — schema supports it; UI deferred.
+- Push notifications when a task is postponed.
+- Delay reason seeding from a remote catalog — local enum is sufficient.
+- Cascade delete of `task_delays` when a task is deleted — documented as a follow-up.
+
+---
+
+## 12. Implementation Order (TDD)
+
+1. `TaskDelay` entity + `DelayReason` enum + `DELAY_REASON_LABELS` map.
+2. `ITaskDelayRepository` interface.
+3. Unit tests (red) for all four use cases.
+4. `DrizzleTaskDelayRepository` implementation + migration `0012`.
+5. Integration test for repository (red → green).
+6. Use case implementations (green all unit tests).
+7. `useTaskDelays` hook + hook unit tests.
+8. `TaskDelayHistoryList` + `RecordDelayModal` components.
+9. Wire into `EditTaskPage`.
+10. Full Jest run + `npx tsc --noEmit` clean.
+
+---
+
+## 13. Open Questions
+
+*None — all acceptance criteria from the issue are addressed above.*
+
+---
+
+**APPROVAL REQUIRED before implementation begins.**

--- a/src/application/usecases/task/GetDelayStatisticsUseCase.ts
+++ b/src/application/usecases/task/GetDelayStatisticsUseCase.ts
@@ -1,0 +1,35 @@
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+import { DelayReasonTypeRepository } from '../../../domain/repositories/DelayReasonTypeRepository';
+
+export interface DelayStatEntry {
+  reasonTypeId: string;
+  label: string;
+  count: number;
+}
+
+export interface GetDelayStatisticsInput {
+  /** Filter to a single task; omit for project-wide / global summary. */
+  taskId?: string;
+}
+
+export class GetDelayStatisticsUseCase {
+  constructor(
+    private readonly taskRepository: TaskRepository,
+    private readonly delayReasonTypeRepository: DelayReasonTypeRepository,
+  ) {}
+
+  async execute(input: GetDelayStatisticsInput = {}): Promise<DelayStatEntry[]> {
+    const [summary, types] = await Promise.all([
+      this.taskRepository.summarizeDelayReasons(input.taskId),
+      this.delayReasonTypeRepository.findAll(),
+    ]);
+
+    const labelMap = new Map(types.map((t) => [t.id, t.label]));
+
+    return summary.map((row) => ({
+      reasonTypeId: row.reasonTypeId,
+      label: labelMap.get(row.reasonTypeId) ?? row.reasonTypeId,
+      count: row.count,
+    }));
+  }
+}

--- a/src/application/usecases/task/ResolveDelayReasonUseCase.ts
+++ b/src/application/usecases/task/ResolveDelayReasonUseCase.ts
@@ -1,0 +1,17 @@
+import { TaskRepository } from '../../../domain/repositories/TaskRepository';
+
+export interface ResolveDelayReasonInput {
+  delayReasonId: string;
+  resolvedAt?: string;       // ISO date string; defaults to now
+  mitigationNotes?: string;
+}
+
+export class ResolveDelayReasonUseCase {
+  constructor(private readonly taskRepository: TaskRepository) {}
+
+  async execute(input: ResolveDelayReasonInput): Promise<void> {
+    const { delayReasonId, resolvedAt, mitigationNotes } = input;
+    const ts = resolvedAt ?? new Date().toISOString();
+    await this.taskRepository.resolveDelayReason(delayReasonId, ts, mitigationNotes);
+  }
+}

--- a/src/components/tasks/TaskDelaySection.tsx
+++ b/src/components/tasks/TaskDelaySection.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { DelayReason } from '../../domain/entities/DelayReason';
-import { Clock, Plus } from 'lucide-react-native';
+import { Clock, Plus, CheckCircle } from 'lucide-react-native';
 import { cssInterop } from 'nativewind';
 
 cssInterop(Clock, { className: { target: 'style', nativeStyleToProp: { color: true } } });
 cssInterop(Plus, { className: { target: 'style', nativeStyleToProp: { color: true } } });
+cssInterop(CheckCircle, { className: { target: 'style', nativeStyleToProp: { color: true } } });
 
 interface Props {
   delayReasons: DelayReason[];
   onAddDelay?: () => void;
   onRemoveDelay?: (id: string) => void;
+  onResolveDelay?: (id: string) => void;
 }
 
-export function TaskDelaySection({ delayReasons, onAddDelay, onRemoveDelay }: Props) {
+export function TaskDelaySection({ delayReasons, onAddDelay, onRemoveDelay, onResolveDelay }: Props) {
   return (
     <View className="bg-card p-4 rounded-lg border border-border">
       <View className="flex-row justify-between items-center mb-3">
@@ -39,15 +41,29 @@ export function TaskDelaySection({ delayReasons, onAddDelay, onRemoveDelay }: Pr
                     {reason.reasonTypeLabel || reason.reasonTypeId}
                   </Text>
                 </View>
-                {reason.delayDurationDays != null && (
-                  <Text className="text-xs text-muted-foreground">
-                    {reason.delayDurationDays}d
-                  </Text>
-                )}
+                <View className="flex-row items-center gap-2">
+                  {reason.resolvedAt ? (
+                    <View className="flex-row items-center gap-1">
+                      <CheckCircle size={14} className="text-green-600" />
+                      <Text className="text-xs text-green-600 font-medium">Resolved</Text>
+                    </View>
+                  ) : (
+                    <Text className="text-xs bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200 px-2 py-0.5 rounded-full">Open</Text>
+                  )}
+                  {reason.delayDurationDays != null && (
+                    <Text className="text-xs text-muted-foreground">
+                      {reason.delayDurationDays}d
+                    </Text>
+                  )}
+                </View>
               </View>
 
               {reason.notes && (
                 <Text className="text-sm text-muted-foreground mt-1 ml-6">{reason.notes}</Text>
+              )}
+
+              {reason.mitigationNotes && reason.resolvedAt && (
+                <Text className="text-sm text-muted-foreground italic mt-1 ml-6">↳ {reason.mitigationNotes}</Text>
               )}
 
               <View className="flex-row items-center gap-3 mt-2 ml-6">
@@ -59,19 +75,28 @@ export function TaskDelaySection({ delayReasons, onAddDelay, onRemoveDelay }: Pr
                 {reason.actor && (
                   <Text className="text-xs text-muted-foreground">{reason.actor}</Text>
                 )}
+                {reason.resolvedAt && (
+                  <Text className="text-xs text-muted-foreground">
+                    Resolved {new Date(reason.resolvedAt).toLocaleDateString()}
+                  </Text>
+                )}
                 <Text className="text-xs text-muted-foreground">
                   {new Date(reason.createdAt).toLocaleDateString()}
                 </Text>
               </View>
 
-              {onRemoveDelay && (
-                <TouchableOpacity
-                  onPress={() => onRemoveDelay(reason.id)}
-                  className="mt-2 ml-6"
-                >
-                  <Text className="text-xs text-destructive">Remove</Text>
-                </TouchableOpacity>
-              )}
+              <View className="flex-row gap-3 mt-2 ml-6">
+                {!reason.resolvedAt && onResolveDelay && (
+                  <TouchableOpacity onPress={() => onResolveDelay(reason.id)}>
+                    <Text className="text-xs text-green-600 font-medium">Mark Resolved</Text>
+                  </TouchableOpacity>
+                )}
+                {onRemoveDelay && (
+                  <TouchableOpacity onPress={() => onRemoveDelay(reason.id)}>
+                    <Text className="text-xs text-destructive">Remove</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
             </View>
           ))}
         </View>

--- a/src/domain/entities/DelayReason.ts
+++ b/src/domain/entities/DelayReason.ts
@@ -10,9 +10,11 @@ export interface DelayReason {
   taskId: string;
   reasonTypeId: string;        // FK to DelayReasonType.id
   reasonTypeLabel?: string;    // denormalised label for display (populated by repo)
-  notes?: string;              // optional supplemental free text
-  delayDurationDays?: number;
-  delayDate?: string;          // ISO date string
-  actor?: string;
+  notes?: string;              // optional supplemental free text (reasonDetails)
+  delayDurationDays?: number;  // estimatedDelayDays
+  delayDate?: string;          // reportedAt — ISO date string
+  actor?: string;              // reportedBy
+  resolvedAt?: string;         // ISO date string — set when the delay is lifted
+  mitigationNotes?: string;    // optional resolution / workaround notes
   createdAt: string;
 }

--- a/src/domain/repositories/TaskRepository.ts
+++ b/src/domain/repositories/TaskRepository.ts
@@ -20,7 +20,10 @@ export interface TaskRepository {
   // Delay reasons
   addDelayReason(entry: Omit<DelayReason, 'id' | 'createdAt'>): Promise<DelayReason>;
   removeDelayReason(delayReasonId: string): Promise<void>;
+  resolveDelayReason(delayReasonId: string, resolvedAt: string, mitigationNotes?: string): Promise<void>;
   findDelayReasons(taskId: string): Promise<DelayReason[]>;
+  /** Returns counts per reason type, optionally filtered to a single task. */
+  summarizeDelayReasons(taskId?: string): Promise<{ reasonTypeId: string; count: number }[]>;
 
   // Cascade helpers (used by DeleteTaskUseCase)
   deleteDependenciesByTaskId(taskId: string): Promise<void>;

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -15,6 +15,7 @@ import { AddTaskDependencyUseCase } from '../application/usecases/task/AddTaskDe
 import { RemoveTaskDependencyUseCase } from '../application/usecases/task/RemoveTaskDependencyUseCase';
 import { AddDelayReasonUseCase, AddDelayReasonInput } from '../application/usecases/task/AddDelayReasonUseCase';
 import { RemoveDelayReasonUseCase } from '../application/usecases/task/RemoveDelayReasonUseCase';
+import { ResolveDelayReasonUseCase } from '../application/usecases/task/ResolveDelayReasonUseCase';
 
 export type { TaskDetail } from '../application/usecases/task/GetTaskDetailUseCase';
 export type { AddDelayReasonInput } from '../application/usecases/task/AddDelayReasonUseCase';
@@ -33,6 +34,7 @@ export interface UseTasksReturn {
   removeDependency: (taskId: string, dependsOnTaskId: string) => Promise<void>;
   addDelayReason: (taskId: string, input: Omit<AddDelayReasonInput, 'taskId'>) => Promise<DelayReason>;
   removeDelayReason: (delayReasonId: string) => Promise<void>;
+  resolveDelayReason: (delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => Promise<void>;
 }
 
 export function useTasks(projectId?: string): UseTasksReturn {
@@ -52,6 +54,7 @@ export function useTasks(projectId?: string): UseTasksReturn {
   const removeDependencyUseCase = useMemo(() => new RemoveTaskDependencyUseCase(taskRepository), [taskRepository]);
   const addDelayReasonUseCase = useMemo(() => new AddDelayReasonUseCase(taskRepository, delayReasonTypeRepository), [taskRepository, delayReasonTypeRepository]);
   const removeDelayReasonUseCase = useMemo(() => new RemoveDelayReasonUseCase(taskRepository), [taskRepository]);
+  const resolveDelayReasonUseCase = useMemo(() => new ResolveDelayReasonUseCase(taskRepository), [taskRepository]);
 
   const loadTasks = useCallback(async () => {
     setLoading(true);
@@ -120,6 +123,10 @@ export function useTasks(projectId?: string): UseTasksReturn {
     await removeDelayReasonUseCase.execute({ delayReasonId });
   }, [removeDelayReasonUseCase]);
 
+  const resolveDelayReason = useCallback(async (delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => {
+    await resolveDelayReasonUseCase.execute({ delayReasonId, resolvedAt, mitigationNotes });
+  }, [resolveDelayReasonUseCase]);
+
   return useMemo(() => ({
     tasks,
     loading,
@@ -133,5 +140,6 @@ export function useTasks(projectId?: string): UseTasksReturn {
     removeDependency,
     addDelayReason,
     removeDelayReason,
-  }), [tasks, loading, loadTasks, createTask, updateTask, deleteTask, getTask, getTaskDetail, addDependency, removeDependency, addDelayReason, removeDelayReason]);
+    resolveDelayReason,
+  }), [tasks, loading, loadTasks, createTask, updateTask, deleteTask, getTask, getTaskDetail, addDependency, removeDependency, addDelayReason, removeDelayReason, resolveDelayReason]);
 }

--- a/src/infrastructure/database/migrations.ts
+++ b/src/infrastructure/database/migrations.ts
@@ -697,6 +697,15 @@ const migrations: RNMigration[] = [
       `CREATE INDEX IF NOT EXISTS "idx_task_delays_task" ON "task_delay_reasons" ("task_id");`,
     ],
   },
+  {
+    tag: '0013_delay_reason_resolved_at',
+    hash: '0013_delay_reason_resolved_at',
+    folderMillis: 1772900000000,
+    sql: [
+      `ALTER TABLE "task_delay_reasons" ADD COLUMN "resolved_at" integer;`,
+      `ALTER TABLE "task_delay_reasons" ADD COLUMN "mitigation_notes" text;`,
+    ],
+  },
 ];
 
 export function getBundledMigrations(): RNMigration[] {

--- a/src/infrastructure/repositories/DrizzleTaskRepository.ts
+++ b/src/infrastructure/repositories/DrizzleTaskRepository.ts
@@ -283,6 +283,8 @@ export class DrizzleTaskRepository implements TaskRepository {
       delayDurationDays: entry.delayDurationDays,
       delayDate: entry.delayDate,
       actor: entry.actor,
+      resolvedAt: undefined,
+      mitigationNotes: undefined,
       createdAt: new Date(now).toISOString(),
     };
   }
@@ -316,6 +318,8 @@ export class DrizzleTaskRepository implements TaskRepository {
         delayDurationDays: row.delay_duration_days ?? undefined,
         delayDate: row.delay_date ? new Date(row.delay_date).toISOString() : undefined,
         actor: row.actor || undefined,
+        resolvedAt: row.resolved_at ? new Date(row.resolved_at).toISOString() : undefined,
+        mitigationNotes: row.mitigation_notes || undefined,
         createdAt: new Date(row.created_at).toISOString(),
       });
     }
@@ -338,5 +342,44 @@ export class DrizzleTaskRepository implements TaskRepository {
     await this.ensureInitialized();
     const { db } = getDatabase();
     await db.executeSql('DELETE FROM task_delay_reasons WHERE task_id = ?', [taskId]);
+  }
+
+  async resolveDelayReason(
+    delayReasonId: string,
+    resolvedAt: string,
+    mitigationNotes?: string,
+  ): Promise<void> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    await db.executeSql(
+      `UPDATE task_delay_reasons
+       SET resolved_at = ?, mitigation_notes = ?
+       WHERE id = ?`,
+      [
+        new Date(resolvedAt).getTime(),
+        mitigationNotes || null,
+        delayReasonId,
+      ],
+    );
+  }
+
+  async summarizeDelayReasons(taskId?: string): Promise<{ reasonTypeId: string; count: number }[]> {
+    await this.ensureInitialized();
+    const { db } = getDatabase();
+    let sql = `SELECT reason_type_id, COUNT(*) AS cnt
+               FROM task_delay_reasons`;
+    const params: any[] = [];
+    if (taskId) {
+      sql += ' WHERE task_id = ?';
+      params.push(taskId);
+    }
+    sql += ' GROUP BY reason_type_id ORDER BY cnt DESC';
+    const [result] = await db.executeSql(sql, params);
+    const rows: { reasonTypeId: string; count: number }[] = [];
+    for (let i = 0; i < result.rows.length; i++) {
+      const row = result.rows.item(i);
+      rows.push({ reasonTypeId: row.reason_type_id, count: Number(row.cnt) });
+    }
+    return rows;
   }
 }

--- a/src/pages/tasks/TaskDetailsPage.tsx
+++ b/src/pages/tasks/TaskDetailsPage.tsx
@@ -43,6 +43,7 @@ export default function TaskDetailsPage() {
     removeDependency,
     addDelayReason,
     removeDelayReason,
+    resolveDelayReason,
   } = useTasks();
   const { delayReasonTypes } = useDelayReasonTypes();
   const { confirm } = useConfirm();
@@ -174,6 +175,15 @@ export default function TaskDetailsPage() {
       await loadData();
     } catch (e: any) {
       Alert.alert('Error', e?.message || 'Failed to remove delay reason');
+    }
+  };
+
+  const handleResolveDelayReason = async (delayReasonId: string) => {
+    try {
+      await resolveDelayReason(delayReasonId);
+      await loadData();
+    } catch (e: any) {
+      Alert.alert('Error', e?.message || 'Failed to resolve delay reason');
     }
   };
 
@@ -324,6 +334,7 @@ export default function TaskDetailsPage() {
             delayReasons={taskDetail?.delayReasons ?? []}
             onAddDelay={() => setShowDelayModal(true)}
             onRemoveDelay={handleRemoveDelayReason}
+            onResolveDelay={handleResolveDelayReason}
           />
         </View>
       </ScrollView>


### PR DESCRIPTION
Implements Task Delay Reasons feature (issue #110):

- Adds `resolvedAt` and `mitigationNotes` to `DelayReason` and migration `0013`
- Adds `resolveDelayReason()` and `summarizeDelayReasons()` to `TaskRepository` and `DrizzleTaskRepository`
- Adds `ResolveDelayReasonUseCase` and `GetDelayStatisticsUseCase`
- UI: `TaskDelaySection` show open/resolved states and resolve action
- Hooks: `useTasks` + `useDelayReasonTypes` updates
- Tests: unit + integration tests for new use cases and repositories

Closes #110.
