### PR TITLE
feat(payments): add TanStack Query, migrate usePayments, and cross-domain invalidation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,13 +12,13 @@ Builder Assistant is a React Native construction project management app for owne
 | Language | TypeScript 5.8+ (strict mode) |
 | Styling | NativeWind v4 (Tailwind CSS) + `lucide-react-native` icons |
 | Navigation | React Navigation v7 (Bottom Tabs + Native Stack) |
-| Persistence | Drizzle ORM v0.45 over `react-native-sqlite-storage` (SQLite) |
+| Persistence | Drizzle ORM v0.45 schema/migrations over `react-native-sqlite-storage` (SQLite); runtime queries use raw `db.executeSql()` via the SQLite proxy |
 | File Storage | `react-native-fs` (abstracted via `LocalDocumentStorageEngine`) |
 | Camera / File Pick | `react-native-image-picker`, `react-native-document-picker` |
-| Audio / Voice | `react-native-nitro-sound`, Groq STT + LLM |
+| Audio / Voice | `react-native-nitro-sound`, Groq STT + LLM transcript parsing |
 | PDF Conversion | `rn-pdf-renderer` |
 | ML / OCR | `@react-native-ml-kit/text-recognition` + deterministic normalizer |
-| DI Container | Lightweight custom registry (`src/infrastructure/di/container.ts`) + `tsyringe` (decorator pattern) |
+| DI Container | **tsyringe** (primary — singleton registration in `registerServices.ts`) + legacy hand-rolled Map registry (`container.ts`, vestigial) |
 | Testing | Jest 29 + React Test Renderer + `@testing-library/react-native` |
 | Integration DB | `better-sqlite3` in-memory (test-only, shims native SQLite) |
 | Node requirement | ≥ 20 |
@@ -39,40 +39,47 @@ Builder Assistant is a React Native construction project management app for owne
 ├── docs/                          # Supplementary documentation
 └── src/
     ├── domain/                    # 🔵 Domain Layer — pure business logic
-    │   ├── entities/              # Business entities (see list below)
-    │   ├── repositories/          # Repository interfaces (contracts only)
-    │   └── services/              # Domain services (e.g. ProjectWorkflowService)
+    │   ├── entities/              # ~17 business entity interfaces + thin factory classes
+    │   ├── repositories/          # ~16 repository interfaces (contracts only, no implementation)
+    │   └── services/              # Domain services (e.g. ProjectWorkflowService, ProjectValidationService)
     ├── application/               # 🟢 Application Layer — use case orchestration
-    │   ├── usecases/              # Grouped by domain (project/, invoice/, quotation/, …)
+    │   ├── usecases/              # Grouped by domain (project/, invoice/, task/, payment/, …)
     │   ├── ai/                    # Normalizer interfaces & implementations (invoice OCR)
     │   ├── receipt/               # Receipt normalizer logic
     │   ├── dtos/                  # Data-transfer objects (e.g. ProjectCardDto)
-    │   └── services/              # Application services
+    │   └── services/              # Application-layer port interfaces: IAudioRecorder,
+    │                              #   IVoiceParsingService, ICameraService, ISuggestionService, …
     ├── infrastructure/            # 🔴 Infrastructure Layer — I/O implementations
-    │   ├── database/              # Drizzle schema, migrations bundle, connection
-    │   ├── repositories/          # Drizzle repository implementations
+    │   ├── database/              # Drizzle schema.ts (source of truth), migrations.ts (bundled SQL), connection.ts
+    │   ├── repositories/          # ~11 DrizzleXxxRepository implementations (raw db.executeSql())
     │   ├── mappers/               # Row → domain entity mappers
-    │   ├── camera/                # ICameraAdapter, MobileCameraAdapter, MockCameraAdapter
+    │   ├── camera/                # ICameraAdapter → MobileCameraAdapter / MockCameraAdapter
     │   ├── files/                 # IFilePickerAdapter, IFileSystemAdapter and mobile impls
     │   ├── storage/               # LocalDocumentStorageEngine (react-native-fs wrapper)
     │   ├── ocr/                   # MobileOcrAdapter (ML Kit text recognition)
-    │   ├── ai/                    # TfLiteReceiptNormalizer (template, falls back to deterministic)
-    │   └── di/                    # DI container (container.ts, registerServices.ts)
-    ├── components/                # 🟡 Reusable UI components
+    │   ├── ai/                    # StubSuggestionService (default) / TfLiteReceiptNormalizer
+    │   ├── voice/                 # MobileAudioRecorder, GroqSTTAdapter, GroqTranscriptParser + mocks
+    │   ├── location/              # DrizzleStoredLocationRepository, DeviceGpsService
+    │   ├── demo/                  # seedDemoData, resetDemoData helpers
+    │   └── di/                    # registerServices.ts (tsyringe), container.ts (legacy Map)
+    ├── components/                # 🟡 Reusable/presentational UI components
     │   ├── inputs/                # DatePickerInput, ContactSelector, TeamSelector
     │   ├── invoices/              # InvoiceForm, InvoiceUploadSection, ExtractionResultsPanel, …
     │   ├── quotations/            # QuotationForm
     │   ├── receipts/              # ReceiptForm
-    │   └── tasks/                 # Task-related components
-    ├── hooks/                     # React hooks — UI-to-application connectors
-    ├── pages/                     # Screen-level components (one folder per feature)
-    │   ├── dashboard/             # Dashboard with Quick Actions & financial stats
+    │   └── tasks/                 # ~17 task UI components (cards, sections, badges, forms)
+    ├── hooks/                     # React hooks — UI-to-application connectors (~17 hooks)
+    ├── config/
+    │   └── featureFlags.ts        # Compile-time feature toggles (e.g. FEATURE_AI_SUGGESTIONS)
+    ├── pages/                     # Screen-level components + navigator wiring
+    │   ├── tabs/index.tsx         # Root BottomTabNavigator (Dashboard / Finances / Work / Projects)
+    │   ├── dashboard/             # DashboardScreen — Quick Actions & financial stats
     │   ├── projects/              # ProjectsPage (list, create, archive)
     │   ├── invoices/              # Invoice list, detail, upload screens
     │   ├── payments/              # Payments screen
     │   ├── quotations/            # QuotationScreen
     │   ├── receipts/              # SnapReceiptScreen
-    │   └── tasks/                 # TasksScreen
+    │   └── tasks/                 # TasksNavigator (NativeStack) + 5 task screens
     ├── shims/                     # Browser/Node shims for Metro bundler compatibility
     ├── types/                     # Shared TypeScript type declarations
     └── utils/                     # Pure utility functions (no side-effects)
@@ -100,23 +107,25 @@ Infrastructure (Drizzle repos, adapters, DI)
 
 Pure TypeScript — no React, no Drizzle, no I/O of any kind.
 
-**Entities** (`src/domain/entities/`) — immutable factory pattern via `.create()`:
+**Entities** (`src/domain/entities/`) — factory pattern via `.create()`. The factory stamps `id`, `createdAt`, `updatedAt` and sets defaults; domain services (not entities) own complex invariant enforcement:
 
-| Entity | Enforced Invariants |
+| Entity | Notes |
 |---|---|
-| `Project` | Status transitions via `ProjectWorkflowService`, budget ≥ 0 |
-| `Invoice` | `total` ≥ 0, line-item sum = total, `dateDue` ≥ `dateIssued` |
+| `Project` | Status transitions owned by `ProjectWorkflowService` |
+| `Invoice` | Line-item amounts, `dateDue` ≥ `dateIssued` |
 | `Payment` | Linked to invoice, amount > 0 |
-| `Quotation` | `expiryDate` ≥ `date`, total ≥ 0, line items sum to total |
+| `Quotation` | `expiryDate` ≥ `date`, total ≥ 0 |
 | `Contact` | Has a `RoleType` (owner, contractor, vendor, …) |
-| `Property` | Project site address |
+| `Task` / `TaskEntity` | ID generation, timestamp stamping, `status` defaulting to `'pending'` |
 | `Document` | File metadata, OCR text, cloud-sync status |
 | `Expense` | Receipt capture, optional AI-validated fields |
-| Others | `Milestone`, `Task`, `Inspection`, `ChangeOrder`, `WorkVariation`, `Quote` |
+| Others | `Property`, `Milestone`, `Inspection`, `ChangeOrder`, `WorkVariation`, `Quote` |
 
-**Repository interfaces** (`src/domain/repositories/`) — declare CRUD and domain-specific query methods; zero implementation code.
+**`CockpitScorer`** (`src/application/usecases/task/CockpitScorer.ts`) — A set of **pure functions** (no DI, no side effects) for task prioritisation: `computePriorityWeight`, `computeDueDateUrgency`, `computeBlockers`, `computeFocus3`. These are the domain-level scoring rules for the task cockpit view, kept separate from the use-case class for independent testability.
 
-**Domain services** (`src/domain/services/`) — stateless business rules that span multiple entities (e.g. `ProjectWorkflowService` enforces the allowed status-transition graph).
+**Repository interfaces** (`src/domain/repositories/`) — declare CRUD and domain-specific query methods; zero implementation code. Each interface is the contract between Application and Infrastructure.
+
+**Domain services** (`src/domain/services/`) — stateless business rules spanning multiple entities (e.g. `ProjectWorkflowService` enforces the allowed status-transition graph, `ProjectValidationService` validates project creation inputs).
 
 ### 🟢 Application Layer (`src/application/`)
 
@@ -131,7 +140,18 @@ Thin orchestration — no database access, no UI.
 | payment/ | `RecordPaymentUseCase`, `ListPaymentsUseCase` |
 | quotation/ | `CreateQuotationUseCase`, `GetQuotationByIdUseCase`, `ListQuotationsUseCase`, `UpdateQuotationUseCase`, `DeleteQuotationUseCase` |
 | receipt/ | `SnapReceiptUseCase` |
-| task/ | `CreateTaskUseCase`, `CreateTaskFromPhotoUseCase`, `UpdateTaskUseCase`, `DeleteTaskUseCase`, `GetTaskUseCase`, `ListTasksUseCase` |
+| task/ | `CreateTaskUseCase`, `UpdateTaskUseCase`, `DeleteTaskUseCase` (cascades deps → delay reasons → task), `GetTaskUseCase`, `ListTasksUseCase`, `GetTaskDetailUseCase` (parallel hydration: task + deps + delays + logs), `GetCockpitDataUseCase` (builds in-memory adjacency graph + calls `CockpitScorer`), `GetBlockerBarDataUseCase`, `AddTaskDependencyUseCase`, `RemoveTaskDependencyUseCase`, `AddDelayReasonUseCase` (validates against `DelayReasonTypeRepository`), `RemoveDelayReasonUseCase`, `ResolveDelayReasonUseCase`, `AddProgressLogUseCase`, `UpdateProgressLogUseCase`, `DeleteProgressLogUseCase`, `ParseVoiceTaskUseCase`, `CreateTaskFromPhotoUseCase`, `AcceptQuoteUseCase` (transitions `quoteStatus → accepted`, links invoice), `GetDelayStatisticsUseCase` |
+
+**Application Service Ports** (`src/application/services/`) — interfaces (ports) for platform capabilities consumed by use cases:
+
+| Port Interface | Description |
+|---|---|
+| `IAudioRecorder` | Start/stop audio recording |
+| `IVoiceParsingService` | STT transcription + LLM task-draft extraction |
+| `ICameraService` | Capture photo |
+| `ISuggestionService` | AI-powered task suggestions |
+
+These are implemented in Infrastructure and injected at runtime via tsyringe.
 
 **Normalizers / AI** (`src/application/receipt/`, `src/application/ai/`) — rules-based field extraction for receipt and invoice OCR; `IReceiptNormalizer` and `IInvoiceNormalizer` are the interfaces; `DeterministicReceiptNormalizer` / `InvoiceNormalizer` are the live implementations.
 
@@ -142,75 +162,175 @@ Thin orchestration — no database access, no UI.
 All I/O and platform concerns live here. Implements domain interfaces; nothing in domain/ or application/ should import from here.
 
 **Database** (`src/infrastructure/database/`):
-- `schema.ts` — Drizzle table definitions (single source of truth for DB shape)
-- `migrations.ts` — bundled SQL migration strings, applied automatically on app start
-- `connection.ts` — initialises and returns the Drizzle database instance
+- `schema.ts` — Drizzle table definitions (single source of truth for DB shape and migration generation)
+- `migrations.ts` — bundled SQL migration strings executed automatically on app start
+- `connection.ts` — initialises and returns the SQLite DB instance via a Drizzle sqlite-proxy; exposes `db.executeSql()` used by all repositories
 
 **Repositories** (`src/infrastructure/repositories/`):
-- `DrizzleProjectRepository`, `DrizzleInvoiceRepository`, `DrizzlePaymentRepository`, `DrizzleQuotationRepository`, `DrizzleDocumentRepository`, `DrizzleReceiptRepository`, `DrizzleTaskRepository`
+- ~11 `DrizzleXxxRepository` classes implement their domain `XxxRepository` interface
+- **Important:** Despite the "Drizzle" prefix, runtime queries use **raw SQL via `db.executeSql()`** — not the Drizzle query builder. Drizzle is used only for schema definition and migration file generation.
+- `DrizzleTaskRepository` additionally manages `task_dependencies`, `task_delay_reasons`, `task_progress_logs` tables
 - `InMemoryProjectRepository` — in-process stub used in unit tests (not production)
-- Mappers live in `src/infrastructure/mappers/` (e.g. `ProjectMapper` assembles hydrated `ProjectDetails` from JOIN rows)
+- Mappers in `src/infrastructure/mappers/` (e.g. `ProjectMapper`) assemble hydrated objects from JOIN rows
 
 **Adapters** — all platform-specific modules are behind interfaces:
 - Camera: `ICameraAdapter` → `MobileCameraAdapter` (wraps `react-native-image-picker`); swap with `MockCameraAdapter` in tests
 - File Pick: `IFilePickerAdapter` → `MobileFilePickerAdapter`
 - File System: `IFileSystemAdapter` → `MobileFileSystemAdapter` (wraps `react-native-fs`)
 - OCR: `MobileOcrAdapter` (wraps ML Kit text recognition)
-- PDF Conversion: `IPdfConverter` → `MobilePdfConverter` (wraps `rn-pdf-renderer`)
-- Voice/Audio: `IAudioRecorder` → `MobileAudioRecorder` (wraps `react-native-nitro-sound`), `IVoiceParsingService` → `RemoteVoiceParsingService` (Groq STT + LLM)
+- PDF: `IPdfConverter` → `MobilePdfConverter` (wraps `rn-pdf-renderer`)
+- Audio: `IAudioRecorder` → `MobileAudioRecorder` (wraps `react-native-nitro-sound`)
+- Voice parsing: `IVoiceParsingService` → `RemoteVoiceParsingService` (Groq STT → `GroqTranscriptParser` LLM)
+- AI suggestions: `ISuggestionService` → `StubSuggestionService` (default no-op until real LLM adapter is wired)
+- Location: `DeviceGpsService`, `DrizzleStoredLocationRepository`
 
 **DI Container** (`src/infrastructure/di/`):
-- Lightweight key-based registry (`container.ts`): `registerInstance`, `registerFactory`, `resolve`, `clearContainer`
-- `registerServices.ts` wires production bindings on app start
-- In tests: call `clearContainer()` in `beforeEach` to reset state
+
+There are **two DI systems**; only tsyringe is active for new code:
+
+| System | File | Role |
+|---|---|---|
+| **tsyringe** (primary) | `registerServices.ts` | Registers all ~9 repositories + adapters as singletons on module import. Every hook file imports this as a side-effect. |
+| Legacy Map registry | `container.ts` | Hand-rolled `Map`-based `registerInstance` / `registerFactory` / `resolve`. Vestigial — used for a `ProjectRepository` fallback only. Do not add new registrations here. |
+
+Hook wiring pattern (tsyringe):
+```ts
+// Side-effect import triggers singleton registration
+import '../infrastructure/di/registerServices';
+
+// Resolve repository singleton from container
+const repo = useMemo(() => container.resolve<TaskRepository>('TaskRepository'), []);
+
+// Instantiate use case with injected repo (use cases are NOT registered in the container)
+const createTask = useMemo(() => new CreateTaskUseCase(repo), [repo]);
+```
 
 ### 🟡 UI Layer (`src/components/`, `src/pages/`, `src/hooks/`)
 
-**Hooks** (`src/hooks/`) — instantiate use cases with Drizzle repositories and expose plain async functions + loading/error state. No business logic here.
+**Navigation** (`src/pages/tabs/`, `src/pages/tasks/`):
+
+```
+App.tsx → NavigationContainer
+└── BottomTabNavigator (tabs/index.tsx)
+    ├── "Dashboard"  → DashboardScreen
+    ├── "Finances"   → PaymentsNavigator (NativeStack)
+    ├── "Work"       → TasksNavigator (NativeStack)
+    │     ├── TasksList    → TasksScreen      — list + cockpit view
+    │     ├── TaskDetails  → TaskDetailsPage  — full detail (card presentation)
+    │     ├── CreateTask   → CreateTaskPage   — new task + voice entry (modal)
+    │     └── EditTask     → EditTaskPage     — edit existing task (modal)
+    └── "Projects"   → ProjectsPage
+```
+
+All navigators use `headerShown: false`; headers are custom-built inside each screen.
+
+**Hooks** (`src/hooks/`) — instantiate use cases with repository singletons from the DI container; expose plain async functions + `loading`/`error` state. Light UI-coordination logic is acceptable (e.g. deriving a field value before calling a use case), but no persistence or business rules.
 
 | Hook | Responsibility |
 |---|---|
+| `useTasks(projectId?)` | Primary task hook — instantiates all 14 task use cases, exposes CRUD + dependency + delay reason + progress log mutations; calls `loadTasks()` after every mutation to re-sync local state |
+| `useTaskForm` | Manages all task form field state; calls `CreateTaskUseCase` or `UpdateTaskUseCase` on submit; contains `computeQuoteStatus()` — auto-derives `quoteStatus` from `taskType` + `quoteAmount` before persisting |
+| `useTaskDetail(task, project)` | Resolves `SuggestionService` from DI; fetches AI suggestions once per task ID (guarded by `FEATURE_AI_SUGGESTIONS`) |
+| `useCockpitData(projectId)` | Calls `GetCockpitDataUseCase`; exposes `{ blockers, focus3 }` |
+| `useBlockerBar(projects)` | Calls `GetBlockerBarDataUseCase` across all projects |
 | `useProjects` | Project CRUD + list |
 | `useInvoices` | Invoice CRUD + lifecycle |
 | `usePayments` | Payment recording + list |
 | `useQuotations` | Quotation CRUD |
 | `useSnapReceipt` | Camera → OCR → ReceiptForm flow |
-| `useTasks` | Task CRUD |
-| `useCameraTask` | Camera → Task creation flow |
-| `useVoiceTask` | Voice recording → STT → Task draft flow |
-| `useContacts` / `useTeams` | Selector data (in-memory stubs; Drizzle-backed repos pending) |
+| `useContacts` / `useTeams` | Selector data |
 
 **Components** (`src/components/`) — purely presentational; receive data and callbacks via props. All styling via NativeWind Tailwind classes (avoid inline `style` props).
 
 **Pages** (`src/pages/`) — screen-level components composed from hooks and components; handle navigation and modal state.
 
----
-
-## Data Flow (End to End)
-
-```
-Page / Component
-     │  user action
-     ▼
-React Hook (useXxx)
-     │  calls useCase.execute(input)
-     ▼
-Use Case
-     │  validates via Entity.create()
-     │  calls repo interface method
-     ▼
-Domain Repository Interface
-     │  implemented by
-     ▼
-DrizzleXxxRepository
-     │  SQL via Drizzle ORM
-     ▼
-SQLite (on-device)
-```
+> ⚠️ **Known inconsistency**: `TaskDetailsPage` resolves `DocumentRepository` and `InvoiceRepository` directly from the tsyringe container rather than through use cases (via `container.resolve<DocumentRepository>('DocumentRepository')` in `useMemo`). This bypasses the intended use-case layer boundary. New screens should not follow this pattern.
 
 ---
 
-## Running the Project
+## Business Logic Distribution
+
+| Layer | What lives here |
+|---|---|
+| **Domain entities** | ID generation, timestamp stamping, `status` defaulting for `TaskEntity`; `PREDEFINED_WORK_TYPES` list |
+| **Domain scoring (`CockpitScorer`)** | `computePriorityWeight`, `computeDueDateUrgency` (0–100 score + label), `computeBlockers` (red/yellow/null severity), `computeFocus3` heuristic ranking |
+| **Domain services** | Project status-transition graph (`ProjectWorkflowService`); project creation validation (`ProjectValidationService`) |
+| **Use cases** | Delete cascade ordering (`DeleteTaskUseCase`); parallel detail hydration (`GetTaskDetailUseCase`); in-memory dependency graph construction + scorer invocation (`GetCockpitDataUseCase`); delay reason type validation (`AddDelayReasonUseCase`); quote state transition (`AcceptQuoteUseCase`) |
+| **Hooks** | `computeQuoteStatus()` in `useTaskForm` — auto-derives `quoteStatus` from `taskType` + `quoteAmount` before persisting; fetch coordination and re-loading after mutations |
+| **Repositories** | SQL query strategy, row↔entity mapping, Unix-ms ↔ ISO-string timestamp conversion, `INSERT OR IGNORE` for idempotent dependency edges |
+| **UI components** | Presentation only — data and callbacks via props |
+
+---
+
+## Data Flow — Task Module (End to End)
+
+### Create Task
+
+```
+CreateTaskPage.tsx
+  └─ useTaskForm.submit()
+       ├─ computeQuoteStatus()          ← derives quoteStatus from taskType + quoteAmount (hook layer)
+       └─ CreateTaskUseCase.execute(data)
+            ├─ TaskEntity.create(data)  ← stamps id, createdAt, updatedAt, defaults status='pending'
+            └─ taskRepository.save(task)
+                 └─ DrizzleTaskRepository.save()
+                      ├─ ensureInitialized() → initDatabase() → SQLite.openDatabase() + runMigrations()
+                      └─ db.executeSql('INSERT INTO tasks ...', [...params])
+  └─ onSuccess() → navigation.goBack()
+  └─ useTasks.loadTasks()  ← full re-fetch refreshes list state
+```
+
+### Task Detail
+
+```
+TaskDetailsPage.tsx  [receives taskId via route.params]
+  └─ useTasks().getTaskDetail(taskId)
+       └─ GetTaskDetailUseCase.execute(taskId)
+            ├─ taskRepository.findById(taskId)
+            └─ Promise.all([
+                 taskRepository.findDependencies(taskId),   // JOIN task_dependencies
+                 taskRepository.findDelayReasons(taskId),   // SELECT task_delay_reasons
+                 taskRepository.findProgressLogs(taskId)    // SELECT task_progress_logs
+               ])
+            └─ returns TaskDetail = Task + { dependencyTasks, delayReasons, progressLogs }
+  └─ Renders sub-components:
+       TaskStatusBadge, StatusPriorityRow, TaskDocumentSection,
+       TaskDependencySection, TaskSubcontractorSection,
+       TaskDelaySection, TaskProgressSection, TaskQuotationSection
+```
+
+### Voice Task Entry
+
+```
+CreateTaskPage.tsx  [voice mode]
+  └─ MobileAudioRecorder.start/stop()  ← IAudioRecorder (tsyringe)
+  └─ ParseVoiceTaskUseCase.execute(audioUri)
+       └─ IVoiceParsingService.parse(audioUri)
+            ├─ GroqSTTAdapter  → audio → transcript text
+            └─ GroqTranscriptParser → transcript → TaskDraft (pre-filled fields)
+  └─ TaskDraft pre-fills TaskForm fields
+  └─ User confirms → CreateTaskUseCase.execute(data)  [same path as above]
+```
+
+### Cockpit Scoring
+
+```
+TasksScreen  [cockpit tab]
+  └─ useCockpitData(projectId)
+       └─ GetCockpitDataUseCase.execute(projectId)
+            ├─ taskRepository.findByProjectId(projectId)   // all tasks
+            ├─ taskRepository.findAllDependencies(projectId) // all edges
+            ├─ Builds in-memory adjacency maps (dependents, dependencies)
+            └─ CockpitScorer.computeFocus3(tasks, deps)
+                 ├─ computePriorityWeight(task)     // priority enum → 0–40 score
+                 ├─ computeDueDateUrgency(task)     // days remaining → 0–100 score
+                 └─ computeBlockers(tasks, deps)    // severity: 'red' | 'yellow' | null
+       └─ returns { blockers: Task[], focus3: Task[] }
+```
+
+---
+
+
 
 ### Prerequisites
 - **Node.js ≥ 20**
@@ -316,30 +436,79 @@ npm run db:check    # Validate migration consistency
 
 | What you're adding | Where it lives |
 |---|---|
-| New business rule | `src/domain/entities/<Entity>.ts` |
-| New status transition rule | `src/domain/services/ProjectWorkflowService.ts` (or new domain service) |
+| New business rule / invariant | `src/domain/entities/<Entity>.ts` or a new domain service in `src/domain/services/` |
+| New status transition rule | `src/domain/services/ProjectWorkflowService.ts` (or a new domain service) |
 | New data access contract | `src/domain/repositories/<Entity>Repository.ts` |
-| New DB table / column | `src/infrastructure/database/schema.ts` → generate migration → bundle |
-| New repository impl | `src/infrastructure/repositories/Drizzle<Entity>Repository.ts` |
+| New DB table / column | `src/infrastructure/database/schema.ts` → `npm run db:generate` → bundle SQL into `migrations.ts` |
+| New repository impl | `src/infrastructure/repositories/Drizzle<Entity>Repository.ts` — use `db.executeSql()` for queries |
+| New platform adapter | Interface (port) in `src/application/services/I<Name>.ts`, mobile impl in `src/infrastructure/<concern>/`, mock impl in `__mocks__/` or `src/infrastructure/<concern>/Mock<Name>.ts` |
 | New use case | `src/application/usecases/<domain>/<Name>UseCase.ts` |
 | New UI form / component | `src/components/<domain>/` |
-| New screen | `src/pages/<domain>/` + wire into navigator in `src/pages/tabs/` |
-| New hook | `src/hooks/use<Feature>.ts` |
-| New native adapter | Interface in `src/infrastructure/<concern>/I<Name>Adapter.ts`, mobile impl alongside, mock impl for tests |
+| New screen | `src/pages/<domain>/` + wire into navigator |
+| New hook | `src/hooks/use<Feature>.ts` — import `registerServices` as side-effect, resolve repo from tsyringe, instantiate use cases in `useMemo` |
+| New DI binding | Add singleton registration to `src/infrastructure/di/registerServices.ts` (tsyringe only) |
+
+---
+
+## Task Database Schema
+
+**Table: `tasks`**
+
+| Column | Type | Notes |
+|---|---|---|
+| `local_id` | INTEGER PK autoincrement | SQLite row ID |
+| `id` | TEXT UNIQUE | App-level UUID (`task_<timestamp>_<random>`) |
+| `project_id` | TEXT nullable | Soft FK to `projects.id`; NULL = ad-hoc task |
+| `phase_id` | TEXT | Soft FK to `project_phases.id` |
+| `title` | TEXT NOT NULL | |
+| `description`, `notes` | TEXT | |
+| `is_scheduled` | INTEGER | Boolean (0/1) |
+| `scheduled_at`, `due_date` | INTEGER | Unix milliseconds |
+| `subcontractor_id` | TEXT | Soft FK to `contacts.id` |
+| `is_critical_path` | INTEGER | Boolean — manual pin for Focus-3 |
+| `status` | TEXT | `pending\|in_progress\|completed\|blocked\|cancelled` |
+| `priority` | TEXT | `low\|medium\|high\|urgent` |
+| `completed_date` | INTEGER | Unix milliseconds |
+| `photos` | TEXT | JSON array of URIs |
+| `site_constraints` | TEXT | Free-text for AI context |
+| `task_type` | TEXT | `standard\|variation\|contract_work` (default `variation`) |
+| `work_type` | TEXT | Trade category string |
+| `quote_amount` | REAL | AUD |
+| `quote_status` | TEXT | `pending\|issued\|accepted\|rejected` |
+| `quote_invoice_id` | TEXT | Soft FK to `invoices.id` |
+| `created_at`, `updated_at` | INTEGER | Unix milliseconds |
+
+**Indexes:** `idx_tasks_project` (project_id), `idx_tasks_scheduled` (scheduled_at), `idx_tasks_status` (status)
+
+**Related tables:**
+
+| Table | Purpose |
+|---|---|
+| `task_dependencies` | Join table: `task_id` + `depends_on_task_id` + `created_at`; unique index on the pair; inserted with `INSERT OR IGNORE` |
+| `task_delay_reasons` | Per-task delay log: `reason_type_id` (FK to `delay_reason_types`), `delay_duration_days`, `resolved_at`, `mitigation_notes` |
+| `delay_reason_types` | Lookup: `id`, `label`, `display_order`, `is_active` |
+| `task_progress_logs` | Progress notes: `log_type`, `notes`, `date`, `photos` (JSON), `actor`, `reason_type_id`, `delay_duration_days`, `resolved_at` |
+| `documents` | `task_id` soft FK — attached files |
+| `invoices` | `task_id` soft FK — variation/contract tasks linked to invoices |
 
 ---
 
 ## Key Gotchas & Conventions
 
-- **No raw SQL in application or domain code.** Use Drizzle ORM in `src/infrastructure/` only. For ad-hoc queries, add a helper to `src/infrastructure/database/`.
-- **No business logic in hooks or components.** Hooks call use cases; use cases call domain entities. If a rule is spreading across multiple files outside domain/, move it back.
+- **Raw SQL is confined to repository implementations.** `DrizzleXxxRepository` classes in `src/infrastructure/repositories/` use `db.executeSql()` at runtime — the Drizzle ORM query builder is **not** used for queries. Drizzle is used for schema definition (`schema.ts`) and migration file generation only. Never write raw SQL in `application/` or `domain/` code.
+- **No business logic in hooks or components — with one documented exception.** `useTaskForm.computeQuoteStatus()` auto-derives `quoteStatus` from `taskType` + `quoteAmount` as a UI-side convenience before calling the use case. This is acceptable for simple UI-driven derivation. All persistence rules and state-transition logic must live in use cases or domain services.
+- **Use tsyringe for all new DI registrations.** Add singleton registrations in `src/infrastructure/di/registerServices.ts`. Do not add new registrations to the legacy `container.ts`.
+- **Use cases are not registered in the DI container.** Hooks instantiate use cases directly via `new XxxUseCase(repo)`. Use cases are stateless so this is safe and keeps instantiation explicit.
+- **Do not resolve repositories directly in screens.** Screens should call hook functions, which delegate to use cases. `TaskDetailsPage` currently resolves `DocumentRepository` directly (a known inconsistency) — do not replicate this pattern.
 - **Entity factories throw on invalid input.** Wrap `Entity.create()` calls in try/catch at the use case boundary; don't swallow errors silently.
 - **`clearContainer()` in tests.** Always call `clearContainer()` in `beforeEach` when your test registers DI bindings, otherwise state leaks between test files.
 - **NativeWind class names only.** Avoid inline `style={{}}` props in components — ESLint rule `react-native/no-inline-styles` will flag them.
 - **Migrations are additive.** Never edit an already-committed SQL migration. Add a new migration for corrections.
-- **`externalId` / `externalReference` on Invoice** — nullable, treated as a composite unique key only when *both* are non-null. This is normalised at the repository layer, not in the entity.
+- **Timestamps are stored as Unix milliseconds (INTEGER) in SQLite.** The repository layer converts to/from ISO strings at the boundary. Do not store ISO strings directly — the schema expects integers.
+- **`FEATURE_AI_SUGGESTIONS` feature flag** (`src/config/featureFlags.ts`) guards AI suggestion fetching in `useTaskDetail`. `StubSuggestionService` is the registered default; the flag prevents any real LLM calls until a production adapter is wired.
+- **`TfLiteReceiptNormalizer` is a placeholder** — it falls back to `DeterministicReceiptNormalizer` until a trained `.tflite` model is wired in.
+- **`externalId` / `externalReference` on Invoice** — nullable, treated as a composite unique key only when *both* are non-null. Normalised at the repository layer.
 - **`project_id` on payments is nullable** — a payment may exist without a linked project (e.g. direct expenses captured via Snap Receipt).
-- **TfLiteReceiptNormalizer is a placeholder** — it falls back to `DeterministicReceiptNormalizer` until a trained `.tflite` model is wired in.
 
 ---
 

--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,9 @@ import { useColorScheme as nwUseColorScheme } from 'nativewind';
 import 'react-native-get-random-values';
 import { verifyInstallation } from 'nativewind';
 
+// TanStack Query
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 // Demo data imports (dev only)
 import { initDatabase } from './src/infrastructure/database/connection';
 import { seedDemoData } from './src/infrastructure/demo/seedDemoData';
@@ -33,6 +36,18 @@ import { SEED_DEMO_DATA, RESET_DEMO_DATA } from '@env';
 if (__DEV__) {
   verifyInstallation();
 }
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,        // No auto-refetch — only explicit invalidateQueries() triggers refetches
+      refetchOnWindowFocus: false, // Don't refetch when app returns to foreground
+      refetchOnReconnect: false,   // App is fully local (SQLite); network reconnect is irrelevant
+      gcTime: 5 * 60_000,         // Keep cache entries for 5 min after last subscriber unmounts
+      retry: 1,
+    },
+  },
+});
 
 function App() {
   const isDarkMode = rnUseColorScheme() === 'dark';
@@ -70,14 +85,16 @@ function App() {
   const containerStyle = [isDark ? darkTheme : lightTheme, styles.container, { backgroundColor }];
 
   return (
-    <SafeAreaProvider>
-      <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
-      <NavigationContainer>
-        <View style={containerStyle}>
-          <TabsLayout />
-        </View>
-      </NavigationContainer>
-    </SafeAreaProvider>
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaProvider>
+        <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
+        <NavigationContainer>
+          <View style={containerStyle}>
+            <TabsLayout />
+          </View>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/__tests__/unit/TasksScreen.test.tsx
+++ b/__tests__/unit/TasksScreen.test.tsx
@@ -91,6 +91,7 @@ function buildHookReturn(
     updateProgressLog: jest.fn(),
     deleteProgressLog: jest.fn(),
     resolveDelayReason: jest.fn(),
+    acceptQuote: jest.fn(),
   };
 }
 

--- a/design/issue-tanstack-query-migration.md
+++ b/design/issue-tanstack-query-migration.md
@@ -1,0 +1,286 @@
+# Design: TanStack Query — Cross-Screen State Invalidation
+
+**Status:** Approved — implementation in progress  
+**Motivation:** Each hook (`usePayments`, `useTasks`, …) holds its own isolated `useState` copy of SQLite data. There is no invalidation bus between screens, so a mutation in one screen (e.g. accepting a quote on a task) is invisible to another screen (e.g. the Payments list) until the user manually navigates away and back.
+
+---
+
+## Problem Statement
+
+### Concrete scenario (the trigger for this design)
+
+1. User opens `TaskDetailsPage` for a `contract_work` task
+2. User taps "Accept Quote" → `AcceptQuoteUseCase.execute(taskId)` runs
+   - Creates a new `Invoice` (status `issued`, paymentStatus `unpaid`)
+   - Updates `task.quoteStatus = 'accepted'`, `task.quoteInvoiceId = invoice.id`
+3. User navigates to the Payments tab
+4. `usePayments` was mounted when the tab was first visited — its `useState` snapshot does **not** include the new invoice
+5. The newly-payable invoice is invisible until the user pulls-to-refresh
+
+### Root cause
+
+Each hook uses an independent `useState + useEffect + loadAll` pattern:
+
+```ts
+// usePayments — simplified current shape
+const [globalPayments, setGlobalPayments] = useState([]);
+
+const loadAll = useCallback(async () => {
+  const result = await listGlobalUc.execute({ contractorSearch });
+  setGlobalPayments(result);
+}, [...deps]);
+
+useEffect(() => { loadAll(); }, [loadAll]);
+```
+
+`useTasks` and `usePayments` both read from SQLite but have no shared subscription mechanism. A write in one hook's callbacks is invisible to the other's `useState`.
+
+---
+
+## Proposed Solution: TanStack Query (`@tanstack/react-query`)
+
+TanStack Query replaces `useState + useEffect + loadAll` for all **server state** (data fetched from SQLite). It introduces a shared `QueryClient` — a cache keyed by query keys — so that calling `queryClient.invalidateQueries({ queryKey: ['invoices'] })` after any mutation causes every component subscribed to that key to automatically refetch.
+
+### What does NOT change
+
+- **All domain entities** (`Task`, `Invoice`, `Payment`, …)
+- **All use cases** (`AcceptQuoteUseCase`, `ListGlobalPaymentsUseCase`, …) — `queryFn` just calls `useCase.execute()`
+- **All repository interfaces and implementations** (`DrizzleTaskRepository`, etc.)
+- **DI container wiring** (`registerServices.ts`, tsyringe singletons)
+- **All UI components and pages** — they continue receiving the same data shapes and callback functions from hooks; the hook's public API is unchanged
+
+### What changes
+
+- Hooks replace `useState + useEffect` fetch loops with `useQuery`
+- Hooks replace `async callback + loadTasks()` mutation calls with `useMutation + onSuccess invalidation`
+- `App.tsx` gains a `QueryClientProvider` wrapper
+
+---
+
+## Query Key Taxonomy
+
+Keys follow the pattern `[domain, ...scope]`. Scope is omitted for global queries.
+
+| Key | Scope | Hook(s) that read it |
+|---|---|---|
+| `['tasks', projectId]` | per project | `useTasks(projectId)` |
+| `['tasks']` | all tasks (ad-hoc) | `useTasks()` |
+| `['taskDetail', taskId]` | per task | `useTaskDetail` |
+| `['invoices']` | global | `useInvoices`, `usePayments` |
+| `['invoices', projectId]` | per project | `useInvoices(projectId)` |
+| `['payments']` | global | `usePayments` (firefighter mode) |
+| `['payments', projectId]` | per project | `usePayments` (site_manager mode) |
+| `['projects']` | global | `useProjects`, `useDashboard` |
+| `['cockpit', projectId]` | per project | `useCockpitData` |
+| `['blockerBar']` | global | `useBlockerBar` |
+
+---
+
+## Cross-Hook Invalidation Map
+
+This is the core of the design. Each mutation lists which query keys it must invalidate.
+
+### `useTasks` mutations → invalidation
+
+| Mutation | Invalidates |
+|---|---|
+| `createTask` | `['tasks', projectId]`, `['cockpit', projectId]` |
+| `updateTask` | `['tasks', projectId]`, `['taskDetail', taskId]`, `['cockpit', projectId]` |
+| `deleteTask` | `['tasks', projectId]`, `['taskDetail', taskId]`, `['cockpit', projectId]` |
+| **`acceptQuote`** (AcceptQuoteUseCase) | `['tasks', projectId]`, `['taskDetail', taskId]`, `['invoices']`, `['invoices', projectId]`, `['payments']`, `['payments', projectId]` |
+| `addDelayReason` / `resolveDelayReason` | `['taskDetail', taskId]`, `['cockpit', projectId]`, `['blockerBar']` |
+| `addProgressLog` / `updateProgressLog` / `deleteProgressLog` | `['taskDetail', taskId]` |
+| `addDependency` / `removeDependency` | `['taskDetail', taskId]`, `['cockpit', projectId]` |
+
+### `usePayments` mutations → invalidation
+
+| Mutation | Invalidates |
+|---|---|
+| `markAsPaid` (MarkPaymentAsPaidUseCase) | `['payments']`, `['payments', projectId]`, `['invoices']`, `['invoices', projectId]`, `['projects']` |
+| `recordPayment` (RecordPaymentUseCase) | `['payments']`, `['payments', projectId]`, `['invoices']` |
+
+### `useInvoices` mutations → invalidation
+
+| Mutation | Invalidates |
+|---|---|
+| `createInvoice` | `['invoices']`, `['invoices', projectId]`, `['payments']` |
+| `markInvoiceAsPaid` | `['invoices']`, `['payments']`, `['projects']` |
+| `cancelInvoice` | `['invoices']`, `['payments']` |
+
+---
+
+## Migration Plan for `usePayments` (First Candidate)
+
+`usePayments` is the highest-value target because it is the consumer most affected by cross-domain mutations (task quote acceptance, invoice creation, payment settlement all affect it).
+
+### Step 1 — App.tsx: add `QueryClientProvider`
+
+```tsx
+// App.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,    // Never auto-refetch — only explicit invalidateQueries() triggers refetches
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      gcTime: 5 * 60_000,     // 5 min cache retention
+      retry: 1,
+    },
+  },
+});
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {/* existing NavigationContainer etc. */}
+    </QueryClientProvider>
+  );
+}
+```
+
+### Step 2 — `usePayments`: replace `useState + useEffect` with `useQuery`
+
+Current shape (simplified):
+```ts
+const [globalPayments, setGlobalPayments] = useState([]);
+const [loading, setLoading] = useState(false);
+
+const loadAll = useCallback(async () => {
+  setLoading(true);
+  try {
+    const result = await listGlobalUc.execute({ contractorSearch });
+    setGlobalPayments(result);
+  } finally {
+    setLoading(false);
+  }
+}, [listGlobalUc, contractorSearch]);
+
+useEffect(() => { loadAll(); }, [loadAll]);
+```
+
+Proposed shape:
+```ts
+const queryKey = mode === 'firefighter'
+  ? ['payments', 'firefighter', contractorSearch ?? '']
+  : ['payments', 'site_manager', projectId ?? ''];
+
+const { data, isLoading, refetch } = useQuery({
+  queryKey,
+  queryFn: () => loadAllPayments({ mode, contractorSearch, projectId, ... }),
+  // staleTime: Infinity inherited from QueryClient default — no override needed
+});
+
+const globalPayments = data?.globalPayments ?? [];
+const globalAmountPayable = data?.globalAmountPayable ?? 0;
+// ...etc — same return shape, same public API
+```
+
+The `loadAllPayments` function is extracted from the existing `loadAll` body — same logic, no changes to use cases.
+
+### Step 3 — `usePayments`: mutations via `useMutation`
+
+```ts
+const queryClient = useQueryClient();
+
+const markPaidMutation = useMutation({
+  mutationFn: (input: MarkPaymentAsPaidInput) => markPaidUseCase.execute(input),
+  onSuccess: (_, variables) => {
+    // Invalidate all payment and invoice views
+    queryClient.invalidateQueries({ queryKey: ['payments'] });
+    queryClient.invalidateQueries({ queryKey: ['invoices'] });
+    queryClient.invalidateQueries({ queryKey: ['projects'] });
+  },
+});
+```
+
+### Step 4 — `useTasks`: wire `acceptQuote` invalidation
+
+`AcceptQuoteUseCase` is currently not exposed via `useTasks`. It will be added as a mutation:
+
+```ts
+// useTasks.ts
+const queryClient = useQueryClient();
+
+const acceptQuoteMutation = useMutation({
+  mutationFn: (taskId: string) => acceptQuoteUseCase.execute(taskId),
+  onSuccess: (result, taskId) => {
+    // Refresh task views
+    queryClient.invalidateQueries({ queryKey: ['tasks', projectId] });
+    queryClient.invalidateQueries({ queryKey: ['taskDetail', taskId] });
+    // Cross-domain: the new invoice must appear in Payments immediately
+    queryClient.invalidateQueries({ queryKey: ['invoices'] });
+    queryClient.invalidateQueries({ queryKey: ['payments'] });
+  },
+});
+```
+
+The `PaymentsScreen` — which calls `usePayments` — has no code change at all. Because it is subscribed to `['payments']`, TanStack Query automatically triggers a refetch when that key is invalidated by the task hook.
+
+---
+
+## Migration Sequence (Incremental — Low Risk)
+
+Each step is independently deployable and does not break existing screens.
+
+| Step | What changes | Screens affected |
+|---|---|---|
+| 1 | Add `@tanstack/react-query` + `QueryClientProvider` in `App.tsx` | None (additive only) |
+| 2 | Migrate `usePayments` to `useQuery` | `PaymentsScreen` |
+| 3 | Add `acceptQuote` to `useTasks` as a `useMutation` with payment invalidation | `TaskDetailsPage` |
+| 4 | Migrate `useInvoices` to `useQuery` + `useMutation` | Invoice screens |
+| 5 | Migrate `useTasks` core list/detail queries | Tasks screens |
+| 6 | Migrate `useProjects`, `useCockpitData`, `useBlockerBar` | Dashboard, Tasks cockpit |
+
+Steps 2 and 3 together resolve the motivating scenario. Steps 4–6 can follow in subsequent PRs.
+
+---
+
+## Public API Contract
+
+The hooks' public return types **do not change**. This is a strict constraint:
+
+```ts
+// usePayments return — before and after migration, identical
+export interface UsePaymentsReturn {
+  globalPayments: PaymentWithProject[];
+  globalAmountPayable: number;
+  contractPayments: Payment[];
+  variationPayments: Payment[];
+  contractTotal: number;
+  variationTotal: number;
+  metrics: PaymentMetrics;
+  loading: boolean;
+  refresh: () => void;   // wraps queryClient.refetchQueries
+}
+```
+
+All pages and components calling `usePayments` require zero changes.
+
+---
+
+## Testing Strategy
+
+- **Unit tests**: mock `useQueryClient` — assert `invalidateQueries` is called with the correct keys after each mutation. Use `@testing-library/react-native` with `createTestQueryClient()` wrapper.
+- **Integration tests**: existing `DrizzlePaymentRepository` integration tests are unaffected (no React Query in infrastructure).
+- **Cross-hook test**: add a new integration test that calls `AcceptQuoteUseCase` directly, then asserts that the invoice count visible to `ListGlobalPaymentsUseCase` has increased — validating the underlying data without React.
+
+---
+
+## Open Questions
+
+1. ~~**`staleTime` value**~~ — **Resolved:** `staleTime: Infinity` with `refetchOnWindowFocus: false` and `refetchOnReconnect: false` globally. All refetches are explicit via `invalidateQueries` only. Automatic background refetching can be re-enabled per-query later when needed (e.g. `refetchOnAppForeground` for the Payments screen).
+2. **`refetchOnAppForeground`** — TanStack Query supports refetching when the app returns to foreground via `AppState`. Worth enabling for the payments screen specifically so overnight due dates recalculate.
+3. **`useTaskForm`** — currently manages `computeQuoteStatus()` derivation before calling the use case. This can stay in the hook (not a query concern); no migration needed for the form layer.
+4. **Offline / background mutations** — out of scope for this migration. The app currently has no offline queue; this design does not change that.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `PaymentsScreen` shows the new invoice-derived payable row immediately after navigating from `TaskDetailsPage` where a quote was accepted — with no manual refresh
+- [ ] `usePayments` public API (`UsePaymentsReturn`) is unchanged; `PaymentsScreen` requires zero prop or hook call changes
+- [ ] All existing unit and integration tests pass without modification
+- [ ] TypeScript strict mode passes (`npx tsc --noEmit`)
+- [ ] No new raw SQL introduced; use cases are unchanged

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/bottom-tabs": "^7.12.0",
         "@react-navigation/native": "^7.1.28",
         "@react-navigation/native-stack": "^7.13.0",
+        "@tanstack/react-query": "^5.90.21",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.1",
         "drizzle-kit": "^0.31.8",
@@ -4387,6 +4388,32 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/react-native": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@react-navigation/bottom-tabs": "^7.12.0",
     "@react-navigation/native": "^7.1.28",
     "@react-navigation/native-stack": "^7.13.0",
+    "@tanstack/react-query": "^5.90.21",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.1",
     "drizzle-kit": "^0.31.8",

--- a/src/hooks/usePayments.ts
+++ b/src/hooks/usePayments.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { container } from 'tsyringe';
 import { PaymentRepository } from '../domain/repositories/PaymentRepository';
 import { ProjectRepository } from '../domain/repositories/ProjectRepository';
@@ -10,8 +11,6 @@ import { Project } from '../domain/entities/Project';
 import { PaymentMetrics } from '../domain/repositories/PaymentRepository';
 import { InvoiceRepository } from '../domain/repositories/InvoiceRepository';
 import { ListGlobalPaymentsUseCase } from '../application/usecases/payment/ListGlobalPaymentsUseCase';
-import { GetGlobalAmountPayableUseCase } from '../application/usecases/payment/GetGlobalAmountPayableUseCase';
-import { ListPaymentsUseCase } from '../application/usecases/payment/ListPaymentsUseCase';
 import { GetPaymentMetricsUseCase } from '../application/usecases/payment/GetPaymentMetricsUseCase';
 import { resolveInvoiceDueDate } from '../utils/resolveInvoiceDueDate';
 import '../infrastructure/di/registerServices';
@@ -157,6 +156,8 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
     invoiceRepoOverride,
   } = options;
 
+  const queryClient = useQueryClient();
+
   const paymentRepo = useMemo(
     () => paymentRepoOverride ?? container.resolve<PaymentRepository>('PaymentRepository' as any),
     [paymentRepoOverride],
@@ -178,20 +179,16 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
   }, []);
 
   const listGlobalUc = useMemo(() => new ListGlobalPaymentsUseCase(paymentRepo), [paymentRepo]);
-  const globalAmountUc = useMemo(() => new GetGlobalAmountPayableUseCase(paymentRepo), [paymentRepo]);
-  const listUc = useMemo(() => new ListPaymentsUseCase(paymentRepo), [paymentRepo]);
   const metricsUc = useMemo(() => new GetPaymentMetricsUseCase(paymentRepo), [paymentRepo]);
 
-  const [globalPayments, setGlobalPayments] = useState<PaymentWithProject[]>([]);
-  const [globalAmountPayable, setGlobalAmountPayable] = useState(0);
-  const [contractPayments, setContractPayments] = useState<Payment[]>([]);
-  const [variationPayments, setVariationPayments] = useState<Payment[]>([]);
-  const [metrics, setMetrics] = useState<PaymentMetrics>({ pendingTotalNext7Days: 0, overdueCount: 0 });
-  const [loading, setLoading] = useState(false);
+  // Stable query key — changes when the scope changes, causing a fresh fetch
+  const queryKey = mode === 'firefighter'
+    ? ['payments', 'firefighter', contractorSearch ?? ''] as const
+    : ['payments', 'site_manager', projectId ?? ''] as const;
 
-  const loadAll = useCallback(async () => {
-    setLoading(true);
-    try {
+  const { data, isFetching, refetch } = useQuery({
+    queryKey,
+    queryFn: async () => {
       if (mode === 'firefighter') {
         const [result, met, invoiceResult] = await Promise.all([
           listGlobalUc.execute({ contractorSearch }),
@@ -199,8 +196,6 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
           invoiceRepo.listInvoices({ limit: 500 }),
         ]);
 
-        // Build project map from invoice project IDs so buildInvoicePayables can resolve
-        // per-project defaultDueDateDays for due date computation.
         const invoiceProjectIds = [
           ...new Set(invoiceResult.items.map((inv) => inv.projectId).filter(Boolean)),
         ] as string[];
@@ -223,7 +218,6 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
 
         const mergedGlobalItems = [...result.items, ...invoicePayables];
 
-        // Ensure payment-only project IDs are also resolved (for display names)
         const additionalProjectIds = [
           ...new Set(result.items.map((p) => p.projectId).filter(Boolean)),
         ] as string[];
@@ -243,9 +237,13 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
           projectName: p.projectId ? (projectMap.get(p.projectId)?.name ?? p.projectId) : undefined,
         }));
 
-        setGlobalPayments(enriched);
-        setGlobalAmountPayable(enriched.reduce((sum, p) => sum + (p.amount ?? 0), 0));
-        setMetrics(met);
+        return {
+          globalPayments: enriched,
+          globalAmountPayable: enriched.reduce((sum, p) => sum + (p.amount ?? 0), 0),
+          contractPayments: [] as Payment[],
+          variationPayments: [] as Payment[],
+          metrics: met,
+        };
       } else {
         // site_manager mode — scoped to a project
         const [contracts, variations, met, invoiceResult] = await Promise.all([
@@ -255,7 +253,6 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
           invoiceRepo.listInvoices({ projectId, limit: 500 }),
         ]);
 
-        // Load the current project for defaultDueDateDays resolution
         const projectMap = new Map<string, Project>();
         if (projectId) {
           try {
@@ -268,31 +265,22 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
         const invoiceContracts = invoicePayables.filter((p) => p.paymentCategory === 'contract');
         const invoiceVariations = invoicePayables.filter((p) => p.paymentCategory === 'variation');
 
-        setContractPayments([...contracts.items, ...invoiceContracts]);
-        setVariationPayments([...variations.items, ...invoiceVariations]);
-        setMetrics(met);
+        return {
+          globalPayments: [] as PaymentWithProject[],
+          globalAmountPayable: 0,
+          contractPayments: [...contracts.items, ...invoiceContracts],
+          variationPayments: [...variations.items, ...invoiceVariations],
+          metrics: met,
+        };
       }
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    mode,
-    projectId,
-    contractorSearch,
-    listGlobalUc,
-    globalAmountUc,
-    listUc,
-    metricsUc,
-    paymentRepo,
-    projectRepo,
-    invoiceRepo,
-    taskRepo,
-    contactRepo,
-  ]);
+    },
+  });
 
-  useEffect(() => {
-    loadAll();
-  }, [loadAll]);
+  const globalPayments = data?.globalPayments ?? [];
+  const globalAmountPayable = data?.globalAmountPayable ?? 0;
+  const contractPayments = data?.contractPayments ?? [];
+  const variationPayments = data?.variationPayments ?? [];
+  const metrics = data?.metrics ?? { pendingTotalNext7Days: 0, overdueCount: 0 };
 
   const contractTotal = useMemo(
     () => contractPayments.reduce((sum, p) => sum + (p.amount ?? 0), 0),
@@ -311,7 +299,9 @@ export function usePayments(options: UsePaymentsOptions): UsePaymentsReturn {
     contractTotal,
     variationTotal,
     metrics,
-    loading,
-    refresh: loadAll,
+    loading: isFetching,
+    refresh: () => {
+      queryClient.invalidateQueries({ queryKey: ['payments'] });
+    },
   };
 }

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Task } from '../domain/entities/Task';
 import { DelayReason } from '../domain/entities/DelayReason';
 import { TaskRepository } from '../domain/repositories/TaskRepository';
 import { DelayReasonTypeRepository } from '../domain/repositories/DelayReasonTypeRepository';
+import { InvoiceRepository } from '../domain/repositories/InvoiceRepository';
 import { container } from 'tsyringe';
 import '../infrastructure/di/registerServices';
 import { CreateTaskUseCase } from '../application/usecases/task/CreateTaskUseCase';
@@ -20,6 +22,7 @@ import { DeleteProgressLogUseCase } from '../application/usecases/task/DeletePro
 import { ProgressLog } from '../domain/entities/ProgressLog';
 import { RemoveDelayReasonUseCase } from '../application/usecases/task/RemoveDelayReasonUseCase';
 import { ResolveDelayReasonUseCase } from '../application/usecases/task/ResolveDelayReasonUseCase';
+import { AcceptQuoteUseCase } from '../application/usecases/task/AcceptQuoteUseCase';
 
 export type { TaskDetail } from '../application/usecases/task/GetTaskDetailUseCase';
 export type { AddDelayReasonInput } from '../application/usecases/task/AddDelayReasonUseCase';
@@ -43,14 +46,18 @@ export interface UseTasksReturn {
   updateProgressLog: (logId: string, patch: Omit<UpdateProgressLogInput, 'logId'>) => Promise<ProgressLog>;
   deleteProgressLog: (logId: string) => Promise<void>;
   resolveDelayReason: (delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => Promise<void>;
+  acceptQuote: (taskId: string) => Promise<void>;
 }
 
 export function useTasks(projectId?: string): UseTasksReturn {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const queryClient = useQueryClient();
+
   const taskRepository = useMemo(() => container.resolve<TaskRepository>('TaskRepository'), []);
   const delayReasonTypeRepository = useMemo(() => container.resolve<DelayReasonTypeRepository>('DelayReasonTypeRepository'), []);
+  const invoiceRepo = useMemo(() => container.resolve<InvoiceRepository>('InvoiceRepository' as any), []);
   
   const createUseCase = useMemo(() => new CreateTaskUseCase(taskRepository), [taskRepository]);
   const updateUseCase = useMemo(() => new UpdateTaskUseCase(taskRepository), [taskRepository]);
@@ -66,6 +73,7 @@ export function useTasks(projectId?: string): UseTasksReturn {
   const deleteProgressLogUseCase = useMemo(() => new DeleteProgressLogUseCase(taskRepository), [taskRepository]);
   const removeDelayReasonUseCase = useMemo(() => new RemoveDelayReasonUseCase(taskRepository), [taskRepository]);
   const resolveDelayReasonUseCase = useMemo(() => new ResolveDelayReasonUseCase(taskRepository), [taskRepository]);
+  const acceptQuoteUseCase = useMemo(() => new AcceptQuoteUseCase(taskRepository, invoiceRepo), [taskRepository, invoiceRepo]);
 
   const loadTasks = useCallback(async () => {
     setLoading(true);
@@ -152,6 +160,16 @@ export function useTasks(projectId?: string): UseTasksReturn {
     await resolveDelayReasonUseCase.execute({ delayReasonId, resolvedAt, mitigationNotes });
   }, [resolveDelayReasonUseCase]);
 
+  const acceptQuote = useCallback(async (taskId: string) => {
+    await acceptQuoteUseCase.execute(taskId);
+    // Invalidate across domains so Payments and Invoices screens update automatically
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['tasks', projectId] }),
+      queryClient.invalidateQueries({ queryKey: ['payments'] }),
+      queryClient.invalidateQueries({ queryKey: ['invoices'] }),
+    ]);
+  }, [acceptQuoteUseCase, projectId, queryClient]);
+
   return useMemo(() => ({
     tasks,
     loading,
@@ -169,5 +187,6 @@ export function useTasks(projectId?: string): UseTasksReturn {
     addProgressLog,
     updateProgressLog,
     deleteProgressLog,
-  }), [tasks, loading, loadTasks, createTask, updateTask, deleteTask, getTask, getTaskDetail, addDependency, removeDependency, addDelayReason, removeDelayReason, resolveDelayReason, addProgressLog, updateProgressLog, deleteProgressLog]);
+    acceptQuote,
+  }), [tasks, loading, loadTasks, createTask, updateTask, deleteTask, getTask, getTaskDetail, addDependency, removeDependency, addDelayReason, removeDelayReason, resolveDelayReason, addProgressLog, updateProgressLog, deleteProgressLog, acceptQuote]);
 }


### PR DESCRIPTION
Summary of changes:

- Add `@tanstack/react-query` and configure `QueryClientProvider` in `App.tsx`.
- Migrate `usePayments` to use `useQuery` for shared caching and explicit invalidation.
- Add `acceptQuote` to `useTasks` that calls `AcceptQuoteUseCase` and invalidates `tasks`, `payments`, and `invoices` queries.
- Update unit test mock for `useTasks`.
- Typecheck passed (`npx tsc --noEmit`).

Why: Fixes cross-screen state sync (e.g., accepting a quote should update Payments screen immediately).

Notes:
- Query keys: `['payments', 'firefighter', contractorSearch]` and `['payments', 'site_manager', projectId]`.
- Default query behavior set to explicit invalidation only (`staleTime: Infinity`).

Please review and merge into `master`. If you'd like a different branch name or PR description, tell me and I can update it.