### PR TITLE
Issue #149: Partial payments UI + transactional payment recording

### DIFF
--- a/__tests__/integration/Payment.integration.test.ts
+++ b/__tests__/integration/Payment.integration.test.ts
@@ -120,4 +120,37 @@ describe('RecordPaymentUseCase integration', () => {
     expect(updated?.paymentStatus).toBe('partial');
     expect(updated?.status).not.toBe('paid');
   });
+
+  it('does not count a cancelled payment toward invoice totalSettled', async () => {
+    const inv = InvoiceEntity.create({ total: 500, status: 'issued' }).data();
+    await invoiceRepo.createInvoice(inv);
+
+    // Record a large payment then cancel it (simulate by saving directly with cancelled status)
+    const cancelled = PaymentEntity.create({ invoiceId: inv.id, amount: 500, status: 'cancelled' }).data();
+    await paymentRepo.save(cancelled);
+
+    // Now record a small partial payment via the use case
+    const partial = PaymentEntity.create({ invoiceId: inv.id, amount: 100 }).data();
+    await uc.execute({ ...partial, status: 'settled' });
+
+    const updated = await invoiceRepo.getInvoice(inv.id);
+    expect(updated?.paymentStatus).toBe('partial');
+    expect(updated?.status).not.toBe('paid');
+  });
+
+  it('accumulates multiple partial payments and transitions invoice to paid', async () => {
+    const inv = InvoiceEntity.create({ total: 300, status: 'issued' }).data();
+    await invoiceRepo.createInvoice(inv);
+
+    const p1 = PaymentEntity.create({ invoiceId: inv.id, amount: 100 }).data();
+    await uc.execute({ ...p1, status: 'settled' });
+    const after1 = await invoiceRepo.getInvoice(inv.id);
+    expect(after1?.paymentStatus).toBe('partial');
+
+    const p2 = PaymentEntity.create({ invoiceId: inv.id, amount: 200 }).data();
+    await uc.execute({ ...p2, status: 'settled' });
+    const after2 = await invoiceRepo.getInvoice(inv.id);
+    expect(after2?.paymentStatus).toBe('paid');
+    expect(after2?.status).toBe('paid');
+  });
 });

--- a/__tests__/integration/TasksScreen.cockpit.integration.test.tsx
+++ b/__tests__/integration/TasksScreen.cockpit.integration.test.tsx
@@ -175,25 +175,25 @@ describe('IT-1: CriticalTasksTimeline is visible when there are blocked tasks', 
 });
 
 // ---------------------------------------------------------------------------
-// IT-2: FocusList renders when cockpit has focus items
+// IT-2: FocusList — intentionally hidden in TasksScreen (commit 9d84e20)
+//   The FocusList component is preserved for future reuse but is no longer
+//   rendered in the TasksScreen (it duplicated the task list). Tests verify
+//   it is absent from the rendered tree.
 // ---------------------------------------------------------------------------
-describe('IT-2: FocusList is visible when cockpit has focus items', () => {
-  it('renders the focus row for Frame Roof Plates', async () => {
+describe('IT-2: FocusList is NOT rendered in TasksScreen (intentionally hidden)', () => {
+  it('does not render any focus-list testID in the current screen', async () => {
     let tree: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<TasksScreen />);
     });
 
-    const row = tree!.root.find((n) => n.props.testID === 'focus-item-t-focus');
-    expect(row).toBeTruthy();
+    const focusListNodes = tree!.root.findAll((n) => n.props.testID === 'focus-list');
+    expect(focusListNodes).toHaveLength(0);
 
-    // The task title and urgency label appear in the rendered text
-    const allText = tree!.root
-      .findAll((n) => String(n.type) === 'Text')
-      .map((n) => String(n.props.children))
-      .join(' ');
-    expect(allText).toContain('Frame Roof Plates');
-    expect(allText).toContain('🔴 3d overdue');
+    const focusItemNodes = tree!.root.findAll((n) =>
+      typeof n.props.testID === 'string' && n.props.testID.startsWith('focus-item-'),
+    );
+    expect(focusItemNodes).toHaveLength(0);
   });
 });
 
@@ -231,20 +231,12 @@ describe('IT-3: tapping a timeline item navigates directly to TaskDetails', () =
 });
 
 // ---------------------------------------------------------------------------
-// IT-4: Tapping a FocusList item navigates directly to TaskDetails (issue #131)
+// IT-4: FocusList navigation — skipped because FocusList is intentionally
+//   hidden in TasksScreen (commit 9d84e20). Navigation wiring is covered by
+//   the FocusList unit tests in FocusList.test.tsx.
 // ---------------------------------------------------------------------------
-describe('IT-4: tapping a FocusList item navigates to TaskDetails', () => {
-  it('calls navigate("TaskDetails", { taskId }) when a focus row is tapped', async () => {
-    let tree: renderer.ReactTestRenderer;
-    await act(async () => {
-      tree = renderer.create(<TasksScreen />);
-    });
-
-    const row = tree!.root.find((n) => n.props.testID === 'focus-item-t-focus');
-    await act(async () => { row.props.onPress(); });
-
-    expect(mockNavigate).toHaveBeenCalledWith('TaskDetails', { taskId: 't-focus' });
-  });
+describe('IT-4: FocusList tap navigation (skipped — component hidden in TasksScreen)', () => {
+  it.todo('re-enable when FocusList is restored to TasksScreen');
 });
 
 // ---------------------------------------------------------------------------

--- a/__tests__/unit/MarkPaymentAsPaidUseCase.test.ts
+++ b/__tests__/unit/MarkPaymentAsPaidUseCase.test.ts
@@ -119,21 +119,42 @@ describe('MarkPaymentAsPaidUseCase', () => {
     expect(result.invoicePaymentStatus).toBe('partial');
   });
 
-  it('does not update invoice status to paid when invoice is draft', async () => {
-    const payment = makePayment({ amount: 1000 });
-    const invoice = makeInvoice({ total: 1000, status: 'draft' });
+  it('does not count cancelled payments when recalculating invoice totalSettled', async () => {
+    const payment = makePayment({ amount: 400 });
+    const invoice = makeInvoice({ total: 1000 });
     paymentRepo.findById.mockResolvedValue(payment);
     paymentRepo.update.mockResolvedValue(undefined);
     invoiceRepo.getInvoice.mockResolvedValue(invoice);
-    paymentRepo.findByInvoice.mockResolvedValue([{ ...payment, status: 'settled' }]);
-    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'paid' });
+    // The settled payment (400) + a cancelled one (800) — only 400 should count
+    paymentRepo.findByInvoice.mockResolvedValue([
+      { ...payment, status: 'settled' },
+      { id: 'pay_cancelled', invoiceId: 'inv_1', amount: 800, status: 'cancelled' } as any,
+    ]);
+    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'partial' });
 
-    await useCase.execute({ paymentId: 'pay_1' });
+    const result = await useCase.execute({ paymentId: 'pay_1' });
 
-    // Should update paymentStatus but NOT set status to 'paid' for a draft invoice
-    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith(
+    expect(result.invoicePaymentStatus).toBe('partial');
+    expect(invoiceRepo.updateInvoice).not.toHaveBeenCalledWith(
       'inv_1',
-      expect.not.objectContaining({ status: 'paid' }),
+      expect.objectContaining({ paymentStatus: 'paid' }),
     );
+  });
+
+  it('does not count reverse_payment records when recalculating invoice totalSettled', async () => {
+    const payment = makePayment({ amount: 400 });
+    const invoice = makeInvoice({ total: 1000 });
+    paymentRepo.findById.mockResolvedValue(payment);
+    paymentRepo.update.mockResolvedValue(undefined);
+    invoiceRepo.getInvoice.mockResolvedValue(invoice);
+    paymentRepo.findByInvoice.mockResolvedValue([
+      { ...payment, status: 'settled' },
+      { id: 'pay_rev', invoiceId: 'inv_1', amount: 700, status: 'reverse_payment' } as any,
+    ]);
+    invoiceRepo.updateInvoice.mockResolvedValue({ ...invoice, paymentStatus: 'partial' });
+
+    const result = await useCase.execute({ paymentId: 'pay_1' });
+
+    expect(result.invoicePaymentStatus).toBe('partial');
   });
 });

--- a/__tests__/unit/RecordPaymentUseCase.test.ts
+++ b/__tests__/unit/RecordPaymentUseCase.test.ts
@@ -2,6 +2,40 @@ import { Payment } from '../../src/domain/entities/Payment';
 import { PaymentRepository } from '../../src/domain/repositories/PaymentRepository';
 import { InvoiceRepository } from '../../src/domain/repositories/InvoiceRepository';
 import { RecordPaymentUseCase } from '../../src/application/usecases/payment/RecordPaymentUseCase';
+import { Invoice } from '../../src/domain/entities/Invoice';
+
+const makeInvoice = (overrides: Partial<Invoice> = {}): Invoice => ({
+  id: 'inv_1',
+  total: 1000,
+  currency: 'AUD',
+  status: 'issued',
+  paymentStatus: 'unpaid',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const baseRepos = () => ({
+  paymentRepo: {
+    save: jest.fn().mockResolvedValue(undefined),
+    findById: jest.fn(),
+    findAll: jest.fn(),
+    findByProjectId: jest.fn(),
+    findPendingByProject: jest.fn(),
+    findByInvoice: jest.fn().mockResolvedValue([]),
+    update: jest.fn(),
+    delete: jest.fn(),
+  } as unknown as jest.Mocked<PaymentRepository>,
+  invoiceRepo: {
+    createInvoice: jest.fn(),
+    getInvoice: jest.fn(),
+    updateInvoice: jest.fn().mockResolvedValue(undefined),
+    deleteInvoice: jest.fn(),
+    findByExternalKey: jest.fn(),
+    listInvoices: jest.fn(),
+    assignProject: jest.fn(),
+  } as unknown as jest.Mocked<InvoiceRepository>,
+});
 
 describe('RecordPaymentUseCase', () => {
   it('saves payment via payment repository', async () => {
@@ -11,30 +45,78 @@ describe('RecordPaymentUseCase', () => {
       amount: 100,
     } as Payment;
 
-    const mockPaymentRepo: PaymentRepository = {
-      save: jest.fn().mockResolvedValue(undefined),
-      findById: jest.fn(),
-      findAll: jest.fn(),
-      findByProjectId: jest.fn(),
-      findPendingByProject: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-    } as unknown as PaymentRepository;
+    const { paymentRepo, invoiceRepo } = baseRepos();
 
-    const mockInvoiceRepo: InvoiceRepository = {
-      createInvoice: jest.fn(),
-      getInvoice: jest.fn(),
-      updateInvoice: jest.fn(),
-      deleteInvoice: jest.fn(),
-      findByExternalKey: jest.fn(),
-      listInvoices: jest.fn(),
-      assignProject: jest.fn(),
-    } as unknown as InvoiceRepository;
-
-    const uc = new RecordPaymentUseCase(mockPaymentRepo, mockInvoiceRepo);
+    const uc = new RecordPaymentUseCase(paymentRepo, invoiceRepo);
     await uc.execute(payment);
 
-    expect((mockPaymentRepo.save as jest.Mock).mock.calls.length).toBe(1);
-    expect((mockPaymentRepo.save as jest.Mock).mock.calls[0][0]).toEqual(payment);
+    expect((paymentRepo.save as jest.Mock).mock.calls.length).toBe(1);
+    expect((paymentRepo.save as jest.Mock).mock.calls[0][0]).toEqual(payment);
+  });
+
+  it('sets invoice paymentStatus to partial when a payment is less than total', async () => {
+    const { paymentRepo, invoiceRepo } = baseRepos();
+    const payment: Payment = { id: 'pay_1', invoiceId: 'inv_1', amount: 400 } as Payment;
+    invoiceRepo.getInvoice.mockResolvedValue(makeInvoice());
+    paymentRepo.findByInvoice.mockResolvedValue([payment]);
+
+    const uc = new RecordPaymentUseCase(paymentRepo, invoiceRepo);
+    await uc.execute(payment);
+
+    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith('inv_1', expect.objectContaining({ paymentStatus: 'partial' }));
+  });
+
+  it('sets invoice paymentStatus to paid when payments cover total', async () => {
+    const { paymentRepo, invoiceRepo } = baseRepos();
+    const payment: Payment = { id: 'pay_1', invoiceId: 'inv_1', amount: 1000 } as Payment;
+    invoiceRepo.getInvoice.mockResolvedValue(makeInvoice());
+    paymentRepo.findByInvoice.mockResolvedValue([payment]);
+
+    const uc = new RecordPaymentUseCase(paymentRepo, invoiceRepo);
+    await uc.execute(payment);
+
+    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith(
+      'inv_1',
+      expect.objectContaining({ paymentStatus: 'paid', status: 'paid' }),
+    );
+  });
+
+  it('does not count cancelled payments toward totalSettled', async () => {
+    const { paymentRepo, invoiceRepo } = baseRepos();
+    const newPayment: Payment = { id: 'pay_2', invoiceId: 'inv_1', amount: 300 } as Payment;
+    // A cancelled payment should NOT contribute to the total
+    const cancelledPayment: Payment = { id: 'pay_1', invoiceId: 'inv_1', amount: 800, status: 'cancelled' } as Payment;
+    invoiceRepo.getInvoice.mockResolvedValue(makeInvoice());
+    paymentRepo.findByInvoice.mockResolvedValue([cancelledPayment, newPayment]);
+
+    const uc = new RecordPaymentUseCase(paymentRepo, invoiceRepo);
+    await uc.execute(newPayment);
+
+    // Only the 300 payment counts; 800 cancelled is excluded → partial not paid
+    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith(
+      'inv_1',
+      expect.objectContaining({ paymentStatus: 'partial' }),
+    );
+    expect(invoiceRepo.updateInvoice).not.toHaveBeenCalledWith(
+      'inv_1',
+      expect.objectContaining({ paymentStatus: 'paid' }),
+    );
+  });
+
+  it('does not count reverse_payment records toward totalSettled', async () => {
+    const { paymentRepo, invoiceRepo } = baseRepos();
+    const newPayment: Payment = { id: 'pay_2', invoiceId: 'inv_1', amount: 500 } as Payment;
+    const reversalPayment: Payment = { id: 'pay_r', invoiceId: 'inv_1', amount: 600, status: 'reverse_payment' } as Payment;
+    invoiceRepo.getInvoice.mockResolvedValue(makeInvoice());
+    paymentRepo.findByInvoice.mockResolvedValue([reversalPayment, newPayment]);
+
+    const uc = new RecordPaymentUseCase(paymentRepo, invoiceRepo);
+    await uc.execute(newPayment);
+
+    // Only 500 counts; reversal excluded → partial
+    expect(invoiceRepo.updateInvoice).toHaveBeenCalledWith(
+      'inv_1',
+      expect.objectContaining({ paymentStatus: 'partial' }),
+    );
   });
 });

--- a/design/issue-149-transactional-payments-partial-pay.md
+++ b/design/issue-149-transactional-payments-partial-pay.md
@@ -1,0 +1,290 @@
+# Design: Issue #149 — Transactional Payments + Partial Payment UI
+
+**Status**: APPROVED
+**Author**: Copilot
+**Date**: 2026-03-16
+**GitHub Issue**: https://github.com/yhua045/builder-assistant/issues/149
+
+---
+
+## 0. Context & Background
+
+The current `PaymentDetails` screen evaluates CTA visibility (`Mark as Paid`) solely from the `Payment` record's own `status` field. This causes two problems:
+
+1. **Synthetic rows** (`invoice-payable:` prefix) are explicitly blocked from the action — the user must navigate elsewhere to record a payment against an invoice that has no existing payment record.
+2. **Partially-paid invoices** have no `Make Partial Payment` CTA at all — the builder cannot record incremental staged payments through the detail screen.
+
+Additionally, the `Payment.status` domain type (`'pending' | 'settled'`) cannot represent reversals or cancellations, limiting reconciliation and reporting capabilities.
+
+This issue resolves both gaps in two coordinated parts:
+
+| Part | Summary |
+|---|---|
+| **A — CTA Visibility** | Drive `Mark as Paid` / `Make Partial Payment` visibility from `invoice.paymentStatus` + `invoice.status` rather than from `payment.status` alone. |
+| **B — Partial Payment UI** | Add a bottom-sheet modal (see mock in `PaymentDetails.mock.tsx`) that lets the builder specify an amount, then records a new `Payment` transaction and updates `Invoice.paymentStatus` atomically. |
+| **C — Payment.status Extension** | Extend the `Payment.status` enum to include `cancelled` and `reverse_payment` for reconciliation and future reversal support. |
+
+---
+
+## 1. User Stories
+
+| # | Story |
+|---|---|
+| US-1 | As a Builder, I want the "Mark as Paid" CTA to be visible whenever an invoice has a remaining balance (regardless of whether a `pending` payment record exists), so I can always record a payment. |
+| US-2 | As a Builder, I want a "Make Partial Payment" CTA available on any unpaid or partially-paid invoice, so I can record staged or split payments. |
+| US-3 | As a Builder, I want to enter a payment amount (pre-filled with the remaining balance) in a modal and have that payment persisted transactionally. |
+| US-4 | As a Builder, I want the invoice's `paymentStatus` to reflect `partial` after a partial payment and `paid` once fully settled, so my financial view stays accurate. |
+| US-5 | As a Builder, I want `cancelled` and `reverse_payment` statuses available on payment records so that voids and refunds can be tracked correctly. |
+
+---
+
+## 2. Acceptance Criteria
+
+### Part A — CTA Visibility
+
+| # | Criterion |
+|---|---|
+| AC-A1 | `Mark as Paid` CTA is shown when `invoice.paymentStatus` is `'unpaid'` or `'partial'` **and** `invoice.status !== 'cancelled'` **and** `remainingBalance > 0`. |
+| AC-A2 | `Make Partial Payment` CTA is shown under the same conditions as AC-A1. Both CTAs may be shown simultaneously (full-pay vs partial-pay intent). |
+| AC-A3 | When no parent invoice is loaded (standalone `Payment` record with no `invoiceId`), fall back to the existing `payment.status === 'pending'` guard as today. |
+| AC-A4 | Neither CTA is shown when `invoice.status === 'cancelled'`, even if `paymentStatus` is `'unpaid'`. |
+
+### Part B — Partial Payment Modal
+
+| # | Criterion |
+|---|---|
+| AC-B1 | Tapping "Make Partial Payment" opens a bottom-sheet modal (handle bar, vendor/invoice summary, amount input, Cancel / Mark as Paid). |
+| AC-B2 | The amount field is pre-filled with `remainingBalance` (`invoice.total − totalSettled`). The builder may edit it to any positive value ≤ `remainingBalance`. |
+| AC-B3 | Submitting the modal calls `RecordPaymentUseCase.execute()` with the entered amount and `invoiceId`; this creates a new `Payment` record with `status: 'settled'` and updates the invoice atomically. |
+| AC-B4 | After a successful submission: the modal closes, `PaymentDetails` reloads its data, and the updated `Invoice.paymentStatus` is reflected in the UI. |
+| AC-B5 | If the entered amount equals `remainingBalance`, the invoice transitions to `paymentStatus: 'paid'` (and `status: 'paid'` if the invoice was `issued` or `overdue`). |
+| AC-B6 | If the entered amount is less than `remainingBalance`, the invoice transitions to `paymentStatus: 'partial'`. |
+| AC-B7 | Validation: amount must be a valid number > 0 and ≤ remainingBalance; show an inline error if not. |
+
+### Part C — Payment.status Extension
+
+| # | Criterion |
+|---|---|
+| AC-C1 | `Payment.status` type in `src/domain/entities/Payment.ts` is updated to `'pending' \| 'settled' \| 'cancelled' \| 'reverse_payment'`. |
+| AC-C2 | The `status` column enum in `src/infrastructure/database/schema.ts` (`payments` table) is extended to include `'cancelled'` and `'reverse_payment'`. |
+| AC-C3 | A Drizzle migration is generated for the schema change. |
+| AC-C4 | Unit tests cover status transition rules: `cancelled` and `reverse_payment` payments are excluded from `totalSettled` in invoice recalculation. |
+| AC-C5 | Existing UI that reads `payment.status` (e.g. status badges in `PaymentDetails`) handles all four values without crashing (unknown values fall back to a neutral display). |
+
+### General
+
+| # | Criterion |
+|---|---|
+| AC-G1 | All changes are TypeScript strict-mode compliant (`npx tsc --noEmit` passes with zero errors). |
+| AC-G2 | Unit tests are added/updated in `__tests__/unit/` for `RecordPaymentUseCase` and `MarkPaymentAsPaidUseCase` covering partial-payment and new-status scenarios. |
+| AC-G3 | Integration tests that touch SQLite/Drizzle verify invoice `paymentStatus` transitions end-to-end. |
+
+---
+
+## 3. Proposed Solution
+
+### 3.1 Domain — `Payment.status` Extension
+
+**File**: `src/domain/entities/Payment.ts`
+
+```typescript
+// Before
+status?: 'pending' | 'settled';
+
+// After
+status?: 'pending' | 'settled' | 'cancelled' | 'reverse_payment';
+```
+
+`cancelled` — the payment record has been voided (e.g., a cheque was stopped). Does **not** count toward `totalSettled`.  
+`reverse_payment` — a deliberate reversal / refund transaction linked back to a prior `settled` payment. Does **not** count toward `totalSettled` (is subtracted in a future reconciliation pass, out of scope for this issue).
+
+### 3.2 Infrastructure — Schema + Migration
+
+**File**: `src/infrastructure/database/schema.ts`
+
+```typescript
+// Before
+status: text('status', { enum: ['pending', 'settled'] }),
+
+// After
+status: text('status', { enum: ['pending', 'settled', 'cancelled', 'reverse_payment'] }),
+```
+
+Run `npm run db:generate` after this change to produce a new migration in `drizzle/migrations/`.
+
+### 3.3 Application — `RecordPaymentUseCase` (no logic changes needed)
+
+The existing `RecordPaymentUseCase.execute()` already:
+1. Saves a new `Payment` record via `paymentRepo.save()`.
+2. Queries all payments for the invoice, sums `amount` values, and derives `paymentStatus`.
+3. Writes the updated `paymentStatus` (and optionally `status`) back to the invoice atomically.
+
+The only change needed is that the `totalSettled` sum must **exclude** `cancelled` and `reverse_payment` payments:
+
+```typescript
+// In RecordPaymentUseCase.execute() — update the reduce:
+const paid = payments
+  .filter(p => p.status !== 'cancelled' && p.status !== 'reverse_payment')
+  .reduce((s, p) => s + (p.amount || 0), 0);
+```
+
+The same filter already exists correctly in `MarkPaymentAsPaidUseCase` (`.filter(p => p.status === 'settled')`), so no change is needed there.
+
+### 3.4 UI — CTA Visibility in `PaymentDetails.tsx`
+
+**File**: `src/pages/payments/PaymentDetails.tsx`
+
+Introduce a derived boolean computed after `invoice` is loaded:
+
+```typescript
+// Derived visibility — drives both CTAs
+const remainingBalance = invoice
+  ? invoice.total - (linkedPayments
+      .filter(p => p.status === 'settled')
+      .reduce((sum, p) => sum + (p.amount ?? 0), 0))
+  : 0;
+
+const canRecordPayment =
+  invoice !== null &&
+  invoice.status !== 'cancelled' &&
+  (invoice.paymentStatus === 'unpaid' || invoice.paymentStatus === 'partial') &&
+  remainingBalance > 0;
+
+// Fallback for standalone Payment records (no invoiceId)
+const showMarkAsPaidFallback =
+  !invoice && payment !== null && payment.status === 'pending' && !isSynthetic;
+```
+
+Replace the existing CTA block:
+
+```tsx
+{/* Before */}
+{payment.status === 'pending' && !isSynthetic && (
+  <TouchableOpacity onPress={handleMarkAsPaid} ...>
+    <Text>Mark as Paid</Text>
+  </TouchableOpacity>
+)}
+
+{/* After */}
+{(canRecordPayment || showMarkAsPaidFallback) && (
+  <View className="gap-3 mb-6">
+    <TouchableOpacity
+      onPress={handleMarkAsPaid}
+      disabled={marking}
+      className="bg-primary rounded-xl py-4 items-center"
+    >
+      <Text className="text-primary-foreground font-bold text-base">Mark as Paid</Text>
+    </TouchableOpacity>
+
+    {canRecordPayment && (
+      <TouchableOpacity
+        onPress={() => setPartialModalVisible(true)}
+        className="border border-primary rounded-xl py-4 items-center"
+      >
+        <Text className="text-primary font-bold text-base">Make Partial Payment</Text>
+      </TouchableOpacity>
+    )}
+  </View>
+)}
+```
+
+### 3.5 UI — Partial Payment Modal
+
+The modal design is taken directly from the `{/* Partial Payment Modal */}` section in `PaymentDetails.mock.tsx`. Key structural elements:
+
+```
+┌──────────────────────────────────────────────┐
+│  ───────  (handle bar)                        │
+│                                               │
+│  Partial Payment                        [X]  │
+│                                               │
+│  ┌─ Info Card ──────────────────────────────┐│
+│  │ Project: <invoice.project>               ││
+│  │ Vendor: <issuerName>    Invoice: <ref>   ││
+│  └──────────────────────────────────────────┘│
+│                                               │
+│  Due: Jan 18, 2024              [Overdue]     │
+│                                               │
+│  ┌─ Balance Card ───────────────────────────┐│
+│  │ Total Invoice   $15,750 (struck-through) ││
+│  │ Remaining Balance              $10,750   ││
+│  └──────────────────────────────────────────┘│
+│                                               │
+│  Payment Amount                               │
+│  ┌─────────────────────────────────────────┐ │
+│  │ $  [  10750.00  (editable)           ]  │ │
+│  └─────────────────────────────────────────┘ │
+│                                               │
+│  ┌──────────────┐  ┌──────────────────────┐  │
+│  │    Cancel    │  │     Mark as Paid     │  │
+│  └──────────────┘  └──────────────────────┘  │
+└──────────────────────────────────────────────┘
+```
+
+**State additions to `PaymentDetails.tsx`**:
+```typescript
+const [partialModalVisible, setPartialModalVisible] = useState(false);
+const [partialAmount, setPartialAmount] = useState('');
+const [submitting, setSubmitting] = useState(false);
+```
+
+**Submit handler** (`handlePartialPaymentSubmit`):
+```typescript
+const handlePartialPaymentSubmit = async () => {
+  const amountNum = parseFloat(partialAmount);
+  if (!amountNum || amountNum <= 0 || amountNum > remainingBalance) {
+    Alert.alert('Invalid amount', 'Enter a valid amount between $0.01 and the remaining balance.');
+    return;
+  }
+  setSubmitting(true);
+  try {
+    await recordPaymentUc.execute({
+      id: `pay_${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
+      invoiceId: invoice!.id,
+      amount: amountNum,
+      status: 'settled',
+      date: new Date().toISOString(),
+    });
+    setPartialModalVisible(false);
+    await loadData(); // reload invoice + payment history
+  } catch (e: any) {
+    Alert.alert('Error', e?.message ?? 'Payment failed');
+  } finally {
+    setSubmitting(false);
+  }
+};
+```
+
+The modal is implemented using React Native's `<Modal>` with `animationType="slide"` and `transparent={true}`, wrapped in a `<KeyboardAvoidingView>` — matching the mock exactly.
+
+---
+
+## 4. Files Changed
+
+| File | Change |
+|---|---|
+| `src/domain/entities/Payment.ts` | Extend `status` union type |
+| `src/infrastructure/database/schema.ts` | Extend `status` enum |
+| `drizzle/migrations/<new>.sql` | Auto-generated migration |
+| `src/application/usecases/payment/RecordPaymentUseCase.ts` | Filter cancelled/reverse from `totalSettled` |
+| `src/pages/payments/PaymentDetails.tsx` | New CTA visibility logic + partial payment modal |
+| `__tests__/unit/RecordPaymentUseCase.test.ts` | New/updated tests |
+| `__tests__/unit/MarkPaymentAsPaidUseCase.test.ts` | Tests for new status values |
+| `__tests__/integration/payment-status-transitions.test.ts` | End-to-end invoice status transition tests |
+
+---
+
+## 5. Out of Scope (This Issue)
+
+- Reverse payment UI (creating a `reverse_payment` record from the UI) — the status is introduced at the domain level only.
+- Bulk payment reconciliation screen.
+- Push notifications for overdue invoices.
+- Changes to the standalone `Payments` list screen beyond what is needed for CTA wiring.
+
+---
+
+## 6. Resolved Decisions
+
+1. **Payment method**: Removed from the modal entirely — the app records payment events only, no method tracking at the point of partial payment entry.
+2. **Synthetic row materialisation**: Call `RecordPaymentUseCase` directly with the `invoiceId`. Simpler and consistent; no materialisation needed for partial payments.
+3. **remainingBalance cap**: Input is hard-capped at `remainingBalance`. Over-payment is not allowed.

--- a/drizzle/migrations/0011_jittery_quicksilver.sql
+++ b/drizzle/migrations/0011_jittery_quicksilver.sql
@@ -1,0 +1,44 @@
+CREATE TABLE `task_progress_logs` (
+	`local_id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`id` text NOT NULL,
+	`task_id` text NOT NULL,
+	`log_type` text NOT NULL,
+	`notes` text,
+	`date` integer,
+	`actor` text,
+	`photos` text,
+	`reason_type_id` text,
+	`delay_duration_days` real,
+	`resolved_at` integer,
+	`mitigation_notes` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `task_progress_logs_id_unique` ON `task_progress_logs` (`id`);--> statement-breakpoint
+CREATE INDEX `idx_progress_logs_task` ON `task_progress_logs` (`task_id`);--> statement-breakpoint
+ALTER TABLE `invoices` ADD `task_id` text;--> statement-breakpoint
+ALTER TABLE `invoices` ADD `quote_id` text;--> statement-breakpoint
+CREATE INDEX `idx_invoices_task` ON `invoices` (`task_id`);--> statement-breakpoint
+CREATE INDEX `idx_invoices_quote` ON `invoices` (`quote_id`);--> statement-breakpoint
+ALTER TABLE `payments` ADD `contact_id` text;--> statement-breakpoint
+ALTER TABLE `payments` ADD `contractor_name` text;--> statement-breakpoint
+ALTER TABLE `payments` ADD `payment_category` text DEFAULT 'other';--> statement-breakpoint
+ALTER TABLE `payments` ADD `stage_label` text;--> statement-breakpoint
+ALTER TABLE `projects` ADD `location` text;--> statement-breakpoint
+ALTER TABLE `projects` ADD `fire_zone` text;--> statement-breakpoint
+ALTER TABLE `projects` ADD `regulatory_flags` text;--> statement-breakpoint
+ALTER TABLE `projects` ADD `default_due_date_days` integer DEFAULT 5;--> statement-breakpoint
+ALTER TABLE `quotations` ADD `task_id` text;--> statement-breakpoint
+ALTER TABLE `quotations` ADD `document_id` text;--> statement-breakpoint
+CREATE INDEX `idx_quotations_task` ON `quotations` (`task_id`);--> statement-breakpoint
+ALTER TABLE `task_delay_reasons` ADD `log_type` text DEFAULT 'delay' NOT NULL;--> statement-breakpoint
+ALTER TABLE `task_delay_reasons` ADD `resolved_at` integer;--> statement-breakpoint
+ALTER TABLE `task_delay_reasons` ADD `mitigation_notes` text;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `photos` text;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `site_constraints` text;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `task_type` text DEFAULT 'variation';--> statement-breakpoint
+ALTER TABLE `tasks` ADD `work_type` text;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `quote_amount` real;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `quote_status` text;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `quote_invoice_id` text;

--- a/drizzle/migrations/meta/0011_snapshot.json
+++ b/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2593 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e8709987-6e55-45d8-9d58-f745ea529a7c",
+  "prevId": "d4f51974-4cdf-468f-8b16-83cf1c0c9798",
+  "tables": {
+    "change_orders": {
+      "name": "change_orders",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_delta": {
+          "name": "amount_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "change_orders_id_unique": {
+          "name": "change_orders_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_change_orders_project": {
+          "name": "idx_change_orders_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trade": {
+          "name": "trade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contacts_id_unique": {
+          "name": "contacts_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delay_reason_types": {
+      "name": "delay_reason_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local-only'"
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_url": {
+          "name": "cloud_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issued_date": {
+          "name": "issued_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "documents_id_unique": {
+          "name": "documents_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_documents_project": {
+          "name": "idx_documents_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_status": {
+          "name": "idx_documents_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expenses": {
+      "name": "expenses",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trade": {
+          "name": "trade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_by_ai": {
+          "name": "validated_by_ai",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "expenses_id_unique": {
+          "name": "expenses_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_expenses_project": {
+          "name": "idx_expenses_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspections": {
+      "name": "inspections",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspection_type": {
+          "name": "inspection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inspections_id_unique": {
+          "name": "inspections_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_inspections_project": {
+          "name": "idx_inspections_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issuer_name": {
+          "name": "issuer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issuer_address": {
+          "name": "issuer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issuer_tax_id": {
+          "name": "issuer_tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_name": {
+          "name": "recipient_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date_due": {
+          "name": "date_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unpaid'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line_items": {
+          "name": "line_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invoices_id_unique": {
+          "name": "invoices_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_invoices_project": {
+          "name": "idx_invoices_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_task": {
+          "name": "idx_invoices_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_quote": {
+          "name": "idx_invoices_quote",
+          "columns": [
+            "quote_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_external_key": {
+          "name": "idx_invoices_external_key",
+          "columns": [
+            "external_id",
+            "external_reference"
+          ],
+          "isUnique": true
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "last_known_locations": {
+      "name": "last_known_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accuracy_meters": {
+          "name": "accuracy_meters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "altitude": {
+          "name": "altitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "materials": {
+      "name": "materials",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_cost": {
+          "name": "unit_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery_date": {
+          "name": "estimated_delivery_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "materials_id_unique": {
+          "name": "materials_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_materials_project": {
+          "name": "idx_materials_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "milestones": {
+      "name": "milestones",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "milestones_id_unique": {
+          "name": "milestones_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_milestones_project": {
+          "name": "idx_milestones_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payments": {
+      "name": "payments",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contractor_name": {
+          "name": "contractor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_category": {
+          "name": "payment_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "stage_label": {
+          "name": "stage_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payments_id_unique": {
+          "name": "payments_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_payments_project": {
+          "name": "idx_payments_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_phases": {
+      "name": "project_phases",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "materials_required": {
+          "name": "materials_required",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_phases_id_unique": {
+          "name": "project_phases_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_phases_project": {
+          "name": "idx_phases_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_end_date": {
+          "name": "expected_end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_zone": {
+          "name": "fire_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regulatory_flags": {
+          "name": "regulatory_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_due_date_days": {
+          "name": "default_due_date_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_id_unique": {
+          "name": "projects_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_projects_property": {
+          "name": "idx_projects_property",
+          "columns": [
+            "property_id"
+          ],
+          "isUnique": false
+        },
+        "idx_projects_owner": {
+          "name": "idx_projects_owner",
+          "columns": [
+            "owner_id"
+          ],
+          "isUnique": false
+        },
+        "idx_projects_status": {
+          "name": "idx_projects_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "properties": {
+      "name": "properties",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size_unit": {
+          "name": "lot_size_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "properties_id_unique": {
+          "name": "properties_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quotations": {
+      "name": "quotations",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor_name": {
+          "name": "vendor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor_address": {
+          "name": "vendor_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor_email": {
+          "name": "vendor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tax_total": {
+          "name": "tax_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_items": {
+          "name": "line_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quotations_id_unique": {
+          "name": "quotations_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_quotations_project": {
+          "name": "idx_quotations_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "idx_quotations_task": {
+          "name": "idx_quotations_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_quotations_vendor": {
+          "name": "idx_quotations_vendor",
+          "columns": [
+            "vendor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_quotations_status": {
+          "name": "idx_quotations_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_quotations_date": {
+          "name": "idx_quotations_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_delay_reasons": {
+      "name": "task_delay_reasons",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_type_id": {
+          "name": "reason_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delay_duration_days": {
+          "name": "delay_duration_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delay_date": {
+          "name": "delay_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_type": {
+          "name": "log_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'delay'"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mitigation_notes": {
+          "name": "mitigation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_delay_reasons_id_unique": {
+          "name": "task_delay_reasons_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_task_delays_task": {
+          "name": "idx_task_delays_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_dependencies": {
+      "name": "task_dependencies",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depends_on_task_id": {
+          "name": "depends_on_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_task_deps_task": {
+          "name": "idx_task_deps_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_task_deps_unique": {
+          "name": "idx_task_deps_unique",
+          "columns": [
+            "task_id",
+            "depends_on_task_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_progress_logs": {
+      "name": "task_progress_logs",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_type": {
+          "name": "log_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_type_id": {
+          "name": "reason_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delay_duration_days": {
+          "name": "delay_duration_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mitigation_notes": {
+          "name": "mitigation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_progress_logs_id_unique": {
+          "name": "task_progress_logs_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_progress_logs_task": {
+          "name": "idx_progress_logs_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_scheduled": {
+          "name": "is_scheduled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcontractor_id": {
+          "name": "subcontractor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_critical_path": {
+          "name": "is_critical_path",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_constraints": {
+          "name": "site_constraints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'variation'"
+        },
+        "work_type": {
+          "name": "work_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_amount": {
+          "name": "quote_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_status": {
+          "name": "quote_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_invoice_id": {
+          "name": "quote_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_id_unique": {
+          "name": "tasks_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_tasks_project": {
+          "name": "idx_tasks_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_scheduled": {
+          "name": "idx_tasks_scheduled",
+          "columns": [
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_status": {
+          "name": "idx_tasks_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "work_variations": {
+      "name": "work_variations",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_impact": {
+          "name": "cost_impact",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeline_impact_days": {
+          "name": "timeline_impact_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_date": {
+          "name": "approved_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_variations_id_unique": {
+          "name": "work_variations_id_unique",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "idx_work_variations_project": {
+          "name": "idx_work_variations_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772673774915,
       "tag": "0010_workable_shard",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1773628573498,
+      "tag": "0011_jittery_quicksilver",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/migrations.js
+++ b/drizzle/migrations/migrations.js
@@ -12,6 +12,7 @@ import m0007 from './0007_cloudy_leper_queen.sql';
 import m0008 from './0008_good_mattie_franklin.sql';
 import m0009 from './0009_lush_stryfe.sql';
 import m0010 from './0010_workable_shard.sql';
+import m0011 from './0011_jittery_quicksilver.sql';
 
   export default {
     journal,
@@ -26,7 +27,8 @@ m0006,
 m0007,
 m0008,
 m0009,
-m0010
+m0010,
+m0011
     }
   }
   

--- a/src/application/usecases/payment/RecordPaymentUseCase.ts
+++ b/src/application/usecases/payment/RecordPaymentUseCase.ts
@@ -15,7 +15,9 @@ export class RecordPaymentUseCase {
       if (!invoice) return;
 
       const payments = await this.paymentRepo.findByInvoice(payment.invoiceId);
-      const paid = payments.reduce((s, p) => s + (p.amount || 0), 0);
+      const paid = payments
+        .filter(p => p.status !== 'cancelled' && p.status !== 'reverse_payment')
+        .reduce((s, p) => s + (p.amount || 0), 0);
 
       const newPaymentStatus = paid >= invoice.total ? 'paid' : (paid > 0 ? 'partial' : 'unpaid');
       const updates: any = { paymentStatus: newPaymentStatus };

--- a/src/domain/entities/Payment.ts
+++ b/src/domain/entities/Payment.ts
@@ -11,7 +11,7 @@ export interface Payment {
   currency?: string;
   notes?: string;
   method?: 'bank' | 'cash' | 'check' | 'card' | 'other';
-  status?: 'pending' | 'settled';
+  status?: 'pending' | 'settled' | 'cancelled' | 'reverse_payment';
   reference?: string;
   // Display / grouping fields added in #142
   contractorName?: string;       // denormalized from Contact.name for list performance

--- a/src/infrastructure/database/schema.ts
+++ b/src/infrastructure/database/schema.ts
@@ -246,7 +246,7 @@ export const payments = sqliteTable('payments', {
   currency: text('currency'),
   paymentDate: integer('payment_date'), // Unix timestamp
   dueDate: integer('due_date'), // Unix timestamp for due date
-  status: text('status', { enum: ['pending', 'settled'] }),
+  status: text('status', { enum: ['pending', 'settled', 'cancelled', 'reverse_payment'] }),
   paymentMethod: text('payment_method'),
   reference: text('reference'),
   notes: text('notes'),

--- a/src/pages/payments/PaymentDetails.tsx
+++ b/src/pages/payments/PaymentDetails.tsx
@@ -7,10 +7,14 @@ import {
   ActivityIndicator,
   Alert,
   StyleSheet,
+  Modal,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRoute, useNavigation } from '@react-navigation/native';
-import { ChevronLeft } from 'lucide-react-native';
+import { ChevronLeft, X, DollarSign } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
 import { container } from 'tsyringe';
 import { Payment } from '../../domain/entities/Payment';
@@ -18,6 +22,7 @@ import { Invoice } from '../../domain/entities/Invoice';
 import { PaymentRepository } from '../../domain/repositories/PaymentRepository';
 import { InvoiceRepository } from '../../domain/repositories/InvoiceRepository';
 import { MarkPaymentAsPaidUseCase } from '../../application/usecases/payment/MarkPaymentAsPaidUseCase';
+import { RecordPaymentUseCase } from '../../application/usecases/payment/RecordPaymentUseCase';
 import { getDueStatus } from '../../utils/getDueStatus';
 import '../../infrastructure/di/registerServices';
 
@@ -58,6 +63,10 @@ export default function PaymentDetails() {
   const [linkedPayments, setLinkedPayments] = useState<Payment[]>([]);
   const [loading, setLoading] = useState(!syntheticRow);
   const [marking, setMarking] = useState(false);
+  const [partialModalVisible, setPartialModalVisible] = useState(false);
+  const [partialAmount, setPartialAmount] = useState('');
+  const [partialAmountError, setPartialAmountError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   const paymentRepo = React.useMemo(
     () => container.resolve<PaymentRepository>('PaymentRepository' as any),
@@ -69,6 +78,10 @@ export default function PaymentDetails() {
   );
   const markPaidUc = React.useMemo(
     () => new MarkPaymentAsPaidUseCase(paymentRepo, invoiceRepo),
+    [paymentRepo, invoiceRepo],
+  );
+  const recordPaymentUc = React.useMemo(
+    () => new RecordPaymentUseCase(paymentRepo, invoiceRepo),
     [paymentRepo, invoiceRepo],
   );
 
@@ -107,14 +120,46 @@ export default function PaymentDetails() {
   }, [loadData]);
 
   const handleMarkAsPaid = () => {
-    if (!payment || payment.id.startsWith('invoice-payable:')) {
-      Alert.alert(
-        'Record Payment',
-        'This obligation is derived from an invoice. Please record a payment against the invoice directly.',
-      );
+    // Invoice-linked path: record a new settled payment against the invoice
+    if (invoice && invoice.status !== 'cancelled' &&
+        (invoice.paymentStatus === 'unpaid' || invoice.paymentStatus === 'partial')) {
+      const settled = linkedPayments
+        .filter(p => p.status === 'settled')
+        .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+      const balance = invoice.total - settled;
+      if (balance <= 0) return;
+
+      Alert.alert('Mark as Paid', `Confirm full payment of ${formatCurrency(balance)}?`, [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Confirm',
+          onPress: async () => {
+            setMarking(true);
+            try {
+              const id = `pay_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+              await recordPaymentUc.execute({
+                id,
+                invoiceId: invoice.id,
+                amount: balance,
+                status: 'settled',
+                date: new Date().toISOString(),
+              });
+              Alert.alert('Done', 'Payment recorded.', [
+                { text: 'OK', onPress: () => navigation.goBack() },
+              ]);
+            } catch (e: any) {
+              Alert.alert('Error', e?.message ?? 'Failed to record payment');
+            } finally {
+              setMarking(false);
+            }
+          },
+        },
+      ]);
       return;
     }
 
+    // Fallback: standalone payment record (no linked invoice)
+    if (!payment || payment.id.startsWith('invoice-payable:')) return;
     Alert.alert('Mark as Paid', `Confirm payment of ${formatCurrency(payment.amount ?? 0)}?`, [
       { text: 'Cancel', style: 'cancel' },
       {
@@ -124,7 +169,7 @@ export default function PaymentDetails() {
           try {
             await markPaidUc.execute({ paymentId: payment.id });
             Alert.alert('Done', 'Payment marked as settled.', [
-              { text: 'OK', onPress: () => { navigation.goBack(); } },
+              { text: 'OK', onPress: () => navigation.goBack() },
             ]);
           } catch (e: any) {
             Alert.alert('Error', e?.message ?? 'Failed to mark payment as paid');
@@ -134,6 +179,37 @@ export default function PaymentDetails() {
         },
       },
     ]);
+  };
+
+  const handlePartialPaymentSubmit = async () => {
+    const settled = linkedPayments
+      .filter(p => p.status === 'settled')
+      .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+    const balance = invoice ? invoice.total - settled : 0;
+    const amountNum = parseFloat(partialAmount);
+    if (!amountNum || amountNum <= 0 || amountNum > balance) {
+      setPartialAmountError(`Enter a valid amount between $0.01 and ${formatCurrency(balance)}.`);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const id = `pay_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      await recordPaymentUc.execute({
+        id,
+        invoiceId: invoice!.id,
+        amount: amountNum,
+        status: 'settled',
+        date: new Date().toISOString(),
+      });
+      setPartialModalVisible(false);
+      setPartialAmount('');
+      setPartialAmountError('');
+      await loadData();
+    } catch (e: any) {
+      Alert.alert('Error', e?.message ?? 'Payment failed');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   if (loading) {
@@ -157,6 +233,14 @@ export default function PaymentDetails() {
   const totalSettled = linkedPayments
     .filter((p) => p.status === 'settled')
     .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+  const remainingBalance = invoice ? invoice.total - totalSettled : 0;
+  const canRecordPayment =
+    invoice !== null &&
+    invoice.status !== 'cancelled' &&
+    (invoice.paymentStatus === 'unpaid' || invoice.paymentStatus === 'partial') &&
+    remainingBalance > 0;
+  const showMarkAsPaidFallback =
+    !invoice && payment.status === 'pending' && !isSynthetic;
 
   return (
     <SafeAreaView className="flex-1 bg-background">
@@ -183,18 +267,27 @@ export default function PaymentDetails() {
           <View className="flex-row items-center gap-2">
             <View
               className={`px-2 py-0.5 rounded ${
-                payment.status === 'settled' ? 'bg-green-100' : 'bg-amber-100'
+                payment.status === 'settled' ? 'bg-green-100' :
+                payment.status === 'cancelled' ? 'bg-red-100' :
+                payment.status === 'reverse_payment' ? 'bg-purple-100' :
+                'bg-amber-100'
               }`}
             >
               <Text
                 className={`text-xs font-semibold ${
-                  payment.status === 'settled' ? 'text-green-700' : 'text-amber-700'
+                  payment.status === 'settled' ? 'text-green-700' :
+                  payment.status === 'cancelled' ? 'text-red-700' :
+                  payment.status === 'reverse_payment' ? 'text-purple-700' :
+                  'text-amber-700'
                 }`}
               >
-                {payment.status === 'settled' ? 'Settled' : 'Pending'}
+                {payment.status === 'settled' ? 'Settled' :
+                 payment.status === 'cancelled' ? 'Cancelled' :
+                 payment.status === 'reverse_payment' ? 'Reversed' :
+                 'Pending'}
               </Text>
             </View>
-            {dueStatus && payment.status !== 'settled' && (
+            {dueStatus && payment.status === 'pending' && (
               <Text style={{ color: dueStatus.style === 'overdue' ? '#dc2626' : dueStatus.style === 'due-soon' ? '#d97706' : '#16a34a' }} className="text-xs font-semibold">
                 {dueStatus.text}
               </Text>
@@ -259,24 +352,154 @@ export default function PaymentDetails() {
           </View>
         )}
 
-        {/* Mark as paid CTA */}
-        {payment.status === 'pending' && !isSynthetic && (
-          <TouchableOpacity
-            onPress={handleMarkAsPaid}
-            disabled={marking}
-            className="bg-primary rounded-xl py-4 items-center mb-6"
-            activeOpacity={0.8}
-          >
-            {marking ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <Text className="text-primary-foreground font-bold text-base">
-                Mark as Paid
-              </Text>
+        {/* CTAs */}
+        {(canRecordPayment || showMarkAsPaidFallback) && (
+          <View className="gap-3 mb-6">
+            <TouchableOpacity
+              onPress={handleMarkAsPaid}
+              disabled={marking}
+              className="bg-primary rounded-xl py-4 items-center"
+              activeOpacity={0.8}
+            >
+              {marking ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text className="text-primary-foreground font-bold text-base">Mark as Paid</Text>
+              )}
+            </TouchableOpacity>
+
+            {canRecordPayment && (
+              <TouchableOpacity
+                onPress={() => {
+                  setPartialAmount(remainingBalance.toString());
+                  setPartialAmountError('');
+                  setPartialModalVisible(true);
+                }}
+                className="border border-primary rounded-xl py-4 items-center"
+                activeOpacity={0.8}
+              >
+                <Text className="text-primary font-bold text-base">Make Partial Payment</Text>
+              </TouchableOpacity>
             )}
-          </TouchableOpacity>
+          </View>
         )}
       </ScrollView>
+
+      {/* Partial Payment Modal */}
+      <Modal
+        visible={partialModalVisible}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={() => setPartialModalVisible(false)}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          className="flex-1"
+        >
+          <TouchableOpacity
+            className="flex-1 bg-black/50"
+            activeOpacity={1}
+            onPress={() => setPartialModalVisible(false)}
+          >
+            <TouchableOpacity
+              activeOpacity={1}
+              className="w-full bg-white dark:bg-gray-900 rounded-t-3xl mt-auto border-t border-gray-200 dark:border-gray-800"
+            >
+              {/* Handle bar */}
+              <View className="w-full items-center pt-3 pb-1">
+                <View className="w-12 h-1.5 bg-gray-300 dark:bg-gray-600 rounded-full" />
+              </View>
+
+              <View className="p-6">
+                {/* Header */}
+                <View className="flex-row items-center justify-between mb-6">
+                  <Text className="text-xl font-bold text-gray-900 dark:text-white">Partial Payment</Text>
+                  <TouchableOpacity onPress={() => setPartialModalVisible(false)}>
+                    <X size={24} color={isDark ? '#9CA3AF' : '#6B7280'} />
+                  </TouchableOpacity>
+                </View>
+
+                {/* Invoice info */}
+                {invoice && (
+                  <View className="mb-6">
+                    <View className="bg-gray-50 dark:bg-gray-800 rounded-xl p-4 mb-4 border border-gray-200 dark:border-gray-700">
+                      <Text className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-1">Invoice</Text>
+                      <Text className="text-base font-bold text-gray-900 dark:text-white mb-3">
+                        {invoice.externalReference ?? invoice.invoiceNumber ?? invoice.id}
+                      </Text>
+                      <View className="flex-row items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-3">
+                        <View>
+                          <Text className="text-xs text-gray-500 dark:text-gray-400">Issued by</Text>
+                          <Text className="text-sm font-medium text-gray-900 dark:text-white">{invoice.issuerName ?? '—'}</Text>
+                        </View>
+                        <View className="items-end">
+                          <Text className="text-xs text-gray-500 dark:text-gray-400">Due date</Text>
+                          <Text className="text-sm font-medium text-gray-900 dark:text-white">
+                            {formatDate(invoice.dateDue ?? invoice.dueDate)}
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+
+                    <View className="flex-row items-end justify-between bg-gray-50 dark:bg-gray-800 p-4 rounded-xl border border-gray-200 dark:border-gray-700">
+                      <View>
+                        <Text className="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Invoice</Text>
+                        <Text className="text-base text-gray-400 dark:text-gray-500 line-through">
+                          {formatCurrency(invoice.total)}
+                        </Text>
+                      </View>
+                      <View className="items-end">
+                        <Text className="text-xs text-gray-500 dark:text-gray-400 mb-1">Remaining Balance</Text>
+                        <Text className="text-xl font-bold text-primary">{formatCurrency(remainingBalance)}</Text>
+                      </View>
+                    </View>
+                  </View>
+                )}
+
+                {/* Amount input */}
+                <View className="mb-6">
+                  <Text className="text-sm font-semibold text-gray-900 dark:text-white mb-2">Payment Amount</Text>
+                  <View className="flex-row items-center bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl px-4 py-3">
+                    <DollarSign size={20} color={isDark ? '#9CA3AF' : '#6B7280'} style={{ marginRight: 8 }} />
+                    <TextInput
+                      className="flex-1 text-2xl font-bold text-gray-900 dark:text-white"
+                      placeholder="0.00"
+                      value={partialAmount}
+                      onChangeText={(t) => { setPartialAmount(t); setPartialAmountError(''); }}
+                      keyboardType="decimal-pad"
+                      placeholderTextColor="#9CA3AF"
+                    />
+                  </View>
+                  {!!partialAmountError && (
+                    <Text className="text-xs text-red-500 mt-1">{partialAmountError}</Text>
+                  )}
+                </View>
+
+                {/* Actions */}
+                <View className="flex-row gap-3">
+                  <TouchableOpacity
+                    onPress={() => setPartialModalVisible(false)}
+                    className="flex-1 py-3.5 rounded-xl border border-gray-300 dark:border-gray-600 items-center justify-center"
+                  >
+                    <Text className="font-semibold text-gray-700 dark:text-gray-300">Cancel</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={handlePartialPaymentSubmit}
+                    disabled={submitting}
+                    className="flex-1 py-3.5 rounded-xl bg-primary items-center justify-center"
+                  >
+                    {submitting ? (
+                      <ActivityIndicator color="#fff" />
+                    ) : (
+                      <Text className="font-semibold text-white">Mark as Paid</Text>
+                    )}
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </KeyboardAvoidingView>
+      </Modal>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Implements transactional recording of payments and adds a partial-payment modal for invoices.

Summary of changes:
- Design: `design/issue-149-transactional-payments-partial-pay.md` (approved) — UI mock referenced.
- Domain: extended `Payment.status` to include `cancelled` and `reverse_payment`.
- Database: updated schema and generated migration `drizzle/migrations/0011_jittery_quicksilver.sql`.
- Use cases: `RecordPaymentUseCase` updated to exclude cancelled/reversed payments when summing.
- UI: `PaymentDetails.tsx` adds CTA logic and partial-payment modal ("Mark as Paid").
- Tests: Unit and integration tests added/updated for new behaviors.

Closes: #149
