### PR TITLE
issue/152: centralize query keys + invalidation map — migrate hooks & tests

### DIFF
--- a/__tests__/integration/QuotationScreen.integration.test.tsx
+++ b/__tests__/integration/QuotationScreen.integration.test.tsx
@@ -19,6 +19,7 @@ describe('QuotationScreen Integration', () => {
       getQuotation: jest.fn(),
       updateQuotation: jest.fn(),
       deleteQuotation: jest.fn(),
+      taskQuotations: undefined,
       loading: false,
       error: null,
     });

--- a/__tests__/unit/queryInvalidations.test.ts
+++ b/__tests__/unit/queryInvalidations.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Invalidation unit tests — §5.1 of design/issue-152-query-invalidation-review.md
+ *
+ * Each test family asserts that after calling a mutation the hook calls
+ * queryClient.invalidateQueries with exactly the expected cache keys.
+ *
+ * Strategy:
+ *  - Use renderHookWithQuery which provides a real QueryClient via QueryClientProvider.
+ *  - Spy on the returned queryClient.invalidateQueries so we can assert calls.
+ *  - Mock the DI container so repository calls are no-ops.
+ */
+
+import { act } from '@testing-library/react-native';
+import { container } from 'tsyringe';
+import { renderHookWithQuery } from '../utils/queryClientWrapper';
+import { useAcceptQuote } from '../../src/hooks/useAcceptQuote';
+import { useTasks } from '../../src/hooks/useTasks';
+import { useInvoices } from '../../src/hooks/useInvoices';
+
+// ── Repo factory helpers ─────────────────────────────────────────────────────
+
+function makeTaskRepo(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    save: jest.fn().mockResolvedValue(undefined),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    findByProjectId: jest.fn().mockResolvedValue([]),
+    findAdHoc: jest.fn().mockResolvedValue([]),
+    findUpcoming: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    addDependency: jest.fn().mockResolvedValue(undefined),
+    removeDependency: jest.fn().mockResolvedValue(undefined),
+    findDependencies: jest.fn().mockResolvedValue([]),
+    findDependents: jest.fn().mockResolvedValue([]),
+    addDelayReason: jest.fn().mockResolvedValue({ id: 'dr-1' }),
+    removeDelayReason: jest.fn().mockResolvedValue(undefined),
+    resolveDelayReason: jest.fn().mockResolvedValue(undefined),
+    findDelayReasons: jest.fn().mockResolvedValue([]),
+    summarizeDelayReasons: jest.fn().mockResolvedValue([]),
+    deleteDependenciesByTaskId: jest.fn().mockResolvedValue(undefined),
+    deleteDelayReasonsByTaskId: jest.fn().mockResolvedValue(undefined),
+    findProgressLogs: jest.fn().mockResolvedValue([]),
+    addProgressLog: jest.fn().mockResolvedValue({ id: 'pl-1', taskId: 'task-1' }),
+    updateProgressLog: jest.fn().mockResolvedValue(undefined),
+    deleteProgressLog: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeInvoiceRepo(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    createInvoice: jest.fn().mockResolvedValue({ id: 'inv-1', status: 'draft', paymentStatus: 'unpaid', total: 0, currency: 'AUD', createdAt: '', updatedAt: '' }),
+    updateInvoice: jest.fn().mockResolvedValue(undefined),
+    deleteInvoice: jest.fn().mockResolvedValue(undefined),
+    listInvoices: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    getInvoice: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+function makeContactRepo(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    create: jest.fn().mockResolvedValue({ id: 'c-1' }),
+    update: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeQuotationRepo(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    create: jest.fn().mockResolvedValue({ id: 'q-1', total: 0 }),
+    update: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    findById: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    findByTask: jest.fn().mockResolvedValue([]),
+    findByTaskId: jest.fn().mockResolvedValue([]),
+    accept: jest.fn().mockResolvedValue(undefined),
+    reject: jest.fn().mockResolvedValue(undefined),
+    createQuotation: jest.fn().mockResolvedValue({ id: 'q-1', total: 0, createdAt: '', updatedAt: '' }),
+    getQuotation: jest.fn().mockResolvedValue(null),
+    updateQuotation: jest.fn().mockResolvedValue({ id: 'q-1', total: 0, createdAt: '', updatedAt: '' }),
+    deleteQuotation: jest.fn().mockResolvedValue(undefined),
+    findByReference: jest.fn().mockResolvedValue(null),
+    listQuotations: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 1. useAcceptQuote
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('useAcceptQuote — invalidations', () => {
+  const PROJECT_ID = 'project-1';
+  const TASK_ID = 'task-1';
+  const INVOICE_ID = 'inv-accepted-1';
+
+  let taskRepo: ReturnType<typeof makeTaskRepo>;
+  let invoiceRepo: ReturnType<typeof makeInvoiceRepo>;
+  let contactRepo: ReturnType<typeof makeContactRepo>;
+  let quotationRepo: ReturnType<typeof makeQuotationRepo>;
+
+  beforeEach(() => {
+    taskRepo = makeTaskRepo({
+      findById: jest.fn().mockResolvedValue({
+        id: TASK_ID,
+        projectId: PROJECT_ID,
+        title: 'Build deck',
+        taskType: 'contract_work',
+        quoteStatus: 'pending',
+        quoteAmount: 5000,
+        subcontractorId: undefined,
+      }),
+    });
+    invoiceRepo = makeInvoiceRepo({
+      createInvoice: jest.fn().mockResolvedValue({
+        id: INVOICE_ID,
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        total: 5000,
+        currency: 'AUD',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    });
+    contactRepo = makeContactRepo();
+    quotationRepo = makeQuotationRepo();
+
+    jest.spyOn(container, 'resolve').mockImplementation((token: any) => {
+      if (token === 'TaskRepository') return taskRepo;
+      if (token === 'InvoiceRepository') return invoiceRepo;
+      if (token === 'ContactRepository') return contactRepo;
+      if (token === 'QuotationRepository') return quotationRepo;
+      return {};
+    });
+  });
+
+  it('acceptQuote invalidates payments, invoices(projectId), tasks(projectId), taskDetail, quotations(taskId)', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useAcceptQuote());
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.acceptQuote(TASK_ID);
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+
+    expect(calledKeys).toContainEqual(['payments']);
+    expect(calledKeys).toContainEqual(['invoices', PROJECT_ID]);
+    expect(calledKeys).toContainEqual(['tasks', PROJECT_ID]);
+    expect(calledKeys).toContainEqual(['taskDetail', TASK_ID]);
+    expect(calledKeys).toContainEqual(['quotations', TASK_ID]);
+    // Must NOT invalidate bare ['invoices'] or ['tasks'] (over-invalidation guard)
+    expect(calledKeys).not.toContainEqual(['invoices']);
+    expect(calledKeys).not.toContainEqual(['tasks']);
+  });
+
+  it('rejectQuote invalidates tasks, taskDetail, quotations — NOT payments', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useAcceptQuote());
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.rejectQuote(TASK_ID);
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+
+    expect(calledKeys).toContainEqual(['tasks', PROJECT_ID]);
+    expect(calledKeys).toContainEqual(['taskDetail', TASK_ID]);
+    expect(calledKeys).toContainEqual(['quotations', TASK_ID]);
+    // Reject should NOT touch payments or invoices — no financial change
+    expect(calledKeys).not.toContainEqual(['payments']);
+    expect(calledKeys).not.toContainEqual(expect.arrayContaining(['invoices']));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2. useTasks — progress log mutations
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('useTasks — progress log invalidations', () => {
+  const TASK_ID = 'task-pl-1';
+  const LOG_ID = 'pl-log-1';
+
+  let taskRepo: ReturnType<typeof makeTaskRepo>;
+
+  beforeEach(() => {
+    taskRepo = makeTaskRepo({
+      findProgressLogs: jest.fn().mockResolvedValue([]),
+      addProgressLog: jest.fn().mockResolvedValue({ id: LOG_ID, taskId: TASK_ID }),
+      updateProgressLog: jest.fn().mockResolvedValue(undefined),
+      deleteProgressLog: jest.fn().mockResolvedValue(undefined),
+    });
+
+    jest.spyOn(container, 'resolve').mockImplementation((token: any) => {
+      if (token === 'TaskRepository') return taskRepo;
+      return {};
+    });
+  });
+
+  it('addProgressLog invalidates progressLogs and taskDetail', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useTasks());
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.addProgressLog(TASK_ID, { description: 'Foundation poured', photos: [] });
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['progressLogs', TASK_ID]);
+    expect(calledKeys).toContainEqual(['taskDetail', TASK_ID]);
+  });
+
+  it('updateProgressLog invalidates progressLogs and taskDetail', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useTasks());
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.updateProgressLog(TASK_ID, LOG_ID, { description: 'Updated note' });
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['progressLogs', TASK_ID]);
+    expect(calledKeys).toContainEqual(['taskDetail', TASK_ID]);
+  });
+
+  it('deleteProgressLog invalidates progressLogs and taskDetail', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useTasks());
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.deleteProgressLog(TASK_ID, LOG_ID);
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['progressLogs', TASK_ID]);
+    expect(calledKeys).toContainEqual(['taskDetail', TASK_ID]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 3. useTasks — task edit invalidations
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('useTasks — updateTask invalidations', () => {
+  const PROJECT_ID = 'project-upd-1';
+  const TASK_ID = 'task-upd-1';
+
+  let taskRepo: ReturnType<typeof makeTaskRepo>;
+
+  beforeEach(() => {
+    taskRepo = makeTaskRepo({
+      findById: jest.fn().mockResolvedValue({
+        id: TASK_ID,
+        projectId: PROJECT_ID,
+        title: 'Old title',
+        status: 'pending',
+      }),
+      update: jest.fn().mockResolvedValue(undefined),
+      findByProjectId: jest.fn().mockResolvedValue([]),
+    });
+
+    jest.spyOn(container, 'resolve').mockImplementation((token: any) => {
+      if (token === 'TaskRepository') return taskRepo;
+      return {};
+    });
+  });
+
+  it('updateTask invalidates tasks(projectId) and taskDetail', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useTasks(PROJECT_ID));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.updateTask({ id: TASK_ID, projectId: PROJECT_ID, title: 'New title', status: 'in_progress' });
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['tasks', PROJECT_ID]);
+    expect(calledKeys).toContainEqual(['taskDetail', TASK_ID]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 4. useInvoices — invoice create/update/delete invalidations
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('useInvoices — mutation invalidations', () => {
+  const PROJECT_ID = 'project-inv-1';
+
+  let invoiceRepo: ReturnType<typeof makeInvoiceRepo>;
+
+  beforeEach(() => {
+    invoiceRepo = makeInvoiceRepo();
+
+    jest.spyOn(container, 'resolve').mockImplementation((token: any) => {
+      if (token === 'InvoiceRepository') return invoiceRepo;
+      return {};
+    });
+  });
+
+  it('createInvoice invalidates payments and invoices(projectId)', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useInvoices({ projectId: PROJECT_ID }));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.createInvoice({
+        projectId: PROJECT_ID,
+        status: 'draft',
+        paymentStatus: 'unpaid',
+        total: 1000,
+        currency: 'AUD',
+        dueDate: '2025-12-31',
+      } as any);
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['payments']);
+    expect(calledKeys).toContainEqual(['invoices', PROJECT_ID]);
+  });
+
+  it('updateInvoice invalidates payments and invoices(projectId)', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useInvoices({ projectId: PROJECT_ID }));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.updateInvoice({ id: 'inv-1', total: 2000 } as any);
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['payments']);
+    expect(calledKeys).toContainEqual(['invoices', PROJECT_ID]);
+  });
+
+  it('deleteInvoice invalidates payments and invoices(projectId)', async () => {
+    const { result, queryClient } = renderHookWithQuery(() => useInvoices({ projectId: PROJECT_ID }));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.deleteInvoice('inv-1');
+    });
+
+    const calledKeys = invalidateSpy.mock.calls.map((c: any) => c[0].queryKey);
+    expect(calledKeys).toContainEqual(['payments']);
+    expect(calledKeys).toContainEqual(['invoices', PROJECT_ID]);
+  });
+});
+

--- a/__tests__/unit/useInvoices.test.tsx
+++ b/__tests__/unit/useInvoices.test.tsx
@@ -1,8 +1,10 @@
 import renderer, { act } from 'react-test-renderer';
 import React, { useEffect } from 'react';
+import { waitFor } from '@testing-library/react-native';
 import { container } from 'tsyringe';
 import { useInvoices } from '../../src/hooks/useInvoices';
 import { Invoice } from '../../src/domain/entities/Invoice';
+import { wrapWithQuery, renderHookWithQuery } from '../utils/queryClientWrapper';
 
 describe('useInvoices hook', () => {
   const mockRepo: any = {
@@ -47,55 +49,25 @@ describe('useInvoices hook', () => {
 
       mockRepo.listInvoices.mockResolvedValueOnce({ items: invoices, total: 2 });
 
-      let latest: any = null;
+      const { result } = renderHookWithQuery(() => useInvoices());
 
-      function TestHarness() {
-        const state = useInvoices();
-        useEffect(() => {
-          latest = state;
-        }, [state]);
-        return null;
-      }
+      await waitFor(() => expect(result.current.loading).toBe(false));
 
-      await act(async () => {
-        renderer.create(<TestHarness />);
-        for (let i = 0; i < 20; i++) {
-          if (latest && latest.loading === false) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
-      });
-
-      expect(latest.loading).toBe(false);
-      expect(latest.error).toBeNull();
-      expect(latest.invoices).toHaveLength(2);
-      expect(latest.invoices[0].id).toBe('inv_1');
+      expect(result.current.error).toBeNull();
+      expect(result.current.invoices).toHaveLength(2);
+      expect(result.current.invoices[0].id).toBe('inv_1');
       expect(mockRepo.listInvoices).toHaveBeenCalledTimes(1);
     });
 
     it('sets error when initial load fails', async () => {
       mockRepo.listInvoices.mockRejectedValueOnce(new Error('Database error'));
 
-      let latest: any = null;
+      const { result } = renderHookWithQuery(() => useInvoices());
 
-      function TestHarness() {
-        const state = useInvoices();
-        useEffect(() => {
-          latest = state;
-        }, [state]);
-        return null;
-      }
+      await waitFor(() => expect(result.current.loading).toBe(false));
 
-      await act(async () => {
-        renderer.create(<TestHarness />);
-        for (let i = 0; i < 20; i++) {
-          if (latest && latest.loading === false) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
-      });
-
-      expect(latest.loading).toBe(false);
-      expect(latest.invoices).toHaveLength(0);
-      expect(latest.error).toContain('Database error');
+      expect(result.current.invoices).toHaveLength(0);
+      expect(result.current.error).toContain('Database error');
     });
 
     it('filters invoices by status', async () => {
@@ -128,27 +100,12 @@ describe('useInvoices hook', () => {
         return Promise.resolve({ items: filtered, total: filtered.length });
       });
 
-      let latest: any = null;
+      const { result } = renderHookWithQuery(() => useInvoices({ status: 'paid' }));
 
-      function TestHarness() {
-        const state = useInvoices({ status: 'paid' });
-        useEffect(() => {
-          latest = state;
-        }, [state]);
-        return null;
-      }
+      await waitFor(() => expect(result.current.loading).toBe(false));
 
-      await act(async () => {
-        renderer.create(<TestHarness />);
-        for (let i = 0; i < 20; i++) {
-          if (latest && latest.loading === false) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
-      });
-
-      expect(latest.loading).toBe(false);
-      expect(latest.invoices).toHaveLength(1);
-      expect(latest.invoices[0].status).toBe('paid');
+      expect(result.current.invoices).toHaveLength(1);
+      expect(result.current.invoices[0].status).toBe('paid');
     });
   });
 
@@ -184,7 +141,7 @@ describe('useInvoices hook', () => {
       }
 
       await act(async () => {
-        renderer.create(<TestHarness />);
+        renderer.create(wrapWithQuery(<TestHarness />));
         for (let i = 0; i < 20; i++) {
           if (latest && latest.loading === false) break;
           await new Promise<void>(resolve => setTimeout(resolve, 50));
@@ -228,7 +185,7 @@ describe('useInvoices hook', () => {
       }
 
       await act(async () => {
-        renderer.create(<TestHarness />);
+        renderer.create(wrapWithQuery(<TestHarness />));
         for (let i = 0; i < 20; i++) {
           if (latest && latest.loading === false) break;
           await new Promise<void>(resolve => setTimeout(resolve, 50));
@@ -274,42 +231,19 @@ describe('useInvoices hook', () => {
 
       mockRepo.updateInvoice.mockResolvedValueOnce(undefined);
 
-      let latest: any = null;
+      const { result } = renderHookWithQuery(() => useInvoices());
 
-      function TestHarness() {
-        const state = useInvoices();
-        useEffect(() => {
-          latest = state;
-        }, [state]);
-        return null;
-      }
+      await waitFor(() => expect(result.current.invoices[0]?.total).toBe(1000));
 
       await act(async () => {
-        renderer.create(<TestHarness />);
-        for (let i = 0; i < 20; i++) {
-          if (latest && latest.loading === false) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
-      });
-
-      expect(latest.invoices[0].total).toBe(1000);
-
-      await act(async () => {
-        const result = await latest.updateInvoice({
+        const updateResult = await result.current.updateInvoice({
           ...invoice,
           total: 1500,
         });
-
-        expect(result.success).toBe(true);
-
-        // Wait for list to refresh
-        for (let i = 0; i < 20; i++) {
-          if (latest.invoices[0].total === 1500) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
+        expect(updateResult.success).toBe(true);
       });
 
-      expect(latest.invoices[0].total).toBe(1500);
+      await waitFor(() => expect(result.current.invoices[0]?.total).toBe(1500));
     });
   });
 
@@ -331,39 +265,16 @@ describe('useInvoices hook', () => {
 
       mockRepo.deleteInvoice.mockResolvedValueOnce(undefined);
 
-      let latest: any = null;
+      const { result } = renderHookWithQuery(() => useInvoices());
 
-      function TestHarness() {
-        const state = useInvoices();
-        useEffect(() => {
-          latest = state;
-        }, [state]);
-        return null;
-      }
+      await waitFor(() => expect(result.current.invoices).toHaveLength(1));
 
       await act(async () => {
-        renderer.create(<TestHarness />);
-        for (let i = 0; i < 20; i++) {
-          if (latest && latest.loading === false) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
+        const deleteResult = await result.current.deleteInvoice('inv_1');
+        expect(deleteResult.success).toBe(true);
       });
 
-      expect(latest.invoices).toHaveLength(1);
-
-      await act(async () => {
-        const result = await latest.deleteInvoice('inv_1');
-
-        expect(result.success).toBe(true);
-
-        // Wait for list to refresh
-        for (let i = 0; i < 20; i++) {
-          if (latest.invoices.length === 0) break;
-          await new Promise<void>(resolve => setTimeout(resolve, 50));
-        }
-      });
-
-      expect(latest.invoices).toHaveLength(0);
+      await waitFor(() => expect(result.current.invoices).toHaveLength(0));
       expect(mockRepo.deleteInvoice).toHaveBeenCalledWith('inv_1');
     });
   });
@@ -394,7 +305,7 @@ describe('useInvoices hook', () => {
       }
 
       await act(async () => {
-        renderer.create(<TestHarness />);
+        renderer.create(wrapWithQuery(<TestHarness />));
         for (let i = 0; i < 20; i++) {
           if (latest && latest.loading === false) break;
           await new Promise<void>(resolve => setTimeout(resolve, 50));
@@ -429,7 +340,7 @@ describe('useInvoices hook', () => {
       }
 
       await act(async () => {
-        renderer.create(<TestHarness />);
+        renderer.create(wrapWithQuery(<TestHarness />));
         for (let i = 0; i < 20; i++) {
           if (latest && latest.loading === false) break;
           await new Promise<void>(resolve => setTimeout(resolve, 50));
@@ -476,7 +387,7 @@ describe('useInvoices hook', () => {
       }
 
       await act(async () => {
-        renderer.create(<TestHarness />);
+        renderer.create(wrapWithQuery(<TestHarness />));
         for (let i = 0; i < 20; i++) {
           if (latest && latest.loading === false) break;
           await new Promise<void>(resolve => setTimeout(resolve, 50));

--- a/__tests__/unit/useQuotations.test.tsx
+++ b/__tests__/unit/useQuotations.test.tsx
@@ -1,5 +1,6 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { act } from '@testing-library/react-native';
 import { useQuotations } from '../../src/hooks/useQuotations';
+import { renderHookWithQuery } from '../utils/queryClientWrapper';
 
 // Mock the use cases
 jest.mock('../../src/application/usecases/quotation/CreateQuotationUseCase');
@@ -32,28 +33,28 @@ describe('useQuotations', () => {
   });
 
   it('provides createQuotation function', () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     expect(result.current.createQuotation).toBeDefined();
     expect(typeof result.current.createQuotation).toBe('function');
   });
 
   it('provides listQuotations function', () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     expect(result.current.listQuotations).toBeDefined();
     expect(typeof result.current.listQuotations).toBe('function');
   });
 
   it('provides loading and error states', () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     expect(result.current).toHaveProperty('loading');
     expect(result.current).toHaveProperty('error');
   });
 
   it('creates quotation successfully', async () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     const mockQuotation = {
       reference: 'QT-2026-001',
@@ -69,7 +70,7 @@ describe('useQuotations', () => {
   });
 
   it('handles creation errors', async () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     await act(async () => {
       try {
@@ -82,7 +83,7 @@ describe('useQuotations', () => {
   });
 
   it('lists quotations with filtering', async () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     await act(async () => {
       const list = await result.current.listQuotations({ status: ['draft'] });
@@ -93,7 +94,7 @@ describe('useQuotations', () => {
   });
 
   it('sets loading state during operations', async () => {
-    const { result } = renderHook(() => useQuotations());
+    const { result } = renderHookWithQuery(() => useQuotations());
     
     expect(result.current.loading).toBe(false);
 

--- a/__tests__/unit/useTaskForm.test.tsx
+++ b/__tests__/unit/useTaskForm.test.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { container } from 'tsyringe';
 import { useTaskForm } from '../../src/hooks/useTaskForm';
 import { Task } from '../../src/domain/entities/Task';
+import { wrapWithQuery } from '../utils/queryClientWrapper';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -70,7 +71,7 @@ async function renderForm(opts: Parameters<typeof useTaskForm>[0] = {}) {
   }
 
   await act(async () => {
-    renderer.create(<TestHarness />);
+    renderer.create(wrapWithQuery(<TestHarness />));
     await new Promise<void>((r) => setTimeout(r, 0));
   });
 

--- a/__tests__/utils/queryClientWrapper.tsx
+++ b/__tests__/utils/queryClientWrapper.tsx
@@ -1,0 +1,53 @@
+/**
+ * Shared test utilities for hooks that use TanStack Query.
+ *
+ * Usage:
+ *   import { renderHookWithQuery, wrapWithQuery } from '../utils/queryClientWrapper';
+ *
+ *   const { result } = renderHookWithQuery(() => useMyHook());
+ *   // or with renderer.create:
+ *   renderer.create(wrapWithQuery(<MyComponent />));
+ */
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react-native';
+
+/** Creates a fresh QueryClient suitable for tests (no retries, no caching). */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+/** Wraps a React element with a fresh QueryClientProvider. */
+export function wrapWithQuery(
+  element: React.ReactElement,
+  qc?: QueryClient,
+): React.ReactElement {
+  const queryClient = qc ?? createTestQueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
+  );
+}
+
+/** renderHook with a fresh QueryClientProvider wrapper. */
+export function renderHookWithQuery<T>(
+  hook: () => T,
+  qc?: QueryClient,
+): ReturnType<typeof renderHook> & { queryClient: QueryClient } {
+  const queryClient = qc ?? createTestQueryClient();
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const result = renderHook(hook, { wrapper });
+  return { ...result, queryClient };
+}

--- a/design/issue-152-query-invalidation-review.md
+++ b/design/issue-152-query-invalidation-review.md
@@ -1,0 +1,413 @@
+# Design: UI Invalidation Logic Review — Invoices, Payments, Documents & Images
+**Issue**: [#152](https://github.com/yhua045/builder-assistant/issues/152)  
+**Date**: 2026-03-17  
+**Status**: Awaiting approval — do NOT implement until approved
+
+---
+
+## 1. Problem Summary
+
+The app has partially migrated to TanStack Query. Only `usePayments` fully participates in the cache. All other data hooks (`useInvoices`, `useQuotations`, `useTasks`, `useContacts`, `useTaskDetail`) use local `useState`/`useEffect` patterns. This means:
+
+- Cross-domain invalidations called today are **no-ops** (e.g., `invalidateQueries({ queryKey: ['invoices'] })` in `useAcceptQuote` never triggers a refetch because `useInvoices` doesn't use TanStack Query).
+- After a mutation in one domain (e.g., task update, progress log change, invoice deletion), **related screens silently go stale**.
+
+---
+
+## 2. Current State Audit
+
+### 2.1 Hook Inventory
+
+| Hook | TanStack Query? | Notes |
+|------|-----------------|-------|
+| `usePayments` | ✅ `useQuery` + `useQueryClient` | Only hook with active cache |
+| `useAcceptQuote` | ⚠️ `useQueryClient` side-effects only | Invalidates `['payments']` and `['invoices']` (second is a no-op) |
+| `useTasks` | ❌ `useState`/`useEffect` | Imports `useQueryClient` but **never calls it** |
+| `useInvoices` | ❌ `useState`/`useEffect` | Target of dead invalidation from `useAcceptQuote` |
+| `useQuotations` | ❌ `useState` only | No refresh strategy |
+| `useTaskDetail` | ❌ `useEffect` only | No invalidation possible |
+| `useContacts` | ❌ `useState`/`useEffect` | No invalidation possible |
+| `useTaskForm` | ❌ form state only | Calls `AcceptQuotationUseCase` directly, bypassing `useAcceptQuote` invalidations |
+
+### 2.2 Known Bugs
+
+| # | Bug | Impact |
+|---|-----|--------|
+| B1 | `invalidateQueries({ queryKey: ['invoices'] })` in `useAcceptQuote` is a no-op — `useInvoices` is not TanStack Query-backed | Invoice list never auto-refreshes after quote acceptance |
+| B2 | `useTasks` holds a dead `useQueryClient` reference — `loadTasks()` re-fetches local state only | Payments screen goes stale after task mutations |
+| B3 | `useTaskForm.submit()` calls `AcceptQuotationUseCase` directly — all invalidations in `useAcceptQuote` are skipped for task-form path | Same stale-payment issue via a different code path |
+| B4 | No hooks for progress logs use TanStack Query — adding/removing progress log attachments never refreshes the Documents/Images tab | Documents/Images tab requires manual refresh |
+
+---
+
+## 3. Proposed Solution
+
+### 3.1 Strategy
+
+Rather than incrementally patching individual hooks, adopt a **two-phase approach**:
+
+**Phase A — Introduce a central query key registry and migrate all data hooks to TanStack Query.**  
+This is the prerequisite for all correct cross-domain invalidations.
+
+**Phase B — Add explicit `invalidateQueries` calls at every mutation point once the caches exist.**
+
+This document covers design for both phases, but the implementation milestone for this issue is Phase B only if Phase A already exists, or a combined Phase A+B if starting fresh.
+
+---
+
+### 3.2 Central Query Key Registry + Invalidation Map
+
+Both the query key factories **and** the "what to invalidate per mutation" relationships live in a single file: `src/hooks/queryKeys.ts`.
+
+The rationale: if you ever rename a key, add a new query to a domain, or rethink a dependency, there is exactly one file to update. Every hook that performs a mutation imports `invalidations.xxx(ctx)` from here rather than spelling out key arrays inline.
+
+**`src/hooks/queryKeys.ts`:**
+
+```ts
+// ─── Key factories ────────────────────────────────────────────────────────────
+// Rules:
+//  • Always use these factories — never write raw string arrays in hook code.
+//  • Prefix-only variants (no extra segment) act as "invalidate whole domain".
+
+export const queryKeys = {
+  // Payments
+  payments: (mode: 'firefighter' | 'site_manager', param: string) =>
+    ['payments', mode, param] as const,
+  paymentsAll: () => ['payments'] as const,
+
+  // Invoices
+  invoices: (projectId?: string) =>
+    projectId ? ['invoices', projectId] : (['invoices'] as const),
+
+  // Quotations
+  quotations: (taskId?: string) =>
+    taskId ? ['quotations', taskId] : (['quotations'] as const),
+
+  // Tasks
+  tasks: (projectId?: string) =>
+    projectId ? ['tasks', projectId] : (['tasks'] as const),
+  taskDetail: (taskId: string) => ['taskDetail', taskId] as const,
+
+  // Progress Logs
+  progressLogs: (taskId: string) => ['progressLogs', taskId] as const,
+
+  // Documents
+  documents: (taskId: string) => ['documents', taskId] as const,
+
+  // Contacts
+  contacts: () => ['contacts'] as const,
+};
+
+// ─── Invalidation map ─────────────────────────────────────────────────────────
+// Single source of truth for cross-domain side-effects.
+//
+// Reading guide: "when mutation X succeeds, call
+//   queryClient.invalidateQueries for each key in invalidations.X(ctx)"
+//
+// Maintenance rule: if you add a new query key above, update every entry
+// below that should cascade to it — the compiler will not catch omissions,
+// so the comment block is the dependency graph.
+
+type AcceptQuotationCtx = { projectId: string; taskId: string };
+type RejectQuotationCtx = { projectId: string; taskId: string };
+type InvoiceCtx         = { projectId: string; taskId?: string };
+type PaymentCtx         = { projectId: string };
+type ProgressLogCtx     = { taskId: string };
+type DocumentCtx        = { taskId: string };
+type TaskEditCtx        = { projectId: string; taskId: string; affectsPayments?: boolean };
+type ContactCtx         = Record<string, never>;
+
+export const invalidations = {
+  /**
+   * Accept quotation → creates Invoice, updates Task.quoteStatus.
+   * Affects: payment totals, invoice list, task status badge, quote badge.
+   */
+  acceptQuotation: (ctx: AcceptQuotationCtx) => [
+    queryKeys.paymentsAll(),
+    queryKeys.invoices(ctx.projectId),
+    queryKeys.tasks(ctx.projectId),
+    queryKeys.taskDetail(ctx.taskId),
+    queryKeys.quotations(ctx.taskId),
+  ],
+
+  /**
+   * Reject quotation → updates Task.quoteStatus only.
+   * Does NOT affect payments or invoices.
+   */
+  rejectQuotation: (ctx: RejectQuotationCtx) => [
+    queryKeys.tasks(ctx.projectId),
+    queryKeys.taskDetail(ctx.taskId),
+    queryKeys.quotations(ctx.taskId),
+  ],
+
+  /**
+   * Create / update / delete invoice.
+   * Affects: payment totals, invoice list, task detail (linked invoice status).
+   */
+  invoiceMutated: (ctx: InvoiceCtx) => [
+    queryKeys.paymentsAll(),
+    queryKeys.invoices(ctx.projectId),
+    ...(ctx.taskId ? [queryKeys.taskDetail(ctx.taskId)] : []),
+  ],
+
+  /**
+   * Record payment or mark payment as paid.
+   * Affects: payment list/amounts, invoice status (partially/fully paid).
+   */
+  paymentRecorded: (ctx: PaymentCtx) => [
+    queryKeys.paymentsAll(),
+    queryKeys.invoices(ctx.projectId),
+  ],
+
+  /**
+   * Add / update / remove a progress log entry.
+   * Affects: progress log list, task detail metadata.
+   */
+  progressLogMutated: (ctx: ProgressLogCtx) => [
+    queryKeys.progressLogs(ctx.taskId),
+    queryKeys.taskDetail(ctx.taskId),
+  ],
+
+  /**
+   * Upload or remove a document/image attached to a progress log.
+   * Affects: document list, progress log list (thumbnail/count), task detail.
+   */
+  documentMutated: (ctx: DocumentCtx) => [
+    queryKeys.documents(ctx.taskId),
+    queryKeys.progressLogs(ctx.taskId),
+    queryKeys.taskDetail(ctx.taskId),
+  ],
+
+  /**
+   * Edit task fields (status, trade type, assigned subcontractor, etc.).
+   * Pass affectsPayments=true only if a payment-linked field changes
+   * (e.g., subcontractor reassignment on a task with an active invoice).
+   */
+  taskEdited: (ctx: TaskEditCtx) => [
+    queryKeys.tasks(ctx.projectId),
+    queryKeys.taskDetail(ctx.taskId),
+    ...(ctx.affectsPayments ? [queryKeys.paymentsAll()] : []),
+  ],
+
+  /**
+   * Add or update a contact/subcontractor.
+   * Affects: contact picker, invoice issuer display.
+   */
+  contactMutated: (_ctx: ContactCtx) => [
+    queryKeys.contacts(),
+    queryKeys.invoices(), // issuer name may appear on any invoice
+  ],
+};
+```
+
+**Usage in a hook:**
+```ts
+import { queryKeys, invalidations } from './queryKeys';
+
+const queryClient = useQueryClient();
+await acceptQuotationUseCase.execute(taskId);
+await Promise.all(
+  invalidations.acceptQuotation({ projectId, taskId })
+    .map(key => queryClient.invalidateQueries({ queryKey: key }))
+);
+```
+
+This pattern means that if, say, `taskDetail` is renamed or a new `cockpit` query should also be refreshed on quote acceptance, there is exactly one line to change in `queryKeys.ts`.
+
+All hooks and mutation sites **must** import key factories and invalidation arrays from this file. No raw string-array literals in hook code.
+
+---
+
+### 3.3 Hooks to Migrate to TanStack Query
+
+The following hooks must be migrated from `useState`/`useEffect` to `useQuery`:
+
+| Hook | New Query Key(s) |
+|------|-----------------|
+| `useInvoices` | `queryKeys.invoices(projectId?)` |
+| `useQuotations` | `queryKeys.quotations(taskId?)` |
+| `useTasks` | `queryKeys.tasks(projectId?)` |
+| `useTaskDetail` | `queryKeys.taskDetail(taskId)` |
+| `useContacts` | `queryKeys.contacts()` |
+
+Migration pattern (example for `useInvoices`):
+```ts
+// Before:
+const [invoices, setInvoices] = useState<Invoice[]>([]);
+useEffect(() => { listInvoicesUseCase.execute().then(setInvoices); }, []);
+
+// After:
+const { data: invoices = [] } = useQuery({
+  queryKey: queryKeys.invoices(projectId),
+  queryFn: () => listInvoicesUseCase.execute(projectId),
+  staleTime: 30_000,
+});
+```
+
+---
+
+### 3.4 Invalidation Matrix
+
+> These relationships are encoded directly in `invalidations` object in `queryKeys.ts` (§ 3.2). The table below is a human-readable view of that same data for review purposes.
+
+| Mutation | `invalidations` entry | Keys invalidated |
+|----------|----------------------|-----------------|
+| Accept quotation | `acceptQuotation` | `payments`, `invoices[projectId]`, `tasks[projectId]`, `taskDetail[taskId]`, `quotations[taskId]` |
+| Reject quotation | `rejectQuotation` | `tasks[projectId]`, `taskDetail[taskId]`, `quotations[taskId]` |
+| Create/update/delete invoice | `invoiceMutated` | `payments`, `invoices[projectId]`, `taskDetail[taskId]` (if known) |
+| Record payment / mark paid | `paymentRecorded` | `payments`, `invoices[projectId]` |
+| Add/update/remove progress log | `progressLogMutated` | `progressLogs[taskId]`, `taskDetail[taskId]` |
+| Upload/remove document or image | `documentMutated` | `documents[taskId]`, `progressLogs[taskId]`, `taskDetail[taskId]` |
+| Edit task fields | `taskEdited` | `tasks[projectId]`, `taskDetail[taskId]`, `payments` (if payment-linked fields) |
+| Add/update contact | `contactMutated` | `contacts`, `invoices` (issuer display on any invoice) |
+
+**Hook assignment** (where each invalidation should live):
+
+| `invalidations` entry | Hook responsible |
+|-----------------------|-----------------|
+| `acceptQuotation` | `useAcceptQuote.acceptQuote()` |
+| `rejectQuotation` | `useAcceptQuote.rejectQuote()` |
+| `invoiceMutated` | Invoice mutation hooks (wherever `CreateInvoiceUseCase`, `UpdateInvoiceUseCase`, `DeleteInvoiceUseCase` are called) |
+| `paymentRecorded` | Payment mutation hooks (`RecordPaymentUseCase`, `MarkPaymentAsPaidUseCase`) |
+| `progressLogMutated` | `useTasks.addProgressLog()`, `updateProgressLog()`, `deleteProgressLog()` |
+| `documentMutated` | Wherever `AddTaskDocumentUseCase` / `RemoveTaskDocumentUseCase` are called |
+| `taskEdited` | `useTasks.updateTask()` |
+| `contactMutated` | Contact mutation hooks |
+
+**Also fix**: `useTaskForm.submit()` for variation tasks must route through `useAcceptQuote` (or call `invalidations.acceptQuotation` directly) — currently bypasses all invalidations.
+
+---
+
+### 3.5 staleTime / refetchOnWindowFocus Recommendations
+
+| Query | Recommended staleTime | refetchOnWindowFocus |
+|-------|----------------------|---------------------|
+| `payments` | 30 s | `true` (financial data should stay fresh) |
+| `invoices` | 60 s | `true` |
+| `quotations` | 60 s | `false` |
+| `tasks` | 30 s | `true` |
+| `taskDetail` | 30 s | `true` |
+| `progressLogs` | 60 s | `false` |
+| `documents` | 120 s | `false` |
+| `contacts` | 5 min | `false` (changes rarely on mobile) |
+
+---
+
+### 3.6 Invalidation Implementation Pattern
+
+Always use the `invalidations` map from `queryKeys.ts` — never write key arrays inline inside a hook. Use `Promise.all` to fire all invalidations concurrently:
+
+```ts
+import { invalidations } from '../hooks/queryKeys';
+
+// Example: accept quotation
+const queryClient = useQueryClient();
+await acceptQuotationUseCase.execute(taskId);
+await Promise.all(
+  invalidations.acceptQuotation({ projectId, taskId })
+    .map(key => queryClient.invalidateQueries({ queryKey: key }))
+);
+```
+
+If you later need to also refresh the cockpit or blocker bar when a quotation is accepted, you update **only `invalidations.acceptQuotation` in `queryKeys.ts`** — every hook that calls it picks up the change automatically.
+
+Prefer adding invalidation logic in the **lowest-level dedicated hook** (e.g., `useAcceptQuote`, not in the component), so that any consumer of the hook benefits automatically.
+
+---
+
+## 4. Affected Screens Checklist
+
+The following screens **must respond** (auto-refresh without manual navigation) after the listed operations:
+
+| Operation | Affected Screens |
+|-----------|-----------------|
+| Accept quotation | Payments, Invoice list, Invoice detail, Task detail (quote status badge), Task list |
+| Reject quotation | Task detail (quote status badge), Task list |
+| Upload document/image to progress log | Task detail → Documents tab, Task detail → Images tab |
+| Add/remove progress log | Task detail → Progress tab, Task detail metadata |
+| Record payment / mark paid | Payments, Invoice detail (payment status) |
+| Create / update / delete invoice | Payments, Invoice list, Invoice detail, Task detail |
+| Edit task fields | Task list, Task detail, Cockpit (blocker/delay counts) |
+| Add / update contact | Invoice detail (issuer name), Subcontractor picker |
+
+---
+
+## 5. Test Plan
+
+### 5.1 Unit Tests — `__tests__/unit/hooks/`
+
+For each mutating hook, assert that after calling the mutation method, `queryClient.invalidateQueries` is called with the exact expected keys.
+
+**Test pattern** (mock `useQueryClient`):
+```ts
+const invalidateMock = jest.fn();
+jest.spyOn(require('@tanstack/react-query'), 'useQueryClient')
+  .mockReturnValue({ invalidateQueries: invalidateMock });
+
+const { result } = renderHook(() => useAcceptQuote(...));
+await act(() => result.current.acceptQuote('task-1'));
+
+expect(invalidateMock).toHaveBeenCalledWith({ queryKey: ['payments'] });
+expect(invalidateMock).toHaveBeenCalledWith({ queryKey: ['invoices'] });
+expect(invalidateMock).toHaveBeenCalledWith({ queryKey: ['invoices', 'project-1'] });
+expect(invalidateMock).toHaveBeenCalledWith({ queryKey: ['taskDetail', 'task-1'] });
+```
+
+Test cases required:
+- [ ] `useAcceptQuote.acceptQuote` — invalidates payments, invoices, taskDetail, tasks, quotations
+- [ ] `useAcceptQuote.rejectQuote` — invalidates taskDetail, tasks, quotations (NOT payments)
+- [ ] `useTasks.addProgressLog` — invalidates progressLogs, taskDetail
+- [ ] `useTasks.updateProgressLog` — invalidates progressLogs, taskDetail
+- [ ] `useTasks.deleteProgressLog` — invalidates progressLogs, taskDetail
+- [ ] `useTasks.updateTask` — invalidates tasks, taskDetail
+- [ ] Document upload mutation — invalidates documents, progressLogs, taskDetail
+- [ ] Payment record mutation — invalidates payments, invoices
+- [ ] Invoice create/update/delete — invalidates payments, invoices
+
+### 5.2 Integration Tests — `__tests__/integration/`
+
+Using in-memory Drizzle DB:
+1. **Accept quotation → invoice list refreshes**: Call `AcceptQuotationUseCase`, then assert `useInvoices` returns the new invoice on next render (requires `useInvoices` to be TanStack Query-backed).
+2. **Add progress log attachment → documents tab refreshes**: Add document via use case, assert `useQuery(['documents', taskId])` returns the added document without manual re-navigation.
+3. **Mark payment as paid → payments screen refreshes**: Call `MarkPaymentAsPaidUseCase`, assert `usePayments` reflects updated status.
+
+### 5.3 Regression Tests
+
+- Ensure existing passing tests for `usePayments` and `useAcceptQuote` remain green.
+- Ensure no double-fetch occurs (verify the query is not re-fetched more than once per mutation).
+
+---
+
+## 6. Implementation Sequence
+
+> Implementation order matters — each step depends on the previous.
+
+1. **Create `src/hooks/queryKeys.ts`** — central key factory (no behavior change, safe to do first).
+2. **Migrate `useInvoices` to TanStack Query** — fixes the dead `['invoices']` invalidation.
+3. **Migrate `useTasks` / `useTaskDetail` to TanStack Query** — enables task-level invalidations.
+4. **Migrate `useQuotations` to TanStack Query** — enables quote-status invalidations.
+5. **Migrate `useContacts` to TanStack Query** — enables contact invalidations.
+6. **Fix `useAcceptQuote`** — add missing invalidation keys; clean up the dead `['invoices']` → real invalidation now works.
+7. **Fix `useTaskForm`** — route through `useAcceptQuote` (or call same invalidations) for variation-task accept path.
+8. **Add invalidations to `useTasks` mutations** — progress log, task update paths.
+9. **Add invalidations to document upload path** — wherever `AddTaskDocumentUseCase` is called.
+10. **Add invalidations to invoice/payment mutation hooks** — wherever remaining use cases are invoked from hooks.
+11. **Write unit tests** (per § 5.1) for each newly-invalidating mutation.
+12. **Write integration tests** (per § 5.2) for the three critical cross-domain scenarios.
+
+---
+
+## 7. Out of Scope
+
+- Migrating `useSnapReceipt`, `useVoiceTask`, `useCameraTask`, `useBlockerBar`, `useCockpitData` to TanStack Query (these are purely imperative/UI-state hooks with no server cache to invalidate).
+- Optimistic updates — this issue targets correctness (stale-data bugs), not UX speed improvements.
+- Real-time / websocket push updates.
+
+---
+
+## 8. Open Questions
+
+1. **Should we use `invalidateQueries` or `refetchQueries`?** — `invalidateQueries` is preferred (marks stale, refetches only if the query is currently mounted). Use `refetchQueries` only if we need an immediate background prefetch regardless of mount state.
+2. **`useTaskForm` variation-task path**: Should it delegate to `useAcceptQuote` hook (preferred for consistency) or call invalidations inline? If `useTaskForm` is used in many places, delegating keeps the fix in one place.
+3. **Should contacts invalidation propagate to invoices?** The invoice issuer display is derived from contacts data. This may require either: (a) the invoice query to join contacts on fetch, or (b) a separate `contacts` invalidation that triggers invoice re-fetch. Option (a) (join in use case) is cleaner.
+4. **staleTime for `taskDetail`**: Should it be 0 (always fresh) given that it's a single-item detail screen? Need to agree on UX tolerance for briefly stale data while navigating back.

--- a/src/hooks/queryKeys.ts
+++ b/src/hooks/queryKeys.ts
@@ -1,0 +1,164 @@
+/**
+ * Central query key registry and invalidation map.
+ *
+ * Single source of truth for:
+ *  1. Query key factories  — import `queryKeys` to build cache keys.
+ *  2. Invalidation map     — import `invalidations` to know which keys to
+ *                            bust after each mutation.
+ *
+ * Maintenance rule
+ * ─────────────────
+ * • NEVER write raw string-array keys in hook code — always use these factories.
+ * • If you add a new query, add its factory to `queryKeys` below.
+ * • Then scan `invalidations` and add the new key to every entry that should
+ *   cascade to it.  The compiler will not catch omissions, so the JSDoc on
+ *   each entry is the human-readable dependency graph.
+ *
+ * Usage in a hook
+ * ───────────────
+ * ```ts
+ * import { invalidations } from './queryKeys';
+ *
+ * const queryClient = useQueryClient();
+ * await myUseCase.execute(...);
+ * await Promise.all(
+ *   invalidations.taskEdited({ projectId, taskId })
+ *     .map(key => queryClient.invalidateQueries({ queryKey: key }))
+ * );
+ * ```
+ */
+
+// ─── Key factories ────────────────────────────────────────────────────────────
+
+export const queryKeys = {
+  /** All payments (use for global invalidations) */
+  paymentsAll: () => ['payments'] as const,
+
+  /** Scoped payment cache (used by usePayments internally) */
+  payments: (mode: 'firefighter' | 'site_manager', param: string) =>
+    ['payments', mode, param] as const,
+
+  /** Invoice list — scoped to projectId when provided */
+  invoices: (projectId?: string) =>
+    (projectId ? ['invoices', projectId] : ['invoices']) as readonly string[],
+
+  /** Quotation list — scoped to taskId when provided */
+  quotations: (taskId?: string) =>
+    (taskId ? ['quotations', taskId] : ['quotations']) as readonly string[],
+
+  /** Task list — scoped to projectId when provided */
+  tasks: (projectId?: string) =>
+    (projectId ? ['tasks', projectId] : ['tasks']) as readonly string[],
+
+  /** Single enriched task detail */
+  taskDetail: (taskId: string) => ['taskDetail', taskId] as const,
+
+  /** Progress logs for a task */
+  progressLogs: (taskId: string) => ['progressLogs', taskId] as const,
+
+  /** Documents attached to a task */
+  documents: (taskId: string) => ['documents', taskId] as const,
+
+  /** Contact / subcontractor list */
+  contacts: () => ['contacts'] as const,
+};
+
+// ─── Context types for the invalidation map ───────────────────────────────────
+
+export type AcceptQuotationCtx = { projectId: string; taskId: string };
+export type RejectQuotationCtx = { projectId: string; taskId: string };
+export type InvoiceCtx = { projectId?: string; taskId?: string };
+export type PaymentCtx = { projectId?: string };
+export type ProgressLogCtx = { taskId: string };
+export type DocumentCtx = { taskId: string };
+export type TaskEditCtx = {
+  projectId: string;
+  taskId: string;
+  /** Pass true when a payment-linked field changes (e.g. subcontractor reassignment) */
+  affectsPayments?: boolean;
+};
+export type ContactCtx = Record<string, never>;
+
+// ─── Invalidation map ─────────────────────────────────────────────────────────
+
+export const invalidations = {
+  /**
+   * Accept quotation → creates Invoice, updates Task.quoteStatus to 'accepted'.
+   * Affects: payment totals, invoice list, task status badge, quote status badge.
+   */
+  acceptQuotation: (ctx: AcceptQuotationCtx) => [
+    queryKeys.paymentsAll(),
+    queryKeys.invoices(ctx.projectId),
+    queryKeys.tasks(ctx.projectId),
+    queryKeys.taskDetail(ctx.taskId),
+    queryKeys.quotations(ctx.taskId),
+  ],
+
+  /**
+   * Reject quotation → updates Task.quoteStatus to 'rejected'.
+   * Does NOT affect payments or invoices — no financial change occurs.
+   */
+  rejectQuotation: (ctx: RejectQuotationCtx) => [
+    queryKeys.tasks(ctx.projectId),
+    queryKeys.taskDetail(ctx.taskId),
+    queryKeys.quotations(ctx.taskId),
+  ],
+
+  /**
+   * Create / update / delete an invoice.
+   * Affects: payment totals/list, invoice list (and task detail if task-linked).
+   */
+  invoiceMutated: (ctx: InvoiceCtx) => [
+    queryKeys.paymentsAll(),
+    queryKeys.invoices(ctx.projectId),
+    ...(ctx.taskId ? [queryKeys.taskDetail(ctx.taskId)] : []),
+  ],
+
+  /**
+   * Record a payment or mark a payment as paid.
+   * Affects: payment list/amounts, invoice payment status.
+   */
+  paymentRecorded: (ctx: PaymentCtx) => [
+    queryKeys.paymentsAll(),
+    queryKeys.invoices(ctx.projectId),
+  ],
+
+  /**
+   * Add, update, or remove a progress log entry.
+   * Affects: progress log list for the task, task detail metadata.
+   */
+  progressLogMutated: (ctx: ProgressLogCtx) => [
+    queryKeys.progressLogs(ctx.taskId),
+    queryKeys.taskDetail(ctx.taskId),
+  ],
+
+  /**
+   * Upload or remove a document/image attached to a task (via a progress log).
+   * Affects: document list, progress log list (thumbnail/count), task detail.
+   */
+  documentMutated: (ctx: DocumentCtx) => [
+    queryKeys.documents(ctx.taskId),
+    queryKeys.progressLogs(ctx.taskId),
+    queryKeys.taskDetail(ctx.taskId),
+  ],
+
+  /**
+   * Edit task fields (status, trade type, subcontractor, etc.).
+   * Pass affectsPayments=true when a payment-linked field changes
+   * (e.g. subcontractor reassignment on a task with an active invoice).
+   */
+  taskEdited: (ctx: TaskEditCtx) => [
+    queryKeys.tasks(ctx.projectId),
+    queryKeys.taskDetail(ctx.taskId),
+    ...(ctx.affectsPayments ? [queryKeys.paymentsAll()] : []),
+  ],
+
+  /**
+   * Add or update a contact/subcontractor.
+   * Affects: contact picker, invoice issuer display (broad invalidation).
+   */
+  contactMutated: (_ctx: ContactCtx) => [
+    queryKeys.contacts(),
+    queryKeys.invoices(), // issuer name may appear on any project's invoice
+  ],
+};

--- a/src/hooks/useAcceptQuote.ts
+++ b/src/hooks/useAcceptQuote.ts
@@ -7,6 +7,7 @@ import { InvoiceRepository } from '../domain/repositories/InvoiceRepository';
 import { ContactRepository } from '../domain/repositories/ContactRepository';
 import { QuotationRepository } from '../domain/repositories/QuotationRepository';
 import { AcceptQuotationUseCase } from '../application/usecases/quotation/AcceptQuotationUseCase';
+import { invalidations } from './queryKeys';
 
 export interface UseAcceptQuoteReturn {
   acceptQuote: (taskId: string) => Promise<{ invoiceId: string }>;
@@ -79,10 +80,10 @@ export function useAcceptQuote(): UseAcceptQuoteReturn {
           contact,
         });
         if (queryClient) {
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ['payments'] }),
-            queryClient.invalidateQueries({ queryKey: ['invoices'] }),
-          ]);
+          await Promise.all(
+            invalidations.acceptQuotation({ projectId: task.projectId ?? '', taskId })
+              .map(key => queryClient!.invalidateQueries({ queryKey: key }))
+          );
         }
         return { invoiceId: invoice.id };
       } catch (e: any) {
@@ -108,7 +109,12 @@ export function useAcceptQuote(): UseAcceptQuoteReturn {
           quoteStatus: 'rejected',
           updatedAt: new Date().toISOString(),
         });
-        if (queryClient) await queryClient.invalidateQueries({ queryKey: ['payments'] });
+        if (queryClient) {
+          await Promise.all(
+            invalidations.rejectQuotation({ projectId: task.projectId ?? '', taskId })
+              .map(key => queryClient!.invalidateQueries({ queryKey: key }))
+          );
+        }
       } catch (e: any) {
         const msg = e?.message ?? 'Failed to reject quote';
         setError(msg);

--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -1,45 +1,39 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { container } from 'tsyringe';
 import '../infrastructure/di/registerServices';
 import { ContactRepository } from '../domain/repositories/ContactRepository';
 import { Contact } from '../domain/entities/Contact';
+import { queryKeys } from './queryKeys';
 
 export function useContacts() {
-  const [contacts, setContacts] = useState<Contact[]>([]);
-  const [loading, setLoading] = useState(false);
-
   const contactRepository = useMemo(() => {
     try { return container.resolve<ContactRepository>('ContactRepository'); }
     catch { return null; }
   }, []);
 
-  const loadContacts = useCallback(async () => {
-    if (!contactRepository) return;
-    setLoading(true);
-    try {
-      const items = await contactRepository.findAll();
-      setContacts(items);
-    } catch (e) {
-      console.error('[useContacts] Failed to load contacts:', e);
-    } finally {
-      setLoading(false);
-    }
-  }, [contactRepository]);
-
-  useEffect(() => {
-    loadContacts();
-  }, [loadContacts]);
+  const {
+    data: contacts = [],
+    isLoading: loading,
+    refetch,
+  } = useQuery<Contact[]>({
+    queryKey: queryKeys.contacts(),
+    queryFn: async () => {
+      if (!contactRepository) return [];
+      return contactRepository.findAll();
+    },
+    staleTime: 5 * 60_000, // contacts change rarely on mobile
+  });
 
   const search = useCallback(async (query: string) => {
-    if (!contactRepository) return contacts;
     if (!query) return contacts;
     const q = query.toLowerCase();
     return contacts.filter(
       (c) => c.name.toLowerCase().includes(q) || (c.trade ?? '').toLowerCase().includes(q),
     );
-  }, [contactRepository, contacts]);
+  }, [contacts]);
 
-  return { contacts, loading, search, refresh: loadContacts };
+  return { contacts, loading, search, refresh: async () => { await refetch(); } };
 }
 
 export default useContacts;

--- a/src/hooks/useInvoices.ts
+++ b/src/hooks/useInvoices.ts
@@ -2,7 +2,8 @@
  * Custom hook for managing invoice data and operations
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Invoice, InvoiceEntity } from '../domain/entities/Invoice';
 import { InvoiceRepository } from '../domain/repositories/InvoiceRepository';
 import { container } from 'tsyringe';
@@ -12,6 +13,7 @@ import { UpdateInvoiceUseCase } from '../application/usecases/invoice/UpdateInvo
 import { DeleteInvoiceUseCase } from '../application/usecases/invoice/DeleteInvoiceUseCase';
 import { GetInvoiceByIdUseCase } from '../application/usecases/invoice/GetInvoiceByIdUseCase';
 import { ListInvoicesUseCase } from '../application/usecases/invoice/ListInvoicesUseCase';
+import { queryKeys, invalidations } from './queryKeys';
 
 export interface UseInvoicesOptions {
   status?: Invoice['status'];
@@ -32,9 +34,7 @@ export interface UseInvoicesReturn {
 }
 
 export const useInvoices = (options?: UseInvoicesOptions): UseInvoicesReturn => {
-  const [invoices, setInvoices] = useState<Invoice[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   // Resolve repository via DI container and construct use cases
   const repository = useMemo(
@@ -63,24 +63,26 @@ export const useInvoices = (options?: UseInvoicesOptions): UseInvoicesReturn => 
     [repository]
   );
 
-  const loadInvoices = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
+  const queryKey = queryKeys.invoices(options?.projectId);
 
-      // Call list use case with optional filters
+  const {
+    data: invoices = [],
+    isLoading: loading,
+    error: queryError,
+    refetch,
+  } = useQuery<Invoice[]>({
+    queryKey,
+    queryFn: async () => {
       const result = await listInvoicesUseCase.execute({
         status: options?.status ? [options.status] : undefined,
         projectId: options?.projectId,
       });
+      return result.items;
+    },
+    staleTime: 60_000,
+  });
 
-      setInvoices(result.items);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load invoices');
-    } finally {
-      setLoading(false);
-    }
-  }, [listInvoicesUseCase, options?.status, options?.projectId]);
+  const error = queryError instanceof Error ? queryError.message : null;
 
   const createInvoice = useCallback(
     async (invoice: Omit<Invoice, 'id' | 'createdAt' | 'updatedAt'>) => {
@@ -88,42 +90,51 @@ export const useInvoices = (options?: UseInvoicesOptions): UseInvoicesReturn => 
         // Ensure domain entity generates required defaults (id, timestamps, status, currency)
         const entity = InvoiceEntity.create(invoice as any);
         await createInvoiceUseCase.execute(entity.data());
-        await loadInvoices(); // Refresh list
+        await Promise.all(
+          invalidations.invoiceMutated({ projectId: options?.projectId })
+            .map(key => queryClient.invalidateQueries({ queryKey: key }))
+        );
         return { success: true };
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : 'Failed to create invoice';
         return { success: false, error: errorMsg };
       }
     },
-    [createInvoiceUseCase, loadInvoices]
+    [createInvoiceUseCase, queryClient, options?.projectId]
   );
 
   const updateInvoice = useCallback(
     async (invoice: Invoice) => {
       try {
         await updateInvoiceUseCase.execute(invoice.id, invoice);
-        await loadInvoices(); // Refresh list
+        await Promise.all(
+          invalidations.invoiceMutated({ projectId: options?.projectId })
+            .map(key => queryClient.invalidateQueries({ queryKey: key }))
+        );
         return { success: true };
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : 'Failed to update invoice';
         return { success: false, error: errorMsg };
       }
     },
-    [updateInvoiceUseCase, loadInvoices]
+    [updateInvoiceUseCase, queryClient, options?.projectId]
   );
 
   const deleteInvoice = useCallback(
     async (id: string) => {
       try {
         await deleteInvoiceUseCase.execute(id);
-        await loadInvoices(); // Refresh list
+        await Promise.all(
+          invalidations.invoiceMutated({ projectId: options?.projectId })
+            .map(key => queryClient.invalidateQueries({ queryKey: key }))
+        );
         return { success: true };
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : 'Failed to delete invoice';
         return { success: false, error: errorMsg };
       }
     },
-    [deleteInvoiceUseCase, loadInvoices]
+    [deleteInvoiceUseCase, queryClient, options?.projectId]
   );
 
   const getInvoiceById = useCallback(
@@ -139,13 +150,8 @@ export const useInvoices = (options?: UseInvoicesOptions): UseInvoicesReturn => 
   );
 
   const refreshInvoices = useCallback(async () => {
-    await loadInvoices();
-  }, [loadInvoices]);
-
-  // Load invoices on mount
-  useEffect(() => {
-    loadInvoices();
-  }, [loadInvoices]);
+    await refetch();
+  }, [refetch]);
 
   return {
     invoices,

--- a/src/hooks/useQuotations.ts
+++ b/src/hooks/useQuotations.ts
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Quotation } from '../domain/entities/Quotation';
 import { QuotationRepository, QuotationFilterParams } from '../domain/repositories/QuotationRepository';
 import { CreateQuotationUseCase } from '../application/usecases/quotation/CreateQuotationUseCase';
@@ -7,10 +8,17 @@ import { GetQuotationByIdUseCase } from '../application/usecases/quotation/GetQu
 import { UpdateQuotationUseCase } from '../application/usecases/quotation/UpdateQuotationUseCase';
 import { DeleteQuotationUseCase } from '../application/usecases/quotation/DeleteQuotationUseCase';
 import { DrizzleQuotationRepository } from '../infrastructure/repositories/DrizzleQuotationRepository';
+import { queryKeys } from './queryKeys';
 
-export const useQuotations = () => {
+export interface UseQuotationsOptions {
+  /** When provided, subscribes reactively to quotations for this task */
+  taskId?: string;
+}
+
+export const useQuotations = (options?: UseQuotationsOptions) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   const repository = useMemo<QuotationRepository>(() => new DrizzleQuotationRepository(), []);
 
@@ -20,11 +28,27 @@ export const useQuotations = () => {
   const updateQuotationUC = useMemo(() => new UpdateQuotationUseCase(repository), [repository]);
   const deleteQuotationUC = useMemo(() => new DeleteQuotationUseCase(repository), [repository]);
 
+  /**
+   * Reactive quotation list for a specific task. Only active when taskId is
+   * provided — otherwise undefined. Invalidated by acceptQuotation / rejectQuotation.
+   */
+  const { data: taskQuotations } = useQuery<Quotation[]>({
+    queryKey: queryKeys.quotations(options?.taskId),
+    queryFn: async () => {
+      const taskId = options?.taskId;
+      if (!taskId) return [];
+      return repository.findByTask(taskId);
+    },
+    enabled: Boolean(options?.taskId),
+    staleTime: 60_000,
+  });
+
   const createQuotation = async (quotation: Omit<Quotation, 'id' | 'createdAt' | 'updatedAt'>): Promise<Quotation> => {
     setLoading(true);
     setError(null);
     try {
       const created = await createQuotationUC.execute(quotation as Quotation);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.quotations() });
       return created;
     } catch (e: any) {
       const msg = e?.message || 'Failed to create quotation';
@@ -70,6 +94,7 @@ export const useQuotations = () => {
     setError(null);
     try {
       const updated = await updateQuotationUC.execute(id, updates);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.quotations() });
       return updated;
     } catch (e: any) {
       const msg = e?.message || 'Failed to update quotation';
@@ -85,6 +110,7 @@ export const useQuotations = () => {
     setError(null);
     try {
       await deleteQuotationUC.execute(id);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.quotations() });
     } catch (e: any) {
       const msg = e?.message || 'Failed to delete quotation';
       setError(msg);
@@ -100,6 +126,8 @@ export const useQuotations = () => {
     getQuotation,
     updateQuotation,
     deleteQuotation,
+    /** Reactive quotations list — only populated when taskId option is provided */
+    taskQuotations,
     loading,
     error,
   };

--- a/src/hooks/useTaskForm.ts
+++ b/src/hooks/useTaskForm.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { container } from 'tsyringe';
 import '../infrastructure/di/registerServices';
 
@@ -12,6 +13,7 @@ import { ContactRepository } from '../domain/repositories/ContactRepository';
 import { QuotationRepository } from '../domain/repositories/QuotationRepository';
 import { IFileSystemAdapter } from '../infrastructure/files/IFileSystemAdapter';
 import { AcceptQuotationUseCase } from '../application/usecases/quotation/AcceptQuotationUseCase';
+import { invalidations, queryKeys } from './queryKeys';
 
 import { CreateTaskUseCase } from '../application/usecases/task/CreateTaskUseCase';
 
@@ -113,6 +115,7 @@ export function useTaskForm({
   onSuccess,
 }: UseTaskFormOptions = {}): UseTaskFormReturn {
   const isEditMode = Boolean(initialTask?.id);
+  const queryClient = useQueryClient();
 
   // ── Basic fields ──────────────────────────────────────────────────────────
   const [title, setTitle] = useState(initialTask?.title ?? '');
@@ -331,6 +334,12 @@ export function useTaskForm({
             size: pd.size,
           });
         }
+        if (pendingDocuments.length > 0) {
+          await Promise.all(
+            invalidations.documentMutated({ taskId: selfId })
+              .map(key => queryClient.invalidateQueries({ queryKey: key }))
+          );
+        }
         setPendingDocuments([]);
 
         // Sync dependency additions (removals were applied eagerly)
@@ -363,6 +372,10 @@ export function useTaskForm({
             },
             contact,
           });
+          await Promise.all(
+            invalidations.acceptQuotation({ projectId: projectId || '', taskId: selfId })
+              .map(key => queryClient.invalidateQueries({ queryKey: key }))
+          );
           const taskWithInvoice: Task = { ...updatedTask, quoteInvoiceId: result.invoice.id, quoteStatus: 'accepted' };
           onSuccess?.(taskWithInvoice);
           return;
@@ -374,8 +387,16 @@ export function useTaskForm({
             status: 'cancelled',
             updatedAt: new Date().toISOString(),
           });
+          await Promise.all(
+            invalidations.invoiceMutated({ projectId: projectId || undefined })
+              .map(key => queryClient.invalidateQueries({ queryKey: key }))
+          );
         }
 
+        await Promise.all(
+          invalidations.taskEdited({ projectId: projectId || '', taskId: selfId })
+            .map(key => queryClient.invalidateQueries({ queryKey: key }))
+        );
         onSuccess?.(updatedTask);
       } else {
         // ── Create mode ───────────────────────────────────────────────────
@@ -406,6 +427,12 @@ export function useTaskForm({
             size: pd.size,
           });
         }
+        if (pendingDocuments.length > 0) {
+          await Promise.all(
+            invalidations.documentMutated({ taskId: newTask.id })
+              .map(key => queryClient.invalidateQueries({ queryKey: key }))
+          );
+        }
         setPendingDocuments([]);
 
         // Attach dependencies
@@ -430,11 +457,16 @@ export function useTaskForm({
             },
             contact,
           });
+          await Promise.all(
+            invalidations.acceptQuotation({ projectId: newTask.projectId || '', taskId: newTask.id })
+              .map(key => queryClient.invalidateQueries({ queryKey: key }))
+          );
           const taskWithInvoice: Task = { ...newTask, quoteInvoiceId: result.invoice.id, quoteStatus: 'accepted' };
           onSuccess?.(taskWithInvoice);
           return;
         }
 
+        await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(newTask.projectId) });
         onSuccess?.(newTask);
       }
     } finally {
@@ -465,6 +497,7 @@ export function useTaskForm({
     acceptQuotationUseCase,
     contactRepository,
     onSuccess,
+    queryClient,
   ]);
 
   return {

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Task } from '../domain/entities/Task';
 import { DelayReason } from '../domain/entities/DelayReason';
 import { TaskRepository } from '../domain/repositories/TaskRepository';
@@ -22,6 +22,8 @@ import { ProgressLog } from '../domain/entities/ProgressLog';
 import { RemoveDelayReasonUseCase } from '../application/usecases/task/RemoveDelayReasonUseCase';
 import { ResolveDelayReasonUseCase } from '../application/usecases/task/ResolveDelayReasonUseCase';
 
+import { queryKeys, invalidations } from './queryKeys';
+
 export type { TaskDetail } from '../application/usecases/task/GetTaskDetailUseCase';
 export type { AddDelayReasonInput } from '../application/usecases/task/AddDelayReasonUseCase';
 export type { UpdateProgressLogInput } from '../application/usecases/task/UpdateProgressLogUseCase';
@@ -39,17 +41,14 @@ export interface UseTasksReturn {
   addDependency: (taskId: string, dependsOnTaskId: string) => Promise<void>;
   removeDependency: (taskId: string, dependsOnTaskId: string) => Promise<void>;
   addDelayReason: (taskId: string, input: Omit<AddDelayReasonInput, 'taskId'>) => Promise<DelayReason>;
-  removeDelayReason: (delayReasonId: string) => Promise<void>;
+  removeDelayReason: (taskId: string, delayReasonId: string) => Promise<void>;
   addProgressLog: (taskId: string, input: Omit<AddProgressLogInput, 'taskId'>) => Promise<ProgressLog>;
-  updateProgressLog: (logId: string, patch: Omit<UpdateProgressLogInput, 'logId'>) => Promise<ProgressLog>;
-  deleteProgressLog: (logId: string) => Promise<void>;
-  resolveDelayReason: (delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => Promise<void>;
+  updateProgressLog: (taskId: string, logId: string, patch: Omit<UpdateProgressLogInput, 'logId'>) => Promise<ProgressLog>;
+  deleteProgressLog: (taskId: string, logId: string) => Promise<void>;
+  resolveDelayReason: (taskId: string, delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => Promise<void>;
 }
 
 export function useTasks(projectId?: string): UseTasksReturn {
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [loading, setLoading] = useState(true);
-
   const queryClient = useQueryClient();
 
   const taskRepository = useMemo(() => container.resolve<TaskRepository>('TaskRepository'), []);
@@ -70,48 +69,35 @@ export function useTasks(projectId?: string): UseTasksReturn {
   const removeDelayReasonUseCase = useMemo(() => new RemoveDelayReasonUseCase(taskRepository), [taskRepository]);
   const resolveDelayReasonUseCase = useMemo(() => new ResolveDelayReasonUseCase(taskRepository), [taskRepository]);
 
-  const loadTasks = useCallback(async () => {
-    setLoading(true);
-    try {
-      let result: Task[];
-      if (projectId) {
-        result = await listUseCase.execute(projectId);
-      } else {
-        // If no project ID, assume we want all tasks or maybe ad-hoc? 
-        // For now list all tasks if no project ID is provided, 
-        // or specifically use listUseCase.execute() which calls findAll() or findByProjectId
-        // The implementation calls findAll() if no projectId provided.
-        // Wait, listUseCase implementation: if(projectId) findByProjectId else findAll.
-        // But maybe we want ad-hoc tasks specifically?
-        // Let's stick to findAll for now to listed everything in main view.
-        result = await listUseCase.execute();
-      }
-      setTasks(result);
-    } catch (error) {
-      console.error('Failed to load tasks', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [listUseCase, projectId]);
+  const tasksQueryKey = queryKeys.tasks(projectId);
 
-  useEffect(() => {
-    loadTasks();
-  }, [loadTasks]);
+  const { data: tasks = [], isLoading: loading, refetch } = useQuery<Task[]>({
+    queryKey: tasksQueryKey,
+    queryFn: () => projectId ? listUseCase.execute(projectId) : listUseCase.execute(),
+    staleTime: 30_000,
+  });
+
+  const loadTasks = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   const updateTask = useCallback(async (task: Task) => {
     await updateUseCase.execute(task);
-    await loadTasks();
-  }, [updateUseCase, loadTasks]);
+    await Promise.all(
+      invalidations.taskEdited({ projectId: task.projectId ?? '', taskId: task.id })
+        .map(key => queryClient.invalidateQueries({ queryKey: key }))
+    );
+  }, [updateUseCase, queryClient]);
 
   const deleteTask = useCallback(async (id: string) => {
     await deleteUseCase.execute(id);
-    await loadTasks();
-  }, [deleteUseCase, loadTasks]);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+  }, [deleteUseCase, queryClient, projectId]);
 
   const createTask = useCallback(async (data: Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'localId'>) => {
     await createUseCase.execute(data);
-    await loadTasks();
-  }, [createUseCase, loadTasks]);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+  }, [createUseCase, queryClient, projectId]);
 
   const getTask = useCallback(async (id: string) => {
     return getUseCase.execute(id);
@@ -123,37 +109,57 @@ export function useTasks(projectId?: string): UseTasksReturn {
 
   const addDependency = useCallback(async (taskId: string, dependsOnTaskId: string) => {
     await addDependencyUseCase.execute({ taskId, dependsOnTaskId });
-  }, [addDependencyUseCase]);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+  }, [addDependencyUseCase, queryClient, projectId]);
 
   const removeDependency = useCallback(async (taskId: string, dependsOnTaskId: string) => {
     await removeDependencyUseCase.execute({ taskId, dependsOnTaskId });
-  }, [removeDependencyUseCase]);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+  }, [removeDependencyUseCase, queryClient, projectId]);
 
   const addDelayReason = useCallback(async (taskId: string, input: Omit<AddDelayReasonInput, 'taskId'>): Promise<DelayReason> => {
-    return addDelayReasonUseCase.execute({ taskId, ...input });
-  }, [addDelayReasonUseCase]);
+    const result = await addDelayReasonUseCase.execute({ taskId, ...input });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+    return result;
+  }, [addDelayReasonUseCase, queryClient, projectId]);
 
   const addProgressLog = useCallback(async (taskId: string, input: Omit<AddProgressLogInput, 'taskId'>) => {
     const res = await addProgressLogUseCase.execute({ taskId, ...input });
-    await loadTasks();
+    await Promise.all(
+      invalidations.progressLogMutated({ taskId })
+        .map(key => queryClient.invalidateQueries({ queryKey: key }))
+    );
     return res;
-  }, [addProgressLogUseCase, loadTasks]);
+  }, [addProgressLogUseCase, queryClient]);
 
-  const updateProgressLog = useCallback(async (logId: string, patch: Omit<UpdateProgressLogInput, 'logId'>) => {
-    return updateProgressLogUseCase.execute({ logId, ...patch });
-  }, [updateProgressLogUseCase]);
+  const updateProgressLog = useCallback(async (taskId: string, logId: string, patch: Omit<UpdateProgressLogInput, 'logId'>) => {
+    const result = await updateProgressLogUseCase.execute({ logId, ...patch });
+    await Promise.all(
+      invalidations.progressLogMutated({ taskId })
+        .map(key => queryClient.invalidateQueries({ queryKey: key }))
+    );
+    return result;
+  }, [updateProgressLogUseCase, queryClient]);
 
-  const deleteProgressLog = useCallback(async (logId: string) => {
-    return deleteProgressLogUseCase.execute({ logId });
-  }, [deleteProgressLogUseCase]);
+  const deleteProgressLog = useCallback(async (taskId: string, logId: string) => {
+    await deleteProgressLogUseCase.execute({ logId });
+    await Promise.all(
+      invalidations.progressLogMutated({ taskId })
+        .map(key => queryClient.invalidateQueries({ queryKey: key }))
+    );
+  }, [deleteProgressLogUseCase, queryClient]);
 
-  const removeDelayReason = useCallback(async (delayReasonId: string) => {
+  const removeDelayReason = useCallback(async (taskId: string, delayReasonId: string) => {
     await removeDelayReasonUseCase.execute({ delayReasonId });
-  }, [removeDelayReasonUseCase]);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.taskDetail(taskId) });
+  }, [removeDelayReasonUseCase, queryClient, projectId]);
 
-  const resolveDelayReason = useCallback(async (delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => {
+  const resolveDelayReason = useCallback(async (taskId: string, delayReasonId: string, resolvedAt?: string, mitigationNotes?: string) => {
     await resolveDelayReasonUseCase.execute({ delayReasonId, resolvedAt, mitigationNotes });
-  }, [resolveDelayReasonUseCase]);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.tasks(projectId) });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.taskDetail(taskId) });
+  }, [resolveDelayReasonUseCase, queryClient, projectId]);
 
   return useMemo(() => ({
     tasks,

--- a/src/pages/tasks/TaskDetailsPage.tsx
+++ b/src/pages/tasks/TaskDetailsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Alert, ActivityIndicator, Pressable, Image } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTasks, TaskDetail } from '../../hooks/useTasks';
 import { useDelayReasonTypes } from '../../hooks/useDelayReasonTypes';
 import { useConfirm } from '../../hooks/useConfirm';
@@ -33,6 +34,7 @@ import { ProgressLog } from '../../domain/entities/ProgressLog';
 import { TaskPickerModal } from './TaskPickerModal';
 import { Edit, Trash2, Calendar, Clock, ArrowLeft, FileText, CheckCircle } from 'lucide-react-native';
 import { cssInterop } from 'nativewind';
+import { invalidations } from '../../hooks/queryKeys';
 
 cssInterop(Edit, { className: { target: 'style', nativeStyleToProp: { color: true } } });
 cssInterop(Trash2, { className: { target: 'style', nativeStyleToProp: { color: true } } });
@@ -46,6 +48,7 @@ export default function TaskDetailsPage() {
   const route = useRoute<any>();
   const navigation = useNavigation<any>();
   const { taskId } = route.params;
+  const queryClient = useQueryClient();
   const {
     getTask,
     deleteTask,
@@ -275,7 +278,7 @@ export default function TaskDetailsPage() {
     });
     if (!confirmed) return;
     try {
-      await removeDelayReason(delayReasonId);
+      await removeDelayReason(taskId, delayReasonId);
       await loadData();
     } catch (e: any) {
       Alert.alert('Error', e?.message || 'Failed to remove delay reason');
@@ -284,7 +287,7 @@ export default function TaskDetailsPage() {
 
   const handleResolveDelayReason = async (delayReasonId: string) => {
     try {
-      await resolveDelayReason(delayReasonId);
+      await resolveDelayReason(taskId, delayReasonId);
       await loadData();
     } catch (e: any) {
       Alert.alert('Error', e?.message || 'Failed to resolve delay reason');
@@ -329,7 +332,7 @@ export default function TaskDetailsPage() {
   const handleUpdateProgressLog = async (data: AddProgressLogFormData) => {
     if (!editingLog) return;
     try {
-      await updateProgressLog(editingLog.id, data);
+      await updateProgressLog(taskId, editingLog.id, data);
       setEditingLog(null);
       await loadData();
     } catch (e: any) {
@@ -339,7 +342,7 @@ export default function TaskDetailsPage() {
 
   const handleDeleteProgressLog = async (logId: string) => {
     try {
-      await deleteProgressLog(logId);
+      await deleteProgressLog(taskId, logId);
       await loadData();
     } catch (e: any) {
       Alert.alert('Error', e?.message || 'Failed to delete progress log');
@@ -361,6 +364,10 @@ export default function TaskDetailsPage() {
         mimeType: result.type,
         size: result.size,
       });
+      await Promise.all(
+        invalidations.documentMutated({ taskId })
+          .map(key => queryClient.invalidateQueries({ queryKey: key }))
+      );
       await loadData();
     } catch (e: any) {
       Alert.alert('Error', e?.message || 'Failed to add document');


### PR DESCRIPTION
Implements design from issue #152: centralizes query key factories and a typed invalidation map in src/hooks/queryKeys.ts; migrates several hooks (useInvoices, useTasks, useQuotations, useContacts, useTaskForm, useAcceptQuote) to use TanStack Query; adds __tests__/unit/queryInvalidations.test.ts and __tests__/utils/queryClientWrapper.tsx to validate invalidations; updates related tests and TaskDetailsPage. All unit tests and TypeScript typecheck pass locally.\n\nPlease review: key API/semantic changes include updated useTasks method signatures for progress log/delay reason functions and the new queryKeys/invalidations usage throughout hooks.