### PR TITLE
feat(#146): Payment card detail — drill-down, due-date resolution, cancel guard

### DIFF
--- a/__tests__/integration/DrizzleProjectRepository.integration.test.ts
+++ b/__tests__/integration/DrizzleProjectRepository.integration.test.ts
@@ -198,6 +198,33 @@ describe('DrizzleProjectRepository integration (better-sqlite3 :memory:)', () =>
     await closeDatabase();
   }, 15000);
 
+  it('persists and retrieves defaultDueDateDays via save/findById', async () => {
+    const repo = new DrizzleProjectRepository();
+    await repo.init();
+
+    const projectData = ProjectEntity.create({
+      name: 'Due Date Project',
+      status: ProjectStatus.PLANNING,
+      defaultDueDateDays: 10,
+      materials: [],
+      phases: [],
+    }).data;
+
+    await repo.save(projectData);
+    const found = await repo.findById(projectData.id);
+
+    expect(found).not.toBeNull();
+    expect(found!.defaultDueDateDays).toBe(10);
+
+    // Update and verify the field is persisted
+    await repo.save({ ...found!, defaultDueDateDays: 14 });
+    const updated = await repo.findById(projectData.id);
+    expect(updated!.defaultDueDateDays).toBe(14);
+
+    await repo.delete(projectData.id);
+    await closeDatabase();
+  }, 15000);
+
 });
   // End of contract tests
 

--- a/__tests__/unit/CancelInvoiceUseCase.test.ts
+++ b/__tests__/unit/CancelInvoiceUseCase.test.ts
@@ -1,5 +1,6 @@
 import { Invoice } from '../../src/domain/entities/Invoice';
 import { InvoiceRepository } from '../../src/domain/repositories/InvoiceRepository';
+import { PaymentRepository } from '../../src/domain/repositories/PaymentRepository';
 import { CancelInvoiceUseCase } from '../../src/application/usecases/invoice/CancelInvoiceUseCase';
 
 describe('CancelInvoiceUseCase', () => {
@@ -325,6 +326,42 @@ describe('CancelInvoiceUseCase', () => {
         actor: 'user_002',
         reason: 'Not needed',
       });
+    });
+  });
+
+  describe('settled-payment guard', () => {
+    const baseInvoice: Invoice = {
+      id: 'inv_guard',
+      total: 1000,
+      currency: 'AUD',
+      status: 'issued',
+      paymentStatus: 'partial',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    } as Invoice;
+
+    it('cancels successfully when paymentRepo is provided but no settled payments exist', async () => {
+      const mockPaymentRepo: PaymentRepository = {
+        findByInvoice: jest.fn().mockResolvedValue([{ id: 'pay_1', status: 'pending', amount: 500 }]),
+      } as unknown as PaymentRepository;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(baseInvoice);
+      (mockRepo.updateInvoice as jest.Mock).mockResolvedValue({ ...baseInvoice, status: 'cancelled' });
+
+      const guardedUseCase = new CancelInvoiceUseCase(mockRepo, mockPaymentRepo);
+      await expect(guardedUseCase.execute('inv_guard')).resolves.not.toThrow();
+    });
+
+    it('throws when a settled payment is linked to the invoice', async () => {
+      const mockPaymentRepo: PaymentRepository = {
+        findByInvoice: jest.fn().mockResolvedValue([{ id: 'pay_1', status: 'settled', amount: 500 }]),
+      } as unknown as PaymentRepository;
+
+      (mockRepo.getInvoice as jest.Mock).mockResolvedValue(baseInvoice);
+
+      const guardedUseCase = new CancelInvoiceUseCase(mockRepo, mockPaymentRepo);
+      await expect(guardedUseCase.execute('inv_guard')).rejects.toThrow(/settled/i);
+      expect(mockRepo.updateInvoice).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/unit/InvoiceEntity.cancel.test.ts
+++ b/__tests__/unit/InvoiceEntity.cancel.test.ts
@@ -1,0 +1,63 @@
+import { InvoiceEntity, Invoice } from '../../src/domain/entities/Invoice';
+import { Payment } from '../../src/domain/entities/Payment';
+
+const makeInvoice = (overrides: Partial<Invoice> = {}): Invoice => ({
+  id: 'inv_1',
+  total: 1000,
+  currency: 'AUD',
+  status: 'issued',
+  paymentStatus: 'unpaid',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const makePayment = (overrides: Partial<Payment> = {}): Payment => ({
+  id: 'pay_1',
+  amount: 500,
+  status: 'pending',
+  ...overrides,
+});
+
+describe('InvoiceEntity.canBeCancelled', () => {
+  it('allows cancellation when there are no linked payments', () => {
+    const entity = new InvoiceEntity(makeInvoice());
+    expect(entity.canBeCancelled([])).toEqual({ allowed: true });
+  });
+
+  it('allows cancellation when all linked payments are pending (not settled)', () => {
+    const entity = new InvoiceEntity(makeInvoice());
+    const payments = [makePayment({ status: 'pending' })];
+    expect(entity.canBeCancelled(payments)).toEqual({ allowed: true });
+  });
+
+  it('blocks cancellation when a settled payment exists', () => {
+    const entity = new InvoiceEntity(makeInvoice());
+    const payments = [makePayment({ status: 'settled' })];
+    const result = entity.canBeCancelled(payments);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/settled/i);
+  });
+
+  it('blocks when at least one of several payments is settled', () => {
+    const entity = new InvoiceEntity(makeInvoice());
+    const payments = [
+      makePayment({ id: 'pay_1', status: 'pending' }),
+      makePayment({ id: 'pay_2', status: 'settled' }),
+    ];
+    expect(entity.canBeCancelled(payments).allowed).toBe(false);
+  });
+});
+
+describe('InvoiceEntity.cancel', () => {
+  it('does not throw when no settled payments', () => {
+    const entity = new InvoiceEntity(makeInvoice());
+    expect(() => entity.cancel([])).not.toThrow();
+  });
+
+  it('throws when a settled payment is linked', () => {
+    const entity = new InvoiceEntity(makeInvoice());
+    const payments = [makePayment({ status: 'settled' })];
+    expect(() => entity.cancel(payments)).toThrow(/settled/i);
+  });
+});

--- a/__tests__/unit/MarkPaymentAsPaidUseCase.test.ts
+++ b/__tests__/unit/MarkPaymentAsPaidUseCase.test.ts
@@ -1,0 +1,139 @@
+import { MarkPaymentAsPaidUseCase } from '../../src/application/usecases/payment/MarkPaymentAsPaidUseCase';
+import { PaymentRepository } from '../../src/domain/repositories/PaymentRepository';
+import { InvoiceRepository } from '../../src/domain/repositories/InvoiceRepository';
+import { Payment } from '../../src/domain/entities/Payment';
+import { Invoice } from '../../src/domain/entities/Invoice';
+
+const makePayment = (overrides: Partial<Payment> = {}): Payment => ({
+  id: 'pay_1',
+  amount: 500,
+  status: 'pending',
+  invoiceId: 'inv_1',
+  currency: 'AUD',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const makeInvoice = (overrides: Partial<Invoice> = {}): Invoice => ({
+  id: 'inv_1',
+  total: 1000,
+  currency: 'AUD',
+  status: 'issued',
+  paymentStatus: 'unpaid',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('MarkPaymentAsPaidUseCase', () => {
+  let paymentRepo: jest.Mocked<PaymentRepository>;
+  let invoiceRepo: jest.Mocked<InvoiceRepository>;
+  let useCase: MarkPaymentAsPaidUseCase;
+
+  beforeEach(() => {
+    paymentRepo = {
+      findById: jest.fn(),
+      update: jest.fn(),
+      findByInvoice: jest.fn(),
+      save: jest.fn(),
+      findAll: jest.fn(),
+      findByProjectId: jest.fn(),
+      findPendingByProject: jest.fn(),
+      delete: jest.fn(),
+      list: jest.fn(),
+      getMetrics: jest.fn(),
+      getGlobalAmountPayable: jest.fn(),
+    } as any;
+
+    invoiceRepo = {
+      getInvoice: jest.fn(),
+      updateInvoice: jest.fn(),
+      createInvoice: jest.fn(),
+      deleteInvoice: jest.fn(),
+      findByExternalKey: jest.fn(),
+      listInvoices: jest.fn(),
+      assignProject: jest.fn(),
+    } as any;
+
+    useCase = new MarkPaymentAsPaidUseCase(paymentRepo, invoiceRepo);
+  });
+
+  it('throws when payment is not found', async () => {
+    paymentRepo.findById.mockResolvedValue(null);
+    await expect(useCase.execute({ paymentId: 'nonexistent' })).rejects.toThrow('not found');
+  });
+
+  it('throws when payment is already settled', async () => {
+    paymentRepo.findById.mockResolvedValue(makePayment({ status: 'settled' }));
+    await expect(useCase.execute({ paymentId: 'pay_1' })).rejects.toThrow('already settled');
+  });
+
+  it('marks a pending payment as settled', async () => {
+    const payment = makePayment();
+    const invoice = makeInvoice();
+    paymentRepo.findById.mockResolvedValue(payment);
+    paymentRepo.update.mockResolvedValue(undefined);
+    invoiceRepo.getInvoice.mockResolvedValue(invoice);
+    paymentRepo.findByInvoice.mockResolvedValue([{ ...payment, status: 'settled' }]);
+    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'partial' });
+
+    const result = await useCase.execute({ paymentId: 'pay_1' });
+
+    expect(paymentRepo.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'pay_1', status: 'settled' }),
+    );
+    expect(result.payment.status).toBe('settled');
+  });
+
+  it('sets invoice paymentStatus to "paid" when full amount settled', async () => {
+    const payment = makePayment({ amount: 1000 });
+    const invoice = makeInvoice({ total: 1000 });
+    paymentRepo.findById.mockResolvedValue(payment);
+    paymentRepo.update.mockResolvedValue(undefined);
+    invoiceRepo.getInvoice.mockResolvedValue(invoice);
+    // findByInvoice returns the now-settled payment
+    paymentRepo.findByInvoice.mockResolvedValue([{ ...payment, status: 'settled' }]);
+    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'paid', status: 'paid' });
+
+    const result = await useCase.execute({ paymentId: 'pay_1' });
+
+    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith(
+      'inv_1',
+      expect.objectContaining({ paymentStatus: 'paid', status: 'paid' }),
+    );
+    expect(result.invoicePaymentStatus).toBe('paid');
+  });
+
+  it('sets invoice paymentStatus to "partial" for a partial payment', async () => {
+    const payment = makePayment({ amount: 400 });
+    const invoice = makeInvoice({ total: 1000 });
+    paymentRepo.findById.mockResolvedValue(payment);
+    paymentRepo.update.mockResolvedValue(undefined);
+    invoiceRepo.getInvoice.mockResolvedValue(invoice);
+    paymentRepo.findByInvoice.mockResolvedValue([{ ...payment, status: 'settled' }]);
+    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'partial' });
+
+    const result = await useCase.execute({ paymentId: 'pay_1' });
+
+    expect(result.invoicePaymentStatus).toBe('partial');
+  });
+
+  it('does not update invoice status to paid when invoice is draft', async () => {
+    const payment = makePayment({ amount: 1000 });
+    const invoice = makeInvoice({ total: 1000, status: 'draft' });
+    paymentRepo.findById.mockResolvedValue(payment);
+    paymentRepo.update.mockResolvedValue(undefined);
+    invoiceRepo.getInvoice.mockResolvedValue(invoice);
+    paymentRepo.findByInvoice.mockResolvedValue([{ ...payment, status: 'settled' }]);
+    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'paid' });
+
+    await useCase.execute({ paymentId: 'pay_1' });
+
+    // Should update paymentStatus but NOT set status to 'paid' for a draft invoice
+    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith(
+      'inv_1',
+      expect.not.objectContaining({ status: 'paid' }),
+    );
+  });
+});

--- a/__tests__/unit/resolveInvoiceDueDate.test.ts
+++ b/__tests__/unit/resolveInvoiceDueDate.test.ts
@@ -1,0 +1,52 @@
+import { resolveInvoiceDueDate } from '../../src/utils/resolveInvoiceDueDate';
+
+describe('resolveInvoiceDueDate', () => {
+  const baseInvoice = {
+    dateDue: undefined as string | undefined,
+    dueDate: undefined as string | undefined,
+    dateIssued: undefined as string | undefined,
+    issueDate: undefined as string | undefined,
+    metadata: undefined as Record<string, any> | undefined,
+  };
+
+  it('returns dateDue when present', () => {
+    const inv = { ...baseInvoice, dateDue: '2025-06-15' };
+    expect(resolveInvoiceDueDate(inv)).toBe('2025-06-15');
+  });
+
+  it('falls back to dueDate when dateDue is absent', () => {
+    const inv = { ...baseInvoice, dueDate: '2025-06-20' };
+    expect(resolveInvoiceDueDate(inv)).toBe('2025-06-20');
+  });
+
+  it('uses taskStartDate + working days when no explicit date', () => {
+    const inv = { ...baseInvoice };
+    // Monday 2025-01-06 + 1 working day = Tuesday 2025-01-07
+    const result = resolveInvoiceDueDate(inv, '2025-01-06', 1);
+    expect(result).toBe('2025-01-07');
+  });
+
+  it('uses dateIssued + working days when taskStartDate is absent', () => {
+    const inv = { ...baseInvoice, dateIssued: '2025-01-06' };
+    // Monday + 1 working day = Tuesday
+    expect(resolveInvoiceDueDate(inv, null, 1)).toBe('2025-01-07');
+  });
+
+  it('uses issueDate as fallback for dateIssued', () => {
+    const inv = { ...baseInvoice, issueDate: '2025-01-06' };
+    expect(resolveInvoiceDueDate(inv, null, 1)).toBe('2025-01-07');
+  });
+
+  it('prefers dateDue over taskStartDate', () => {
+    const inv = { ...baseInvoice, dateDue: '2025-06-10' };
+    const result = resolveInvoiceDueDate(inv, '2025-01-06', 5);
+    expect(result).toBe('2025-06-10');
+  });
+
+  it('defaults to dueDatePeriodDays = 5 when not provided', () => {
+    // With a known Monday anchor, 5 working days = next Monday
+    const inv = { ...baseInvoice, dateIssued: '2025-01-06' }; // Monday
+    const result = resolveInvoiceDueDate(inv, null);
+    expect(result).toBe('2025-01-13');
+  });
+});

--- a/__tests__/unit/workingDays.test.ts
+++ b/__tests__/unit/workingDays.test.ts
@@ -1,0 +1,37 @@
+import { addWorkingDays } from '../../src/utils/workingDays';
+
+describe('addWorkingDays', () => {
+  it('returns the same date for 0 days', () => {
+    const start = new Date('2025-01-06'); // Monday
+    const result = addWorkingDays(start, 0);
+    expect(result.toISOString().slice(0, 10)).toBe('2025-01-06');
+  });
+
+  it('adds 1 working day on Monday → Tuesday', () => {
+    const monday = new Date('2025-01-06');
+    expect(addWorkingDays(monday, 1).toISOString().slice(0, 10)).toBe('2025-01-07');
+  });
+
+  it('skips Saturday and Sunday: Friday + 1 = Monday', () => {
+    const friday = new Date('2025-01-10');
+    expect(addWorkingDays(friday, 1).toISOString().slice(0, 10)).toBe('2025-01-13');
+  });
+
+  it('skips a full weekend: Friday + 3 = Wednesday', () => {
+    const friday = new Date('2025-01-10');
+    expect(addWorkingDays(friday, 3).toISOString().slice(0, 10)).toBe('2025-01-15');
+  });
+
+  it('adds 5 working days spanning one weekend', () => {
+    const monday = new Date('2025-01-06');
+    // Mon + 5 working days = Mon→Tue→Wed→Thu→Fri→Mon(next week)
+    expect(addWorkingDays(monday, 5).toISOString().slice(0, 10)).toBe('2025-01-13');
+  });
+
+  it('does not mutate the input date', () => {
+    const start = new Date('2025-01-06');
+    const original = start.getTime();
+    addWorkingDays(start, 3);
+    expect(start.getTime()).toBe(original);
+  });
+});

--- a/design/issue-146-payment-card-detail.md
+++ b/design/issue-146-payment-card-detail.md
@@ -1,0 +1,480 @@
+# Design: Issue #146 — Payment Card Detail (Due Date Sourcing + Clickable Card → Payment Details)
+
+**Status**: APPROVED
+**Author**: Copilot
+**Date**: 2026-03-16
+**GitHub Issue**: https://github.com/yhua045/builder-assistant/issues/146
+
+---
+
+## 0. Unified Display DTO — Payment Row Source Model
+
+The Payments list renders a single card type (`PaymentCard`) regardless of where the underlying data came from. The `Payment` interface acts as the **unified display DTO**. Three distinct sources feed into it:
+
+| Source | `payment.id` | Origin | Persisted? | Typical status |
+|---|---|---|---|---|
+| **Real settled payment** | `pay_<timestamp>_<random>` | `payments` DB table | ✅ Yes | `settled` |
+| **Real pending payment** | `pay_<timestamp>_<random>` | `payments` DB table | ✅ Yes | `pending` |
+| **Synthetic invoice-payable row** | `invoice-payable:<invoiceId>` | Constructed in-memory by `buildInvoicePayables()` from an `Invoice` record | ❌ No — never written to DB | `pending` |
+
+The synthetic row exists because an outstanding invoice represents a financial obligation that must appear on the payments list even before the builder has explicitly recorded a payment transaction against it. It is assembled from `Invoice` fields and discarded after the render cycle.
+
+**De-duplication rule** (already in `buildInvoicePayables`): a synthetic row is only generated for an invoice if *no real `pending` payment already exists* for that invoice. When real pending payment records exist (e.g. an agreed staged-payment schedule), they cover the obligation and the synthetic row is suppressed.
+
+**Materialisation**: when the user taps "Mark as Paid" on a synthetic row, `MarkPaymentAsPaidUseCase` creates a real `Payment` record in the DB for the first time — this is the moment the synthetic row is "materialised" into a persisted transaction.
+
+---
+
+## 1. Scope Overview
+
+This issue covers two distinct but related areas:
+
+| Part | Summary |
+|---|---|
+| **A — Due Date Sourcing** | For payment cards that are linked to an invoice, show the due date from the invoice (not from the payment row). Add fallback logic, handle `draft`/`cancelled` invoice states, and protect against cancelling invoices that have payments. |
+| **B — Payment Card Interactivity** | Make every payment card tappable. Tapping opens a `PaymentDetails` screen. Settled payments are read-only. Pending payments offer a "Mark as Paid" action that creates an internal settled transaction. |
+
+---
+
+## 2. User Stories
+
+| # | Story |
+|---|---|
+| US-1 | As a Builder, I want the due date on a payment card to reflect the actual invoice due date so I can trust the urgency indicator. |
+| US-2 | As a Builder, I want to see a warning (red highlight) on a payment card when its linked invoice has been cancelled so I know action is required. |
+| US-3 | As a Builder, I want to tap a payment card to view its full details including the project name, linked invoice, reference number, notes, and line items. |
+| US-4 | As a Builder, I want to mark a pending payment as paid from the details screen and have that action create a traceable internal transaction record. |
+| US-5 | As a Builder, I cannot cancel an invoice if settled payments already exist against it — the system must warn me and block or guide me to reverse the payments first. |
+| US-6 | As a Builder, I want to see on a payment's detail screen how much of the linked invoice has already been paid (across all staged payments) so I know the remaining obligation. |
+| US-7 | As a Builder, I want the default due date period (used when no explicit due date is set) to reflect my project's payment terms, not a hard-coded constant. |
+
+---
+
+## 3. Acceptance Criteria
+
+### Part A — Due Date Sourcing
+
+| # | Criterion |
+|---|---|
+| AC-A1 | For any payment row linked to an invoice (`payment.invoiceId` or `id` prefix `invoice-payable:`), the displayed due date is resolved in this priority order: `invoice.dateDue` → `invoice.dueDate` → `invoice.metadata?.dueDate` → calculated fallback (task `startDate` or today + project's `defaultDueDateDays`, defaulting to 5 working days). |
+| AC-A2 | Synthetic rows produced by `buildInvoicePayables()` have their `dueDate` field set using the same priority order before being returned to the hook. No second lookup is needed in the render layer. |
+| AC-A3 | Legacy/standalone payments (no `invoiceId`) continue to use `payment.dueDate` → `payment.date` → show `N/A`. |
+| AC-A4 | Payments linked to a `draft` or `cancelled` invoice do NOT display a due date. Instead the `PaymentCard` renders a red-highlighted warning banner: *"Invoice [status]"* (e.g. "Invoice cancelled"). The card body is also visually flagged (red border or red tint background). |
+| AC-A5 | Stored UTC date values are never mutated. All date resolution logic is display-only. |
+| AC-A6 | Date display uses existing `formatDate` / locale utilities — no new date-formatting code is introduced. |
+
+### Part A — Invoice Cancellation Guard
+
+| # | Criterion |
+|---|---|
+| AC-A7 | `InvoiceEntity` exposes a `canBeCancelled(linkedPayments: Payment[]): { allowed: boolean; reason?: string }` method. |
+| AC-A8 | `canBeCancelled` returns `{ allowed: false, reason: 'Invoice has settled payments. Reverse all payments before cancelling.' }` when any linked payment has `status === 'settled'`. |
+| AC-A9 | The existing or forthcoming invoice update pathway calls this guard before allowing a status transition to `cancelled`. If blocked, it throws a domain error rather than persisting the change. |
+| AC-A10 | A reverse-payment path is documented (but NOT implemented in this issue) — the guard message references it as the resolution step. Implementation is deferred to a follow-up issue. |
+
+### Part B — Navigation & Payment Details Screen
+
+| # | Criterion |
+|---|---|
+| AC-B1 | The `Finances` tab uses a new `PaymentsNavigator` (a `NativeStackNavigator`) wrapping `PaymentsScreen` (as `PaymentsList`) and the new `PaymentDetails` screen. The existing `PaymentsScreen` component is unchanged. |
+| AC-B2 | Tapping any `PaymentCard` navigates to `PaymentDetails` with either `{ paymentId: string }` (real payment) or `{ syntheticRow: Payment }` (synthetic `invoice-payable:` row passed as navigation params). |
+| AC-B3 | `PaymentDetails` fetches and displays: payment fields (amount, date, due date, reference, notes, method), linked invoice summary (invoice number, issuer, invoice total, **amount paid so far across all linked payments**, **remaining outstanding**, status), linked project name (if available). |
+| AC-B4 | If `payment.status === 'settled'`: all fields are read-only; a green "Settled" badge with `settledAt` date is shown; "Mark as Paid" is hidden. |
+| AC-B5 | If `payment.status === 'pending'`: a prominent "Mark as Paid" button is shown. Tapping it opens a confirmation modal pre-filled with the **outstanding amount** (invoice total minus sum of all settled payments) and a `note` field (optional). The user may edit the amount downward for a partial payment. Confirming creates a settled `Payment` record via `MarkPaymentAsPaidUseCase`. |
+| AC-B6 | For synthetic rows (`invoice-payable:`), "Mark as Paid" creates a **new** real `Payment` linked to `invoiceId`. The synthetic row is NOT mutated. If the amount recorded is less than the full outstanding, the invoice `paymentStatus` is updated to `partial` and the synthetic row will reappear on the list for the remaining amount on next refresh. |
+| AC-B6a | For an invoice with **multiple staged payments** (several real `pending` records), `PaymentDetails` for each individual payment shows the per-payment amount; the invoice summary section shows the aggregate (total, paid-to-date, remaining). Each payment stage is settled independently. |
+| AC-B7 | If the linked invoice cannot be found, `PaymentDetails` still renders the payment fields and shows a muted warning "Invoice not found". "Mark as Paid" is still available. |
+| AC-B8 | Concurrent conflict detection: if the payment was settled by another user while details are open, the screen detects the mismatch on re-focus and transitions to the settled read-only state with a conflict banner. |
+| AC-B9 | `createdAt` and optionally `note` are stored on the new settled payment record. |
+| AC-B10 | TypeScript strict mode passes with no new errors. |
+
+---
+
+## 4. Current State Analysis
+
+| Concern | Current state | Gap |
+|---|---|---|
+| `buildInvoicePayables()` | Sets `dueDate: inv.dateDue ?? inv.dueDate` (2-field lookup only, no metadata fallback, no working-day fallback) | Add `metadata?.dueDate` and working-day fallback |
+| `PaymentCard.tsx` | Reads `payment.dueDate` directly; no special handling for cancelled/draft invoice state | Add invoice-status awareness; add red highlight path |
+| `PaymentsScreen` in `TabsLayout` | Registered directly as a Tab screen — no stack navigator | Wrap in `PaymentsNavigator` |
+| `PaymentDetails` screen | Does not exist | Create from scratch |
+| `MarkPaymentAsPaidUseCase` | Does not exist | Create |
+| `InvoiceEntity` cancellation guard | Does not exist | Add `canBeCancelled()` method |
+| Navigation params typing | No `PaymentsStackParamList` type | Add |
+
+---
+
+## 5. Architecture & File Plan
+
+### 5.1 New Files
+
+| File | Purpose |
+|---|---|
+| `src/pages/payments/PaymentsNavigator.tsx` | Stack navigator wrapping Payments list + details |
+| `src/pages/payments/PaymentDetails.tsx` | Payment details screen (read-only + mark-as-paid) |
+| `src/application/usecases/payment/MarkPaymentAsPaidUseCase.ts` | Creates a settled payment record; updates invoice status |
+| `src/utils/workingDays.ts` | `addWorkingDays(date: Date, days: number): Date` (Mon–Fri, no public holidays) |
+| `src/application/usecases/invoice/CancelInvoiceUseCase.ts` | Guards invoice cancellation against existing settled payments |
+
+### 5.2 Modified Files
+
+| File | Change |
+|---|---|
+| `src/domain/entities/Invoice.ts` | Add `canBeCancelled(linkedPayments: Payment[]): { allowed: boolean; reason?: string }` to `InvoiceEntity` |
+| `src/domain/entities/Project.ts` | Add optional `defaultDueDateDays?: number` field |
+| `src/infrastructure/database/schema.ts` | Add `defaultDueDateDays` column to `projects` table |
+| `src/hooks/usePayments.ts` | Update `buildInvoicePayables()`: use `resolveInvoiceDueDate` with project's `defaultDueDateDays`; set `invoiceStatus` on synthetic rows |
+| `src/components/payments/PaymentCard.tsx` | Accept optional `invoiceStatus` prop; render red-flagged state for draft/cancelled |
+| `src/pages/tabs/index.tsx` | Replace `PaymentsScreen` import with `PaymentsNavigator` |
+
+### 5.3 Schema Changes
+
+One small addition to the `projects` table is needed to support the configurable due-date period:
+
+| Table | Column | Type | Default | Notes |
+|---|---|---|---|---|
+| `projects` | `default_due_date_days` | `INTEGER` | `5` | Working days added to the anchor date when no explicit due date exists on an invoice. |
+
+This requires a new Drizzle migration. The `Project` domain entity gains a corresponding optional field `defaultDueDateDays?: number`.
+
+All other changes are display-layer or use-case logic only. No changes to the `payments` or `invoices` tables.
+
+---
+
+## 6. Detailed Design
+
+### 6.1 Due Date Resolution Helper
+
+A pure utility function that encapsulates the resolution priority:
+
+```ts
+// src/utils/resolveInvoiceDueDate.ts
+import { Invoice } from '../domain/entities/Invoice';
+import { addWorkingDays } from './workingDays';
+
+/**
+ * Resolves the display due date for a payment linked to an invoice.
+ * Priority: dateDue → dueDate → metadata.dueDate → anchor + dueDatePeriodDays working days
+ *
+ * @param invoice            The linked invoice record.
+ * @param taskStartDate      Optional start date of the linked task (used as fallback anchor).
+ * @param dueDatePeriodDays  Project-level configurable period; defaults to 5 working days.
+ */
+export function resolveInvoiceDueDate(
+  invoice: Invoice,
+  taskStartDate?: string | null,
+  dueDatePeriodDays: number = 5,
+): string | undefined {
+  if (invoice.dateDue) return invoice.dateDue;
+  if (invoice.dueDate) return invoice.dueDate;
+  const metaDue = invoice.metadata?.dueDate;
+  if (typeof metaDue === 'string' && metaDue) return metaDue;
+
+  // Fallback: anchor date + project-configured working days
+  const anchor = taskStartDate ? new Date(taskStartDate) : new Date();
+  return addWorkingDays(anchor, dueDatePeriodDays).toISOString();
+}
+```
+
+### 6.2 `buildInvoicePayables()` Changes
+
+Current code already sets `dueDate: inv.dateDue ?? inv.dueDate`. The update:
+
+1. Accept a `projectDueDateDays: number` parameter (fetched per-project from `Project.defaultDueDateDays ?? 5`) and pass it to `resolveInvoiceDueDate(inv, task?.startDate, projectDueDateDays)`.
+2. Also pass `invoiceStatus: inv.status` into the synthetic payment object so `PaymentCard` can inspect it without a second lookup.
+
+Because `buildInvoicePayables` already has an optional `taskRepo` parameter (used for contractor name lookup), the task startDate is available when the task is already fetched. The hook resolves per-project `defaultDueDateDays` from the project map it already builds for project names, so no additional repo call is needed.
+
+**Staged-payment / multi-payment handling**: The existing `hasPendingLegacyPayable` guard (skip invoice if a real `pending` payment record already exists) remains correct — those real pending records represent the agreed staged schedule and appear directly in the list. The synthetic row is only generated for invoices with **no existing pending records** (i.e. an outstanding invoice not yet entered into the payment schedule). The outstanding-amount calculation (invoice.total − sum of settled payments) already handles partial payment correctly.
+
+The synthetic `Payment` object now carries one extra field:
+
+```ts
+// Existing Payment interface extension needed:
+invoiceStatus?: Invoice['status'];  // 'draft' | 'issued' | 'paid' | 'overdue' | 'cancelled'
+```
+
+This field is **display-only** — it lives in the Payment entity as an optional field alongside the existing `invoiceId`.
+
+### 6.3 `PaymentCard.tsx` Changes
+
+The card accepts an optional `invoiceStatus` prop (or reads `payment.invoiceStatus`). If the status is `draft` or `cancelled`:
+
+- The due-status footer is **replaced** with a red warning banner: `"Invoice {status}"`.
+- A red left border (or a red-tinted card background) visually flags the card.
+- The `Pay Now` button is hidden.
+
+```tsx
+const isInvoiceDead = payment.invoiceStatus === 'cancelled' || payment.invoiceStatus === 'draft';
+
+// In the render:
+{isInvoiceDead ? (
+  <View style={styles.footerCancelled} className="px-4 py-2">
+    <Text style={styles.footerTextCancelled} className="text-xs font-semibold">
+      Invoice {payment.invoiceStatus}
+    </Text>
+  </View>
+) : dueStatus ? (
+  // existing footer
+) : null}
+```
+
+### 6.4 `InvoiceEntity.canBeCancelled()`
+
+```ts
+canBeCancelled(linkedPayments: Payment[]): { allowed: boolean; reason?: string } {
+  const hasSettled = linkedPayments.some(p => p.status === 'settled');
+  if (hasSettled) {
+    return {
+      allowed: false,
+      reason: 'Invoice has settled payments. Reverse all payments before cancelling.',
+    };
+  }
+  return { allowed: true };
+}
+```
+
+This method is **pure** — it takes payments as an argument so it has no repository dependency. The call site (invoice update use case or repository adapter) is responsible for fetching the linked payments and calling this guard before persisting a `cancelled` status.
+
+### 6.5 Navigation: `PaymentsNavigator`
+
+```ts
+// src/pages/payments/PaymentsNavigator.tsx
+export type PaymentsStackParamList = {
+  PaymentsList: undefined;
+  PaymentDetails: { paymentId: string } | { syntheticRow: Payment };
+};
+```
+
+Pattern mirrors `TasksNavigator.tsx`. `PaymentsScreen` becomes `PaymentsList` within the stack.
+
+### 6.6 `PaymentDetails` Screen Layout
+
+```
+┌─────────────────────────────────┐
+│ ← Back          Payment Details │  ← header
+├─────────────────────────────────┤
+│ [Settled ✓  16 Mar 2026]        │  ← status badge (green) or empty
+│                                 │
+│ CONTRACTOR NAME  Bold           │
+│ $2,400.00        Large          │  ← this payment's amount
+│                                 │
+│ Due Date: 20 Mar 2026           │
+│ Method:   Bank Transfer         │
+│ Reference: INV-0042             │
+│ Notes:    ...                   │
+├─────────────────────────────────┤
+│ INVOICE DETAILS                 │  ← section header (if invoiceId)
+│ Invoice #: INV-0042             │
+│ Issued by: ABC Constructions    │
+│ Invoice Total:  $10,000.00      │
+│ Paid to date:    $4,000.00      │  ← sum of all settled payments on this invoice
+│ Remaining:       $6,000.00      │  ← outstanding (shown in amber/red if overdue)
+│ Status:    Partial              │
+│ Due:       20 Mar 2026          │
+│ Items: [collapsed/expanded]     │
+├─────────────────────────────────┤
+│ PAYMENT HISTORY (this invoice)  │  ← list of all real Payment records for this invoice
+│  ✓ $3,000  Settled  01 Mar 2026 │
+│  ● $1,000  Settled  08 Mar 2026 │
+│  ○ $2,400  Pending  ← current   │  ← highlighted
+│  ○ $3,600  Pending              │
+├─────────────────────────────────┤
+│ PROJECT                         │
+│ 14 Smith Street                 │
+├─────────────────────────────────┤
+│        [Mark as Paid]           │  ← only shown when current payment is pending
+└─────────────────────────────────┘
+```
+
+> **Note on staged payments**: When multiple `Payment` records share the same `invoiceId`, the "Payment History" section lists all of them. Each row is tappable to navigate to that payment's own `PaymentDetails` screen. This gives the builder a full picture of the staged schedule without leaving the details view.
+
+### 6.7 `MarkPaymentAsPaidUseCase`
+
+```ts
+interface MarkAsPaidInput {
+  paymentId: string;           // real payment id, OR 'invoice-payable:<invoiceId>'
+  invoiceId?: string;          // required when paymentId is synthetic
+  amount: number;              // may be partial (user editable in the confirmation modal)
+  note?: string;
+  settledAt?: string;          // ISO; defaults to now
+}
+```
+
+Logic:
+1. Parse `paymentId`: if it starts with `invoice-payable:`, extract `invoiceId` and treat as synthetic.
+2. Create a new `Payment` via `PaymentEntity.create({ status: 'settled', invoiceId, amount, notes: note, date: settledAt ?? now })`.
+3. Save via `paymentRepo.save()`.
+4. Recalculate invoice `paymentStatus` by summing **all** settled payments for the invoice (not just this one): if `paidTotal >= invoice.total` → `paid`; if `paidTotal > 0` → `partial`; else → `unpaid`. Update invoice via `invoiceRepo.updateInvoice()`.
+5. If the original payment was a real `pending` record (not synthetic), also update it to `settled` via `paymentRepo.update()`.
+6. Return the newly created settled payment.
+
+**Partial payment note**: If the recorded `amount` is less than the invoice total remaining, the invoice stays at `partial` and the outstanding portion will re-appear as a synthetic row on the next list refresh. This is the expected behaviour for staged payments — each stage is settled individually.
+
+**Idempotency**: Before saving, check `paymentRepo.findByInvoice(invoiceId)` — if a settled payment already exists for the same invoice with the same amount and date (within 60 seconds), return that existing record instead of creating a duplicate.
+
+### 6.8 Conflict Detection on PaymentDetails
+
+On `useFocusEffect` (re-focus the screen), re-fetch the payment. If it has transitioned to `settled` since the screen was opened, display a banner:
+
+> *"This payment was marked as paid by another session. Refreshing..."*
+
+Then update local state to show the settled view.
+
+---
+
+## 7. Data Flow Diagram
+
+```
+PaymentsScreen (list)
+  └── usePayments (hook)
+        ├── ListGlobalPaymentsUseCase       → real pending Payments from DB
+        └── buildInvoicePayables()
+              ├── invoiceRepo.listInvoices()
+              ├── projectRepo.findById()    → supplies defaultDueDateDays per project
+              ├── resolveInvoiceDueDate(inv, taskStartDate, project.defaultDueDateDays ?? 5)
+              │                             ← NEW utility with configurable period
+              └── returns synthetic Payment[] with invoiceStatus + dueDate fields
+
+PaymentCard
+  ├── reads payment.dueDate (now resolved from invoice by hook)
+  └── reads payment.invoiceStatus for dead-invoice highlight ← NEW
+
+PaymentsNavigator (NEW)
+  ├── PaymentsList (= existing PaymentsScreen)
+  │     └── PaymentCard.onPress → navigate('PaymentDetails', params)
+  └── PaymentDetails (NEW)
+        ├── usePaymentDetails hook
+        │     ├── fetch payment record (or use syntheticRow from params)
+        │     ├── fetch linked invoice (invoiceRepo.getInvoice)
+        │     ├── fetch ALL payments for invoice (paymentRepo.findByInvoice)
+        │     │     → used for: paid-to-date, remaining, payment history list
+        │     └── fetch project name (projectRepo.findById)
+        └── MarkPaymentAsPaidUseCase (on confirm)
+              ├── PaymentRepository.save()   (new settled record)
+              ├── PaymentRepository.update() (update original pending, if real)
+              └── InvoiceRepository.updateInvoice()  (paymentStatus: partial | paid)
+```
+
+### Staged Payment Example
+
+```
+Invoice INV-0042  total: $10,000
+  ├── Payment pay_001  $3,000  settled  01-Mar  ← real DB record
+  ├── Payment pay_002  $3,000  pending  15-Mar  ← real DB record (appears in list directly)
+  └── (no more pending records → outstanding $4,000 → synthetic row generated)
+        invoice-payable:INV-0042  $4,000  pending  ← synthetic
+
+On list: 2 cards shown for INV-0042
+  Card A: pay_002  $3,000 pending
+  Card B: invoice-payable:INV-0042  $4,000 pending
+
+After settling Card B ($4,000):
+  → new pay_003  $4,000 settled created
+  → invoice paymentStatus → 'paid'
+  → no more synthetic row generated on next refresh
+```
+
+---
+
+## 8. Invoice Cancellation Guard — Call Site
+
+The guard belongs in the **InvoiceEntity** (domain). It must be invoked wherever an invoice status is updated to `cancelled`. Currently, invoice status updates flow through `InvoiceRepository.updateInvoice()` in the infrastructure layer, called from `RecordPaymentUseCase` and any direct hook calls.
+
+**Recommended approach** (in scope for this issue):
+- Add the `canBeCancelled()` method to `InvoiceEntity`.
+- Add a new `CancelInvoiceUseCase` that fetches linked payments, calls `canBeCancelled()`, and either proceeds or throws.
+- The existing `updateInvoice()` repository method is NOT the enforcement point — enforcement lives in the use case layer, consistent with Clean Architecture conventions.
+
+The `CancelInvoiceUseCase` itself is a small wrapper and within the scope of this issue since the guard logic is needed to satisfy AC-A8/AC-A9.
+
+---
+
+## 9. `Payment` Entity — Addendum
+
+Add one optional display field (no DB migration needed — this is only populated on in-memory synthetic rows and enriched real rows):
+
+```ts
+// To Payment interface (Payment.ts):
+invoiceStatus?: 'draft' | 'issued' | 'paid' | 'overdue' | 'cancelled'; // display-only enrichment
+```
+
+---
+
+## 10. Tests
+
+### Unit Tests (`__tests__/unit/`)
+
+| Test file | Scenarios |
+|---|---|
+| `resolveInvoiceDueDate.test.ts` | All four priority branches; configurable period (3 days vs 5 days); working-day fallback uses mocked `Date.now` |
+| `InvoiceEntity.canBeCancelled.test.ts` | No payments → allowed; pending-only → allowed; settled payments → blocked |
+| `MarkPaymentAsPaidUseCase.test.ts` | Real pending payment → settled; synthetic → new payment created; partial payment → invoice stays `partial`; full payment → invoice becomes `paid`; idempotency check |
+| `buildInvoicePayables.due-date.test.ts` | Synthetic row carries correct `dueDate` using project's `defaultDueDateDays`; also carries `invoiceStatus`; cancelled/draft invoices skipped; invoice with existing pending records → no synthetic row generated |
+| `buildInvoicePayables.staged.test.ts` | Invoice with 2 settled + 1 pending → no synthetic row; invoice with 2 settled + 0 pending → synthetic row for outstanding amount |
+
+### Integration Tests (`__tests__/integration/`)
+
+| Test file | Scenarios |
+|---|---|
+| `PaymentDetails.navigation.test.ts` | Navigate from list → details with real paymentId; with synthetic row param |
+| `MarkPaymentAsPaid.integration.test.ts` | Full flow: synthetic row → mark paid → settled payment in DB → invoice paymentStatus updated |
+
+---
+
+## 11. Out of Scope (Deferred)
+
+- **Reverse payment UI**: The cancellation guard references it, but creating the reverse-payment flow is a separate issue.
+- **Offline queue**: `Mark as Paid` shows an error and retry prompt if offline; no offline queue implementation.
+- **Permission/role gating**: `Mark as Paid` button is always shown to the current user (single-user app for now). Multi-user RBAC is deferred.
+- **External payment gateway**: Explicitly out of scope per issue requirements.
+
+---
+
+## 12. Open Questions
+
+| # | Question | Impact |
+|---|---|---|
+| ~~OQ-1~~ | ~~Should the working-day fallback be hardcoded or configurable?~~ | **Resolved**: `defaultDueDateDays` added to `Project` entity + DB. |
+| ~~OQ-2~~ | ~~Should direct `updateInvoice()` calls also enforce the guard?~~ | **Resolved**: Guard lives in `InvoiceEntity` as the aggregate root. `InvoiceEntity` exposes a `cancel(linkedPayments)` state-transition method that internally calls `canBeCancelled()` and throws a domain error if blocked. All cancellation flows must go through this entity method — the use case calls `entity.cancel(payments)` before persisting. Direct `updateInvoice()` calls for non-cancellation transitions remain unguarded. |
+| ~~OQ-3~~ | ~~Modal or card presentation for `PaymentDetails`?~~ | **Resolved**: Card presentation (`presentation: 'card'`), matching the `TaskDetails` pattern. |
+
+---
+
+## 13. Checklist for Implementation
+
+**Schema & Domain**
+- [ ] Drizzle migration — add `default_due_date_days` to `projects` table
+- [ ] `src/infrastructure/database/schema.ts` — add column
+- [ ] `src/domain/entities/Project.ts` — add `defaultDueDateDays?: number`
+- [ ] `src/domain/entities/Invoice.ts` — add `canBeCancelled(linkedPayments: Payment[])` to `InvoiceEntity`
+- [ ] `src/domain/entities/Payment.ts` — add `invoiceStatus?` display-only field
+
+**Utilities**
+- [ ] `src/utils/workingDays.ts` — `addWorkingDays(date, days)` utility
+- [ ] `src/utils/resolveInvoiceDueDate.ts` — due date priority helper (with `dueDatePeriodDays` param)
+
+**Use Cases**
+- [ ] `src/application/usecases/payment/MarkPaymentAsPaidUseCase.ts` — new use case (handles real + synthetic + partial)
+- [ ] `src/application/usecases/invoice/CancelInvoiceUseCase.ts` — new use case with cancellation guard
+
+**Hook**
+- [ ] `src/hooks/usePayments.ts` — update `buildInvoicePayables()` to use `resolveInvoiceDueDate(inv, taskStartDate, project.defaultDueDateDays)` + set `invoiceStatus` on synthetic rows
+
+**UI**
+- [ ] `src/components/payments/PaymentCard.tsx` — dead-invoice red highlight state
+- [ ] `src/pages/payments/PaymentsNavigator.tsx` — new stack navigator
+- [ ] `src/pages/payments/PaymentDetails.tsx` — new screen (with invoice summary, payment history, mark-as-paid)
+- [ ] `src/pages/tabs/index.tsx` — swap `PaymentsScreen` for `PaymentsNavigator`
+
+**Tests**
+- [ ] Unit: `resolveInvoiceDueDate.test.ts`
+- [ ] Unit: `InvoiceEntity.canBeCancelled.test.ts`
+- [ ] Unit: `MarkPaymentAsPaidUseCase.test.ts`
+- [ ] Unit: `buildInvoicePayables.due-date.test.ts`
+- [ ] Unit: `buildInvoicePayables.staged.test.ts`
+- [ ] Integration: `PaymentDetails.navigation.test.ts`
+- [ ] Integration: `MarkPaymentAsPaid.integration.test.ts`
+
+**Quality**
+- [ ] `npx tsc --noEmit` passes

--- a/src/application/usecases/invoice/CancelInvoiceUseCase.ts
+++ b/src/application/usecases/invoice/CancelInvoiceUseCase.ts
@@ -1,5 +1,6 @@
-import { Invoice } from '../../../domain/entities/Invoice';
+import { Invoice, InvoiceEntity } from '../../../domain/entities/Invoice';
 import { InvoiceRepository } from '../../../domain/repositories/InvoiceRepository';
+import { PaymentRepository } from '../../../domain/repositories/PaymentRepository';
 
 export interface CancelInvoiceOptions {
   reason?: string;
@@ -7,7 +8,10 @@ export interface CancelInvoiceOptions {
 }
 
 export class CancelInvoiceUseCase {
-  constructor(private readonly repo: InvoiceRepository) {}
+  constructor(
+    private readonly repo: InvoiceRepository,
+    private readonly paymentRepo?: PaymentRepository,
+  ) {}
 
   async execute(
     invoiceId: string,
@@ -29,7 +33,14 @@ export class CancelInvoiceUseCase {
       throw new Error('Cannot cancel a paid invoice');
     }
 
-    // 3. Prepare audit trail entry
+    // 3. Guard: reject if any settled payment is linked to this invoice
+    if (this.paymentRepo) {
+      const linkedPayments = await this.paymentRepo.findByInvoice(invoiceId);
+      const entity = new InvoiceEntity(invoice);
+      entity.cancel(linkedPayments); // throws if settled payments exist
+    }
+
+    // 4. Prepare audit trail entry
     const now = new Date().toISOString();
     const statusChange = {
       from: invoice.status,
@@ -39,7 +50,7 @@ export class CancelInvoiceUseCase {
       ...(options?.reason && { reason: options.reason }),
     };
 
-    // 4. Preserve existing metadata and append to status history
+    // 5. Preserve existing metadata and append to status history
     const existingMetadata = invoice.metadata || {};
     const existingHistory = (existingMetadata.statusHistory as any[]) || [];
     
@@ -49,7 +60,7 @@ export class CancelInvoiceUseCase {
       ...(options?.reason && { cancellationReason: options.reason }),
     };
 
-    // 5. Update the invoice
+    // 6. Update the invoice
     const updates: Partial<Invoice> = {
       status: 'cancelled',
       metadata: updatedMetadata,

--- a/src/application/usecases/payment/MarkPaymentAsPaidUseCase.ts
+++ b/src/application/usecases/payment/MarkPaymentAsPaidUseCase.ts
@@ -1,0 +1,90 @@
+import { Payment } from '../../../domain/entities/Payment';
+import { PaymentRepository } from '../../../domain/repositories/PaymentRepository';
+import { InvoiceRepository } from '../../../domain/repositories/InvoiceRepository';
+
+export interface MarkPaymentAsPaidInput {
+  paymentId: string;
+  /** Partial amount paid. Defaults to the full outstanding payment amount if omitted. */
+  amount?: number;
+  method?: Payment['method'];
+  notes?: string;
+  reference?: string;
+}
+
+export interface MarkPaymentAsPaidResult {
+  payment: Payment;
+  invoicePaymentStatus?: 'unpaid' | 'partial' | 'paid';
+}
+
+/**
+ * Marks an existing pending payment record as settled.
+ *
+ * When the payment is linked to an invoice, the invoice's `paymentStatus` (and
+ * optionally `status`) are recalculated across all settled payments so that
+ * partial payments are reflected correctly.
+ */
+export class MarkPaymentAsPaidUseCase {
+  constructor(
+    private readonly paymentRepo: PaymentRepository,
+    private readonly invoiceRepo: InvoiceRepository,
+  ) {}
+
+  async execute(input: MarkPaymentAsPaidInput): Promise<MarkPaymentAsPaidResult> {
+    const { paymentId, amount, method, notes, reference } = input;
+
+    // 1. Load existing payment
+    const existing = await this.paymentRepo.findById(paymentId);
+    if (!existing) throw new Error(`Payment ${paymentId} not found`);
+
+    if (existing.status === 'settled') {
+      throw new Error('Payment is already settled');
+    }
+
+    // 2. Build updated payment record
+    const updated: Payment = {
+      ...existing,
+      status: 'settled',
+      ...(amount !== undefined && { amount }),
+      ...(method && { method }),
+      ...(notes !== undefined && { notes }),
+      ...(reference !== undefined && { reference }),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.paymentRepo.update(updated);
+
+    // 3. Recalculate invoice payment status when linked
+    let invoicePaymentStatus: MarkPaymentAsPaidResult['invoicePaymentStatus'];
+
+    if (updated.invoiceId) {
+      const invoice = await this.invoiceRepo.getInvoice(updated.invoiceId);
+      if (invoice) {
+        const allPayments = await this.paymentRepo.findByInvoice(updated.invoiceId);
+        const totalSettled = allPayments
+          .filter((p) => p.status === 'settled')
+          .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+
+        invoicePaymentStatus =
+          totalSettled >= invoice.total
+            ? 'paid'
+            : totalSettled > 0
+              ? 'partial'
+              : 'unpaid';
+
+        const invoiceUpdates: any = { paymentStatus: invoicePaymentStatus };
+
+        if (
+          invoicePaymentStatus === 'paid' &&
+          (invoice.status === 'issued' || invoice.status === 'overdue')
+        ) {
+          invoiceUpdates.status = 'paid';
+          invoiceUpdates.paymentDate = new Date().toISOString();
+        }
+
+        await this.invoiceRepo.updateInvoice(invoice.id, invoiceUpdates);
+      }
+    }
+
+    return { payment: updated, invoicePaymentStatus };
+  }
+}

--- a/src/components/payments/PaymentCard.tsx
+++ b/src/components/payments/PaymentCard.tsx
@@ -21,7 +21,10 @@ const formatCurrency = (amount: number): string =>
   new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', minimumFractionDigits: 0 }).format(amount);
 
 export default function PaymentCard({ payment, onPress, onPayNow }: PaymentCardProps) {
-  const dueStatus = payment.dueDate ? getDueStatus(payment.dueDate) : null;
+  const isDeadInvoice =
+    payment.invoiceStatus === 'cancelled' || payment.invoiceStatus === 'draft';
+
+  const dueStatus = !isDeadInvoice && payment.dueDate ? getDueStatus(payment.dueDate) : null;
   const label = categoryLabel(payment.paymentCategory, payment.stageLabel);
 
   const footerBg =
@@ -68,8 +71,16 @@ export default function PaymentCard({ payment, onPress, onPayNow }: PaymentCardP
         <Text className="text-lg font-bold text-foreground">{formatCurrency(payment.amount)}</Text>
       </View>
 
-      {/* Footer — due status */}
-      {dueStatus ? (
+      {/* Footer — dead-invoice banner or due status */}
+      {isDeadInvoice ? (
+        <View style={styles.footerDeadInvoice} className="px-4 py-2 flex-row items-center">
+          <Text style={styles.footerTextDeadInvoice} className="text-xs font-semibold">
+            {payment.invoiceStatus === 'cancelled'
+              ? 'Invoice cancelled'
+              : 'Invoice draft — not yet issued'}
+          </Text>
+        </View>
+      ) : dueStatus ? (
         <View style={[styles.footer, footerBg]} className="px-4 py-2 flex-row items-center justify-between">
           <Text style={footerText} className="text-xs font-semibold">
             {dueStatus.text}
@@ -96,7 +107,9 @@ const styles = StyleSheet.create({
   footerOverdue: { backgroundColor: '#fef2f2' },
   footerDueSoon: { backgroundColor: '#fffbeb' },
   footerOnTime: { backgroundColor: '#f0fdf4' },
+  footerDeadInvoice: { backgroundColor: '#fef2f2', minHeight: 36 },
   footerTextOverdue: { color: '#dc2626' },
   footerTextDueSoon: { color: '#d97706' },
   footerTextOnTime: { color: '#16a34a' },
+  footerTextDeadInvoice: { color: '#6b7280' },
 });

--- a/src/domain/entities/Invoice.ts
+++ b/src/domain/entities/Invoice.ts
@@ -1,3 +1,5 @@
+import { Payment } from './Payment';
+
 export interface InvoiceLineItem {
   id?: string;
   description: string;
@@ -130,4 +132,25 @@ export class InvoiceEntity {
   }
 
   data(): Invoice { return { ...this._data }; }
+
+  /** Returns whether this invoice can be cancelled given its linked payments. */
+  canBeCancelled(linkedPayments: Payment[]): { allowed: boolean; reason?: string } {
+    const hasSettled = linkedPayments.some((p) => p.status === 'settled');
+    if (hasSettled) {
+      return {
+        allowed: false,
+        reason: 'Invoice has one or more settled payments. Reverse all payments before cancelling.',
+      };
+    }
+    return { allowed: true };
+  }
+
+  /**
+   * Marks the invoice as cancelled.
+   * Throws a domain error if the invoice has settled payments.
+   */
+  cancel(linkedPayments: Payment[]): void {
+    const check = this.canBeCancelled(linkedPayments);
+    if (!check.allowed) throw new Error(check.reason);
+  }
 }

--- a/src/domain/entities/Payment.ts
+++ b/src/domain/entities/Payment.ts
@@ -17,6 +17,8 @@ export interface Payment {
   contractorName?: string;       // denormalized from Contact.name for list performance
   paymentCategory?: 'contract' | 'variation' | 'other'; // grouping discriminator
   stageLabel?: string;           // e.g. "Frame Stage", "Patching"
+  /** Snapshot of the parent invoice status — display-only, not persisted on payment rows */
+  invoiceStatus?: 'draft' | 'issued' | 'paid' | 'overdue' | 'cancelled';
   createdAt?: string;
   updatedAt?: string;
 }

--- a/src/domain/entities/Project.ts
+++ b/src/domain/entities/Project.ts
@@ -29,6 +29,9 @@ export interface Project {
   /** Arbitrary regulatory constraint labels (e.g. heritage overlay codes). */
   regulatoryFlags?: string[];
 
+  /** Default calendar days to add from invoice issue date when dateDue is absent. Defaults to 5. */
+  defaultDueDateDays?: number;
+
   createdAt?: Date;
   updatedAt?: Date;
 }

--- a/src/hooks/usePayments.ts
+++ b/src/hooks/usePayments.ts
@@ -13,6 +13,7 @@ import { ListGlobalPaymentsUseCase } from '../application/usecases/payment/ListG
 import { GetGlobalAmountPayableUseCase } from '../application/usecases/payment/GetGlobalAmountPayableUseCase';
 import { ListPaymentsUseCase } from '../application/usecases/payment/ListPaymentsUseCase';
 import { GetPaymentMetricsUseCase } from '../application/usecases/payment/GetPaymentMetricsUseCase';
+import { resolveInvoiceDueDate } from '../utils/resolveInvoiceDueDate';
 import '../infrastructure/di/registerServices';
 
 export type PaymentsMode = 'firefighter' | 'site_manager';
@@ -58,6 +59,7 @@ async function buildInvoicePayables(
   paymentRepo: PaymentRepository,
   taskRepo?: TaskRepository | null,
   contactRepo?: ContactRepository | null,
+  projectMap?: Map<string, Project>,
 ): Promise<Payment[]> {
   const payableRows: Payment[] = [];
 
@@ -76,17 +78,27 @@ async function buildInvoicePayables(
     if (outstanding <= 0) continue;
 
     let contractorName = deriveContractorNameFromInvoice(inv);
+    let taskStartDate: string | null = null;
 
-    // Fallback: derive name from linked task's subcontractor when all other fields are empty
-    if (contractorName === 'Invoice Payable' && inv.taskId && taskRepo && contactRepo) {
+    // Fetch linked task once — used for contractor name fallback AND due date anchor
+    if (inv.taskId && taskRepo) {
       try {
         const task = await taskRepo.findById(inv.taskId);
-        if (task?.subcontractorId) {
-          const contact = await contactRepo.findById(task.subcontractorId);
-          if (contact?.name) contractorName = contact.name;
+        if (task) {
+          // Use scheduled start as the due-date anchor
+          taskStartDate = task.scheduledAt ?? task.scheduledStart ?? null;
+          // Contractor name fallback via subcontractor contact
+          if (contractorName === 'Invoice Payable' && contactRepo && task.subcontractorId) {
+            const contact = await contactRepo.findById(task.subcontractorId);
+            if (contact?.name) contractorName = contact.name;
+          }
         }
       } catch { /* ignore — non-critical enrichment */ }
     }
+
+    const project = inv.projectId ? projectMap?.get(inv.projectId) : undefined;
+    const dueDatePeriodDays = project?.defaultDueDateDays ?? 5;
+    const dueDate = resolveInvoiceDueDate(inv, taskStartDate, dueDatePeriodDays);
 
     payableRows.push({
       id: `invoice-payable:${inv.id}`,
@@ -95,8 +107,9 @@ async function buildInvoicePayables(
       amount: outstanding,
       currency: inv.currency,
       date: inv.dateIssued ?? inv.issueDate,
-      dueDate: inv.dateDue ?? inv.dueDate,
+      dueDate,
       status: 'pending',
+      invoiceStatus: inv.status,
       contractorName,
       paymentCategory: deriveCategoryFromInvoice(inv),
       stageLabel: inv.externalReference ?? inv.invoiceNumber,
@@ -186,7 +199,22 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
           invoiceRepo.listInvoices({ limit: 500 }),
         ]);
 
-        const invoicePayablesRaw = await buildInvoicePayables(invoiceResult.items, paymentRepo, taskRepo, contactRepo);
+        // Build project map from invoice project IDs so buildInvoicePayables can resolve
+        // per-project defaultDueDateDays for due date computation.
+        const invoiceProjectIds = [
+          ...new Set(invoiceResult.items.map((inv) => inv.projectId).filter(Boolean)),
+        ] as string[];
+        const projectMap = new Map<string, Project>();
+        await Promise.all(
+          invoiceProjectIds.map(async (id) => {
+            try {
+              const proj = await projectRepo.findById(id);
+              if (proj) projectMap.set(id, proj);
+            } catch (_) { /* ignore missing projects */ }
+          }),
+        );
+
+        const invoicePayablesRaw = await buildInvoicePayables(invoiceResult.items, paymentRepo, taskRepo, contactRepo, projectMap);
         const invoicePayables = contractorSearch
           ? invoicePayablesRaw.filter((p) =>
               (p.contractorName ?? '').toLowerCase().includes(contractorSearch.toLowerCase()),
@@ -195,21 +223,24 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
 
         const mergedGlobalItems = [...result.items, ...invoicePayables];
 
-        // Resolve project names for display
-        const projectMap = new Map<string, string>();
-        const projectIds = [...new Set(mergedGlobalItems.map(p => p.projectId).filter(Boolean))] as string[];
+        // Ensure payment-only project IDs are also resolved (for display names)
+        const additionalProjectIds = [
+          ...new Set(result.items.map((p) => p.projectId).filter(Boolean)),
+        ] as string[];
         await Promise.all(
-          projectIds.map(async (id) => {
-            try {
-              const proj: Project | null = await projectRepo.findById(id);
-              if (proj) projectMap.set(id, proj.name);
-            } catch (_) { /* ignore missing projects */ }
-          }),
+          additionalProjectIds
+            .filter((id) => !projectMap.has(id))
+            .map(async (id) => {
+              try {
+                const proj = await projectRepo.findById(id);
+                if (proj) projectMap.set(id, proj);
+              } catch (_) { /* ignore missing projects */ }
+            }),
         );
 
         const enriched: PaymentWithProject[] = mergedGlobalItems.map(p => ({
           ...p,
-          projectName: p.projectId ? (projectMap.get(p.projectId) ?? p.projectId) : undefined,
+          projectName: p.projectId ? (projectMap.get(p.projectId)?.name ?? p.projectId) : undefined,
         }));
 
         setGlobalPayments(enriched);
@@ -224,7 +255,16 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
           invoiceRepo.listInvoices({ projectId, limit: 500 }),
         ]);
 
-        const invoicePayables = await buildInvoicePayables(invoiceResult.items, paymentRepo, taskRepo, contactRepo);
+        // Load the current project for defaultDueDateDays resolution
+        const projectMap = new Map<string, Project>();
+        if (projectId) {
+          try {
+            const proj = await projectRepo.findById(projectId);
+            if (proj) projectMap.set(projectId, proj);
+          } catch (_) { /* ignore */ }
+        }
+
+        const invoicePayables = await buildInvoicePayables(invoiceResult.items, paymentRepo, taskRepo, contactRepo, projectMap);
         const invoiceContracts = invoicePayables.filter((p) => p.paymentCategory === 'contract');
         const invoiceVariations = invoicePayables.filter((p) => p.paymentCategory === 'variation');
 

--- a/src/infrastructure/database/migrations.ts
+++ b/src/infrastructure/database/migrations.ts
@@ -856,6 +856,22 @@ const migrations: RNMigration[] = [
       }
     },
   },
+  {
+    tag: '0021_project_due_date_days',
+    hash: '0021_project_due_date_days',
+    folderMillis: 1748736000000, // 2025-06-01
+    sql: [],
+    run: async (db) => {
+      const [result] = await db.executeSql(`SELECT name FROM pragma_table_info('projects')`);
+      const existing = new Set<string>();
+      for (let i = 0; i < result.rows.length; i++) {
+        existing.add(result.rows.item(i).name);
+      }
+      if (!existing.has('default_due_date_days')) {
+        await db.executeSql(`ALTER TABLE "projects" ADD COLUMN "default_due_date_days" integer DEFAULT 5`);
+      }
+    },
+  },
 ];
 
 export function getBundledMigrations(): RNMigration[] {

--- a/src/infrastructure/database/schema.ts
+++ b/src/infrastructure/database/schema.ts
@@ -20,6 +20,8 @@ export const projects = sqliteTable('projects', {
   location: text('location'),               // street address or lat/lng string
   fireZone: text('fire_zone'),              // BAL rating or zone code
   regulatoryFlags: text('regulatory_flags'), // JSON array of constraint labels
+  // Default days to add from invoice issue date when dateDue is absent (issue #146)
+  defaultDueDateDays: integer('default_due_date_days').default(5),
   createdAt: integer('created_at'),
   updatedAt: integer('updated_at'),
 }, (table) => ({

--- a/src/infrastructure/repositories/DrizzleProjectRepository.ts
+++ b/src/infrastructure/repositories/DrizzleProjectRepository.ts
@@ -107,8 +107,8 @@ export class DrizzleProjectRepository implements ProjectRepository {
         `INSERT INTO projects (
           id, property_id, owner_id, name, description, status,
           start_date, expected_end_date, budget, currency, meta,
-          created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          default_due_date_days, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           project.id,
           project.propertyId || null,
@@ -121,6 +121,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
           project.budget || null,
           project.currency || null,
           project.meta ? JSON.stringify(project.meta) : null,
+          project.defaultDueDateDays ?? null,
           project.createdAt ? project.createdAt.getTime() : null,
           project.updatedAt ? project.updatedAt.getTime() : null,
         ]
@@ -318,8 +319,8 @@ export class DrizzleProjectRepository implements ProjectRepository {
       const txRepo = {
         save: async (project: Project) => {
           await tx.executeSql(
-            `INSERT INTO projects (id, property_id, owner_id, name, description, status, start_date, expected_end_date, budget, currency, meta, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `INSERT INTO projects (id, property_id, owner_id, name, description, status, start_date, expected_end_date, budget, currency, meta, default_due_date_days, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
              property_id=excluded.property_id,
              owner_id=excluded.owner_id,
@@ -331,6 +332,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
              budget=excluded.budget,
              currency=excluded.currency,
              meta=excluded.meta,
+             default_due_date_days=excluded.default_due_date_days,
              updated_at=excluded.updated_at`,
             [
               project.id,
@@ -344,6 +346,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
               project.budget,
               project.currency,
               project.meta ? JSON.stringify(project.meta) : null,
+              project.defaultDueDateDays ?? null,
               project.createdAt?.getTime() || Date.now(),
               project.updatedAt?.getTime() || Date.now()
             ]
@@ -429,7 +432,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
         `UPDATE projects SET
           property_id = ?, owner_id = ?, name = ?, description = ?, status = ?,
           start_date = ?, expected_end_date = ?, budget = ?, currency = ?,
-          meta = ?, updated_at = ?
+          meta = ?, default_due_date_days = ?, updated_at = ?
          WHERE id = ?`,
         [
           project.propertyId || null,
@@ -442,6 +445,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
           project.budget || null,
           project.currency || null,
           project.meta ? JSON.stringify(project.meta) : null,
+          project.defaultDueDateDays ?? null,
           project.updatedAt ? project.updatedAt.getTime() : Date.now(),
           project.id,
         ]
@@ -562,6 +566,7 @@ export class DrizzleProjectRepository implements ProjectRepository {
       materials,
       phases,
       meta: row.meta ? JSON.parse(row.meta) : undefined,
+      defaultDueDateDays: row.default_due_date_days ?? undefined,
       createdAt: row.created_at ? new Date(row.created_at) : undefined,
       updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
     };

--- a/src/pages/payments/PaymentDetails.tsx
+++ b/src/pages/payments/PaymentDetails.tsx
@@ -1,0 +1,295 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute, useNavigation } from '@react-navigation/native';
+import { ChevronLeft } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
+import { container } from 'tsyringe';
+import { Payment } from '../../domain/entities/Payment';
+import { Invoice } from '../../domain/entities/Invoice';
+import { PaymentRepository } from '../../domain/repositories/PaymentRepository';
+import { InvoiceRepository } from '../../domain/repositories/InvoiceRepository';
+import { MarkPaymentAsPaidUseCase } from '../../application/usecases/payment/MarkPaymentAsPaidUseCase';
+import { getDueStatus } from '../../utils/getDueStatus';
+import '../../infrastructure/di/registerServices';
+
+const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 0,
+  }).format(amount);
+
+const formatDate = (iso?: string | null): string => {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleDateString('en-AU', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+};
+
+export default function PaymentDetails() {
+  const route = useRoute<any>();
+  const navigation = useNavigation<any>();
+  const { colorScheme } = useColorScheme();
+  const isDark = colorScheme === 'dark';
+  const iconColor = isDark ? '#e4e4e7' : '#18181b';
+
+  const { paymentId, syntheticRow } = route.params as {
+    paymentId?: string;
+    syntheticRow?: Payment;
+  };
+
+  const [payment, setPayment] = useState<Payment | null>(syntheticRow ?? null);
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
+  const [linkedPayments, setLinkedPayments] = useState<Payment[]>([]);
+  const [loading, setLoading] = useState(!syntheticRow);
+  const [marking, setMarking] = useState(false);
+
+  const paymentRepo = React.useMemo(
+    () => container.resolve<PaymentRepository>('PaymentRepository' as any),
+    [],
+  );
+  const invoiceRepo = React.useMemo(
+    () => container.resolve<InvoiceRepository>('InvoiceRepository' as any),
+    [],
+  );
+  const markPaidUc = React.useMemo(
+    () => new MarkPaymentAsPaidUseCase(paymentRepo, invoiceRepo),
+    [paymentRepo, invoiceRepo],
+  );
+
+  const loadData = useCallback(async () => {
+    try {
+      let resolved = syntheticRow ?? null;
+
+      // Synthetic rows (id starts with "invoice-payable:") don't exist in DB
+      const isSynthetic = resolved?.id?.startsWith('invoice-payable:');
+
+      if (!isSynthetic && paymentId) {
+        resolved = await paymentRepo.findById(paymentId);
+      }
+
+      setPayment(resolved);
+
+      // Load parent invoice for context
+      const invoiceId = resolved?.invoiceId;
+      if (invoiceId) {
+        const [inv, payments] = await Promise.all([
+          invoiceRepo.getInvoice(invoiceId),
+          paymentRepo.findByInvoice(invoiceId),
+        ]);
+        setInvoice(inv);
+        setLinkedPayments(payments.filter((p) => p.id !== resolved?.id));
+      }
+    } catch (e: any) {
+      Alert.alert('Error', e?.message ?? 'Failed to load payment details');
+    } finally {
+      setLoading(false);
+    }
+  }, [paymentId, syntheticRow, paymentRepo, invoiceRepo]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleMarkAsPaid = () => {
+    if (!payment || payment.id.startsWith('invoice-payable:')) {
+      Alert.alert(
+        'Record Payment',
+        'This obligation is derived from an invoice. Please record a payment against the invoice directly.',
+      );
+      return;
+    }
+
+    Alert.alert('Mark as Paid', `Confirm payment of ${formatCurrency(payment.amount ?? 0)}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Confirm',
+        onPress: async () => {
+          setMarking(true);
+          try {
+            await markPaidUc.execute({ paymentId: payment.id });
+            Alert.alert('Done', 'Payment marked as settled.', [
+              { text: 'OK', onPress: () => { navigation.goBack(); } },
+            ]);
+          } catch (e: any) {
+            Alert.alert('Error', e?.message ?? 'Failed to mark payment as paid');
+          } finally {
+            setMarking(false);
+          }
+        },
+      },
+    ]);
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView className="flex-1 bg-background items-center justify-center">
+        <ActivityIndicator size="large" />
+      </SafeAreaView>
+    );
+  }
+
+  if (!payment) {
+    return (
+      <SafeAreaView className="flex-1 bg-background items-center justify-center">
+        <Text className="text-muted-foreground">Payment not found.</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const isSynthetic = payment.id.startsWith('invoice-payable:');
+  const dueStatus = payment.dueDate ? getDueStatus(payment.dueDate) : null;
+  const totalSettled = linkedPayments
+    .filter((p) => p.status === 'settled')
+    .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      {/* Header */}
+      <View className="px-4 pt-4 pb-3 border-b border-border flex-row items-center">
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          className="mr-3"
+        >
+          <ChevronLeft size={24} color={iconColor} />
+        </TouchableOpacity>
+        <Text className="text-xl font-bold text-foreground flex-1" numberOfLines={1}>
+          {payment.contractorName ?? 'Payment Detail'}
+        </Text>
+      </View>
+
+      <ScrollView className="flex-1 px-4 pt-4" contentContainerStyle={styles.content}>
+        {/* Amount + Status */}
+        <View className="bg-card border border-border rounded-xl p-4 mb-4">
+          <Text className="text-3xl font-bold text-foreground mb-1">
+            {formatCurrency(payment.amount ?? 0)}
+          </Text>
+          <View className="flex-row items-center gap-2">
+            <View
+              className={`px-2 py-0.5 rounded ${
+                payment.status === 'settled' ? 'bg-green-100' : 'bg-amber-100'
+              }`}
+            >
+              <Text
+                className={`text-xs font-semibold ${
+                  payment.status === 'settled' ? 'text-green-700' : 'text-amber-700'
+                }`}
+              >
+                {payment.status === 'settled' ? 'Settled' : 'Pending'}
+              </Text>
+            </View>
+            {dueStatus && payment.status !== 'settled' && (
+              <Text style={{ color: dueStatus.style === 'overdue' ? '#dc2626' : dueStatus.style === 'due-soon' ? '#d97706' : '#16a34a' }} className="text-xs font-semibold">
+                {dueStatus.text}
+              </Text>
+            )}
+          </View>
+        </View>
+
+        {/* Invoice summary */}
+        {invoice && (
+          <View className="bg-card border border-border rounded-xl p-4 mb-4">
+            <Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+              Invoice
+            </Text>
+            <Row label="Reference" value={invoice.externalReference ?? invoice.invoiceNumber ?? invoice.id} />
+            <Row label="Issued by" value={invoice.issuerName ?? '—'} />
+            <Row label="Issue date" value={formatDate(invoice.dateIssued ?? invoice.issueDate)} />
+            <Row label="Due date" value={formatDate(invoice.dateDue ?? invoice.dueDate)} />
+            <Row label="Total" value={formatCurrency(invoice.total)} />
+            <Row label="Payment status" value={invoice.paymentStatus} />
+            {invoice.status === 'cancelled' && (
+              <View className="mt-2 bg-red-50 rounded px-3 py-2">
+                <Text className="text-xs text-red-600 font-semibold">Invoice cancelled</Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* Payment details */}
+        <View className="bg-card border border-border rounded-xl p-4 mb-4">
+          <Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            Details
+          </Text>
+          <Row label="Category" value={payment.paymentCategory ?? '—'} />
+          <Row label="Stage" value={payment.stageLabel ?? '—'} />
+          <Row label="Due" value={formatDate(payment.dueDate)} />
+          <Row label="Method" value={payment.method ?? '—'} />
+          <Row label="Reference" value={payment.reference ?? '—'} />
+          {payment.notes ? <Row label="Notes" value={payment.notes} /> : null}
+        </View>
+
+        {/* Payment history for this invoice */}
+        {linkedPayments.length > 0 && (
+          <View className="bg-card border border-border rounded-xl p-4 mb-4">
+            <Text className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+              Payment History
+            </Text>
+            {linkedPayments.map((p) => (
+              <View key={p.id} className="flex-row items-center justify-between py-2 border-b border-border last:border-0">
+                <View>
+                  <Text className="text-sm text-foreground">{formatDate(p.date ?? p.updatedAt)}</Text>
+                  <Text className="text-xs text-muted-foreground capitalize">{p.status}</Text>
+                </View>
+                <Text className="text-sm font-semibold text-foreground">{formatCurrency(p.amount ?? 0)}</Text>
+              </View>
+            ))}
+            {totalSettled > 0 && (
+              <View className="flex-row justify-between pt-2 mt-1">
+                <Text className="text-sm font-semibold text-foreground">Total settled</Text>
+                <Text className="text-sm font-semibold text-green-600">{formatCurrency(totalSettled)}</Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* Mark as paid CTA */}
+        {payment.status === 'pending' && !isSynthetic && (
+          <TouchableOpacity
+            onPress={handleMarkAsPaid}
+            disabled={marking}
+            className="bg-primary rounded-xl py-4 items-center mb-6"
+            activeOpacity={0.8}
+          >
+            {marking ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text className="text-primary-foreground font-bold text-base">
+                Mark as Paid
+              </Text>
+            )}
+          </TouchableOpacity>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Row({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <View className="flex-row justify-between py-1.5">
+      <Text className="text-sm text-muted-foreground">{label}</Text>
+      <Text className="text-sm text-foreground font-medium flex-shrink ml-4 text-right">{value ?? '—'}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: { paddingBottom: 32 },
+});

--- a/src/pages/payments/PaymentsNavigator.tsx
+++ b/src/pages/payments/PaymentsNavigator.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import PaymentsScreen from './index';
+import PaymentDetails from './PaymentDetails';
+import { Payment } from '../../domain/entities/Payment';
+
+export type PaymentsStackParamList = {
+  PaymentsList: undefined;
+  PaymentDetails: { paymentId?: string; syntheticRow?: Payment };
+};
+
+const Stack = createNativeStackNavigator();
+
+export default function PaymentsNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="PaymentsList" component={PaymentsScreen} />
+      <Stack.Screen
+        name="PaymentDetails"
+        component={PaymentDetails}
+        options={{ presentation: 'card' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/pages/payments/index.tsx
+++ b/src/pages/payments/index.tsx
@@ -6,6 +6,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Search, ChevronDown, ChevronUp, Layers, Filter } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
+import { useNavigation } from '@react-navigation/native';
 import { ThemeToggle } from '../../components/ThemeToggle';
 import AmountPayableBanner from '../../components/payments/AmountPayableBanner';
 import PaymentCard, { PaymentCardPayment } from '../../components/payments/PaymentCard';
@@ -17,6 +18,15 @@ export default function PaymentsScreen() {
   const isDark = colorScheme === 'dark';
   const iconPrimary = isDark ? '#3b82f6' : '#2563eb';
   const iconMuted = isDark ? '#a1a1aa' : '#71717a';
+  const navigation = useNavigation<any>();
+
+  const handlePaymentPress = (p: PaymentCardPayment) => {
+    if (p.id.startsWith('invoice-payable:')) {
+      navigation.navigate('PaymentDetails', { syntheticRow: p });
+    } else {
+      navigation.navigate('PaymentDetails', { paymentId: p.id });
+    }
+  };
 
   const [mode, setMode] = useState<PaymentsMode>('firefighter');
   const [contractorSearch, setContractorSearch] = useState('');
@@ -84,7 +94,7 @@ export default function PaymentsScreen() {
           </Text>
         </View>
       ) : (
-        globalPayments.map((p) => <PaymentCard key={p.id} payment={p} />)
+        globalPayments.map((p) => <PaymentCard key={p.id} payment={p} onPress={() => handlePaymentPress(p)} />)
       )}
     </>
   );
@@ -136,7 +146,7 @@ export default function PaymentsScreen() {
             {contractPayments.length === 0 ? (
               <Text className="text-muted-foreground text-xs px-1 pb-2">No contract payments.</Text>
             ) : (
-              contractPayments.map((p) => <PaymentCard key={p.id} payment={p as PaymentCardPayment} />)
+              contractPayments.map((p) => <PaymentCard key={p.id} payment={p as PaymentCardPayment} onPress={() => handlePaymentPress(p as PaymentCardPayment)} />)
             )}
           </CollapsibleSection>
 
@@ -149,7 +159,7 @@ export default function PaymentsScreen() {
             {variationPayments.length === 0 ? (
               <Text className="text-muted-foreground text-xs px-1 pb-2">No variation payments.</Text>
             ) : (
-              variationPayments.map((p) => <PaymentCard key={p.id} payment={p as PaymentCardPayment} />)
+              variationPayments.map((p) => <PaymentCard key={p.id} payment={p as PaymentCardPayment} onPress={() => handlePaymentPress(p as PaymentCardPayment)} />)
             )}
           </CollapsibleSection>
         </>

--- a/src/pages/tabs/index.tsx
+++ b/src/pages/tabs/index.tsx
@@ -4,7 +4,7 @@ import { Home, CreditCard, CheckSquare, User } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
 import { cssInterop } from 'nativewind';
 import DashboardScreen from '../dashboard';
-import PaymentsScreen from '../payments';
+import PaymentsNavigator from '../payments/PaymentsNavigator';
 import TasksNavigator from '../tasks/TasksNavigator';
 import ProjectsPage from '../projects/ProjectsPage';
 
@@ -47,7 +47,7 @@ export default function TabsLayout() {
       />
       <Tab.Screen
         name="Finances"
-        component={PaymentsScreen}
+        component={PaymentsNavigator}
         options={{
           title: 'Finances',
           tabBarIcon: FinancesIcon,

--- a/src/utils/resolveInvoiceDueDate.ts
+++ b/src/utils/resolveInvoiceDueDate.ts
@@ -1,0 +1,47 @@
+import { Invoice } from '../domain/entities/Invoice';
+import { addWorkingDays } from './workingDays';
+
+/**
+ * Resolves the effective due date for a payment obligation derived from an invoice.
+ *
+ * Priority order:
+ *   1. `inv.dateDue` — explicit due date stored on the invoice
+ *   2. `inv.dueDate` — legacy alias for dateDue
+ *   3. `taskStartDate` + `dueDatePeriodDays` working days
+ *   4. `inv.dateIssued` / `inv.issueDate` + `dueDatePeriodDays` working days
+ *   5. Today + `dueDatePeriodDays` working days (last-resort fallback)
+ *
+ * @param invoice          The invoice record
+ * @param taskStartDate    Optional ISO date string of the linked task's start date
+ * @param dueDatePeriodDays  Working days to add when no explicit date is available (default 5)
+ * @returns ISO date string (YYYY-MM-DD)
+ */
+export function resolveInvoiceDueDate(
+  invoice: Pick<Invoice, 'dateDue' | 'dueDate' | 'dateIssued' | 'issueDate' | 'metadata'>,
+  taskStartDate?: string | null,
+  dueDatePeriodDays: number = 5,
+): string {
+  // 1 & 2: explicit due date on invoice
+  const explicit = invoice.dateDue ?? invoice.dueDate;
+  if (explicit) return explicit;
+
+  // 3: task start date as anchor
+  if (taskStartDate) {
+    const anchor = new Date(taskStartDate);
+    if (!isNaN(anchor.getTime())) {
+      return addWorkingDays(anchor, dueDatePeriodDays).toISOString().slice(0, 10);
+    }
+  }
+
+  // 4: invoice issue date as anchor
+  const issued = invoice.dateIssued ?? invoice.issueDate;
+  if (issued) {
+    const anchor = new Date(issued);
+    if (!isNaN(anchor.getTime())) {
+      return addWorkingDays(anchor, dueDatePeriodDays).toISOString().slice(0, 10);
+    }
+  }
+
+  // 5: fallback to today
+  return addWorkingDays(new Date(), dueDatePeriodDays).toISOString().slice(0, 10);
+}

--- a/src/utils/workingDays.ts
+++ b/src/utils/workingDays.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns a new Date that is `days` calendar days after `start`.
+ * Saturdays and Sundays are skipped so that the result always falls on a weekday.
+ */
+export function addWorkingDays(start: Date, days: number): Date {
+  if (days <= 0) return new Date(start);
+  const result = new Date(start);
+  let remaining = days;
+  while (remaining > 0) {
+    result.setDate(result.getDate() + 1);
+    const dow = result.getDay();
+    if (dow !== 0 && dow !== 6) {
+      remaining--;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Implements Payment Card Detail per issue #146.

Summary of changes:
- Domain: add invoice cancel guard and project defaultDueDateDays
- DB: add `default_due_date_days` column and migration
- New use case: MarkPaymentAsPaid
- UI: PaymentDetails screen, PaymentsStack navigator, PaymentCard dead-invoice state
- Utilities: workingDays, resolveInvoiceDueDate

Includes unit and integration tests. Please review and merge to `master`.