### PR TITLE
feat: LLM Quotation Parser with Strategy Pattern

### DIFF
--- a/__tests__/unit/LlmQuotationParser.test.ts
+++ b/__tests__/unit/LlmQuotationParser.test.ts
@@ -1,0 +1,200 @@
+import { LlmQuotationParser } from '../../src/infrastructure/ai/LlmQuotationParser';
+import { OcrResult } from '../../src/application/services/IOcrAdapter';
+
+const mockOcrResult: OcrResult = {
+  fullText: 'Quote from Builder Co\nRef: QUO-001\nTotal: $5,500.00',
+  tokens: [],
+  imageUri: 'file:///tmp/quote.jpg',
+};
+
+function mockFetchSuccess(content: string): jest.SpyInstance {
+  return jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content } }],
+    }),
+  } as Response);
+}
+
+function mockFetchHttpError(status: number): jest.SpyInstance {
+  return jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok: false,
+    status,
+  } as Response);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('LlmQuotationParser', () => {
+  it('strategyType is "llm"', () => {
+    const parser = new LlmQuotationParser('test-key');
+    expect(parser.strategyType).toBe('llm');
+  });
+
+  it('parses a well-formed LLM JSON response', async () => {
+    const responseJson = JSON.stringify({
+      reference: 'QUO-001',
+      vendor: 'Builder Co',
+      vendorEmail: 'info@builder.co',
+      vendorPhone: '0400 123 456',
+      vendorAddress: '1 Main St, Sydney NSW 2000',
+      taxId: '12 345 678 901',
+      date: '2026-03-01',
+      expiryDate: '2026-04-01',
+      currency: 'AUD',
+      subtotal: 5000,
+      tax: 500,
+      total: 5500,
+      lineItems: [
+        {
+          description: 'Concrete Slab',
+          quantity: 2,
+          unit: 'm2',
+          unitPrice: 2500,
+          total: 5000,
+          tax: 500,
+        },
+      ],
+      paymentTerms: 'Net 30',
+      scope: 'Supply and install concrete slab',
+      exclusions: 'Excavation not included',
+      notes: 'Valid for 30 days',
+    });
+
+    mockFetchSuccess(responseJson);
+    const parser = new LlmQuotationParser('test-key');
+    const result = await parser.parse(mockOcrResult);
+
+    expect(result.reference).toBe('QUO-001');
+    expect(result.vendor).toBe('Builder Co');
+    expect(result.vendorEmail).toBe('info@builder.co');
+    expect(result.vendorPhone).toBe('0400 123 456');
+    expect(result.vendorAddress).toBe('1 Main St, Sydney NSW 2000');
+    expect(result.taxId).toBe('12 345 678 901');
+    expect(result.date).toEqual(new Date('2026-03-01'));
+    expect(result.expiryDate).toEqual(new Date('2026-04-01'));
+    expect(result.currency).toBe('AUD');
+    expect(result.subtotal).toBe(5000);
+    expect(result.tax).toBe(500);
+    expect(result.total).toBe(5500);
+    expect(result.paymentTerms).toBe('Net 30');
+    expect(result.scope).toBe('Supply and install concrete slab');
+    expect(result.exclusions).toBe('Excavation not included');
+    expect(result.notes).toBe('Valid for 30 days');
+    expect(result.lineItems).toHaveLength(1);
+    expect(result.lineItems[0]).toMatchObject({
+      description: 'Concrete Slab',
+      quantity: 2,
+      unit: 'm2',
+      unitPrice: 2500,
+      total: 5000,
+      tax: 500,
+    });
+  });
+
+  it('sets confidence scores for non-null fields', async () => {
+    const responseJson = JSON.stringify({
+      vendor: 'Builder Co',
+      reference: 'QUO-001',
+      date: '2026-03-01',
+      total: 5500,
+      currency: 'AUD',
+      lineItems: [],
+    });
+
+    mockFetchSuccess(responseJson);
+    const parser = new LlmQuotationParser('test-key');
+    const result = await parser.parse(mockOcrResult);
+
+    expect(result.confidence.vendor).toBe(0.9);
+    expect(result.confidence.reference).toBe(0.9);
+    expect(result.confidence.date).toBe(0.9);
+    expect(result.confidence.total).toBe(0.9);
+    expect(result.confidence.overall).toBeGreaterThan(0);
+  });
+
+  it('sets confidence to 0 for null fields', async () => {
+    const responseJson = JSON.stringify({
+      vendor: null,
+      reference: null,
+      date: null,
+      total: null,
+      currency: 'AUD',
+      lineItems: [],
+    });
+
+    mockFetchSuccess(responseJson);
+    const parser = new LlmQuotationParser('test-key');
+    const result = await parser.parse(mockOcrResult);
+
+    expect(result.confidence.vendor).toBe(0);
+    expect(result.confidence.reference).toBe(0);
+    expect(result.confidence.date).toBe(0);
+    expect(result.confidence.total).toBe(0);
+    expect(result.confidence.overall).toBe(0);
+  });
+
+  it('returns empty NormalizedQuotation on JSON parse failure', async () => {
+    mockFetchSuccess('this is not valid JSON {{{');
+    const parser = new LlmQuotationParser('test-key');
+    const result = await parser.parse(mockOcrResult);
+
+    expect(result.vendor).toBeNull();
+    expect(result.reference).toBeNull();
+    expect(result.total).toBeNull();
+    expect(result.currency).toBe('AUD');
+    expect(result.lineItems).toHaveLength(0);
+    expect(result.confidence.overall).toBe(0);
+    expect(result.suggestedCorrections).toHaveLength(0);
+  });
+
+  it('returns empty object content ({}) → valid empty result', async () => {
+    mockFetchSuccess('{}');
+    const parser = new LlmQuotationParser('test-key');
+    const result = await parser.parse(mockOcrResult);
+
+    expect(result.vendor).toBeNull();
+    expect(result.currency).toBe('AUD');
+    expect(result.lineItems).toHaveLength(0);
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetchHttpError(429);
+    const parser = new LlmQuotationParser('test-key');
+    await expect(parser.parse(mockOcrResult)).rejects.toThrow('Groq LLM failed: HTTP 429');
+  });
+
+  it('throws timeout error when fetch is aborted', async () => {
+    jest.spyOn(globalThis, 'fetch').mockImplementationOnce((_url: RequestInfo, _options?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        // Simulate abort after a tick
+        setTimeout(() => {
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          reject(err);
+        }, 10);
+      });
+    });
+
+    const parser = new LlmQuotationParser('test-key', 50);
+    await expect(parser.parse(mockOcrResult)).rejects.toThrow(/timed out/i);
+  });
+
+  it('sends OCR text as user message to Groq API', async () => {
+    const spy = mockFetchSuccess(JSON.stringify({ currency: 'AUD', lineItems: [] }));
+    const parser = new LlmQuotationParser('sk-test-key');
+    await parser.parse(mockOcrResult);
+
+    const [url, options] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.groq.com/openai/v1/chat/completions');
+
+    const body = JSON.parse(options.body as string);
+    expect(body.messages[1].role).toBe('user');
+    expect(body.messages[1].content).toBe(mockOcrResult.fullText);
+    expect(options.headers).toMatchObject({
+      Authorization: 'Bearer sk-test-key',
+    });
+  });
+});

--- a/__tests__/unit/ProcessQuotationUploadUseCase.test.ts
+++ b/__tests__/unit/ProcessQuotationUploadUseCase.test.ts
@@ -1,0 +1,202 @@
+import {
+  ProcessQuotationUploadUseCase,
+  ProcessQuotationUploadInput,
+} from '../../src/application/usecases/quotation/ProcessQuotationUploadUseCase';
+import { IOcrAdapter, OcrResult } from '../../src/application/services/IOcrAdapter';
+import {
+  IQuotationParsingStrategy,
+  NormalizedQuotation,
+} from '../../src/application/ai/IQuotationParsingStrategy';
+import { IPdfConverter } from '../../src/infrastructure/files/IPdfConverter';
+
+function makeOcrResult(text = 'OCR text'): OcrResult {
+  return { fullText: text, tokens: [], imageUri: 'file:///tmp/img.jpg' };
+}
+
+function makeNormalizedQuotation(
+  overrides: Partial<NormalizedQuotation> = {},
+): NormalizedQuotation {
+  return {
+    reference: 'QUO-001',
+    vendor: 'Builder Co',
+    vendorEmail: null,
+    vendorPhone: null,
+    vendorAddress: null,
+    taxId: null,
+    date: new Date('2026-03-01'),
+    expiryDate: null,
+    currency: 'AUD',
+    subtotal: null,
+    tax: null,
+    total: 5500,
+    lineItems: [],
+    paymentTerms: null,
+    scope: null,
+    exclusions: null,
+    notes: null,
+    confidence: { overall: 0.9, vendor: 0.9, reference: 0.9, date: 0.9, total: 0.9 },
+    suggestedCorrections: [],
+    ...overrides,
+  };
+}
+
+function makeOcrAdapter(ocrResult?: OcrResult): IOcrAdapter {
+  return {
+    extractText: jest.fn().mockResolvedValue(ocrResult ?? makeOcrResult()),
+  };
+}
+
+function makeParsingStrategy(normalized?: NormalizedQuotation): IQuotationParsingStrategy {
+  return {
+    strategyType: 'llm',
+    parse: jest.fn().mockResolvedValue(normalized ?? makeNormalizedQuotation()),
+  };
+}
+
+const imageInput: ProcessQuotationUploadInput = {
+  fileUri: 'file:///app/quote_123.jpg',
+  filename: 'quote.jpg',
+  mimeType: 'image/jpeg',
+  fileSize: 102400,
+};
+
+const pdfInput: ProcessQuotationUploadInput = {
+  fileUri: 'file:///app/quote_123.pdf',
+  filename: 'quote.pdf',
+  mimeType: 'application/pdf',
+  fileSize: 204800,
+};
+
+describe('ProcessQuotationUploadUseCase', () => {
+  describe('image path', () => {
+    it('returns normalized quotation and documentRef for image file', async () => {
+      const ocrAdapter = makeOcrAdapter();
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy);
+
+      const output = await useCase.execute(imageInput);
+
+      expect(output.normalized.vendor).toBe('Builder Co');
+      expect(output.documentRef).toMatchObject({
+        localPath: imageInput.fileUri,
+        filename: imageInput.filename,
+        size: imageInput.fileSize,
+        mimeType: imageInput.mimeType,
+      });
+    });
+
+    it('passes OcrResult to strategy.parse()', async () => {
+      const ocrResult = makeOcrResult('Custom OCR text');
+      const ocrAdapter = makeOcrAdapter(ocrResult);
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy);
+
+      await useCase.execute(imageInput);
+
+      expect(strategy.parse).toHaveBeenCalledWith(ocrResult);
+    });
+
+    it('rawOcrText is the fullText from OCR', async () => {
+      const ocrAdapter = makeOcrAdapter(makeOcrResult('Some OCR text'));
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy);
+
+      const output = await useCase.execute(imageInput);
+
+      expect(output.rawOcrText).toBe('Some OCR text');
+    });
+
+    it('throws wrapped error when OCR fails', async () => {
+      const ocrAdapter: IOcrAdapter = {
+        extractText: jest.fn().mockRejectedValue(new Error('OCR service down')),
+      };
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy);
+
+      await expect(useCase.execute(imageInput)).rejects.toThrow(
+        'Quotation processing failed: OCR service down',
+      );
+    });
+
+    it('throws wrapped error when strategy.parse() fails', async () => {
+      const ocrAdapter = makeOcrAdapter();
+      const strategy: IQuotationParsingStrategy = {
+        strategyType: 'llm',
+        parse: jest.fn().mockRejectedValue(new Error('LLM error')),
+      };
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy);
+
+      await expect(useCase.execute(imageInput)).rejects.toThrow(
+        'Quotation processing failed: LLM error',
+      );
+    });
+  });
+
+  describe('PDF path — no pdfConverter', () => {
+    it('returns empty NormalizedQuotation gracefully', async () => {
+      const ocrAdapter = makeOcrAdapter();
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy);
+
+      const output = await useCase.execute(pdfInput);
+
+      expect(output.normalized.vendor).toBeNull();
+      expect(output.normalized.currency).toBe('AUD');
+      expect(output.normalized.lineItems).toHaveLength(0);
+      expect(output.rawOcrText).toBe('');
+      expect(strategy.parse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PDF path — with pdfConverter', () => {
+    it('converts PDF to images, runs OCR, passes merged result to strategy', async () => {
+      const pdfConverter: IPdfConverter = {
+        convertToImages: jest.fn().mockResolvedValue([
+          { uri: 'file:///tmp/page1.jpg', pageIndex: 0 },
+          { uri: 'file:///tmp/page2.jpg', pageIndex: 1 },
+        ]),
+        getPageCount: jest.fn().mockResolvedValue(2),
+      };
+      const ocrAdapter = makeOcrAdapter(makeOcrResult('Page OCR'));
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy, pdfConverter);
+
+      const output = await useCase.execute(pdfInput);
+
+      expect(pdfConverter.convertToImages).toHaveBeenCalledWith(pdfInput.fileUri);
+      expect(ocrAdapter.extractText).toHaveBeenCalledTimes(2);
+      expect(strategy.parse).toHaveBeenCalledTimes(1);
+      expect(output.normalized.vendor).toBe('Builder Co');
+    });
+
+    it('returns empty NormalizedQuotation when PDF has no pages', async () => {
+      const pdfConverter: IPdfConverter = {
+        convertToImages: jest.fn().mockResolvedValue([]),
+        getPageCount: jest.fn().mockResolvedValue(0),
+      };
+      const ocrAdapter = makeOcrAdapter();
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy, pdfConverter);
+
+      const output = await useCase.execute(pdfInput);
+
+      expect(output.normalized.vendor).toBeNull();
+      expect(output.rawOcrText).toBe('');
+      expect(strategy.parse).not.toHaveBeenCalled();
+    });
+
+    it('throws wrapped error when PDF conversion fails', async () => {
+      const pdfConverter: IPdfConverter = {
+        convertToImages: jest.fn().mockRejectedValue(new Error('PDF conversion failed')),
+        getPageCount: jest.fn().mockResolvedValue(0),
+      };
+      const ocrAdapter = makeOcrAdapter();
+      const strategy = makeParsingStrategy();
+      const useCase = new ProcessQuotationUploadUseCase(ocrAdapter, strategy, pdfConverter);
+
+      await expect(useCase.execute(pdfInput)).rejects.toThrow(
+        'Quotation processing failed: PDF conversion failed',
+      );
+    });
+  });
+});

--- a/__tests__/unit/QuotationParserFactory.test.ts
+++ b/__tests__/unit/QuotationParserFactory.test.ts
@@ -1,0 +1,32 @@
+import { QuotationParserFactory } from '../../src/application/ai/QuotationParserFactory';
+import { LlmQuotationParser } from '../../src/infrastructure/ai/LlmQuotationParser';
+
+describe('QuotationParserFactory', () => {
+  it('creates an LlmQuotationParser when strategyType is "llm"', () => {
+    const strategy = QuotationParserFactory.create({
+      strategyType: 'llm',
+      groqApiKey: 'test-key',
+    });
+    expect(strategy).toBeInstanceOf(LlmQuotationParser);
+    expect(strategy.strategyType).toBe('llm');
+  });
+
+  it('throws when strategyType is "llm" but groqApiKey is missing', () => {
+    expect(() =>
+      QuotationParserFactory.create({ strategyType: 'llm' }),
+    ).toThrow('groqApiKey is required for llm strategy');
+  });
+
+  it('throws when strategyType is "llm" and groqApiKey is empty string', () => {
+    expect(() =>
+      QuotationParserFactory.create({ strategyType: 'llm', groqApiKey: '' }),
+    ).toThrow('groqApiKey is required for llm strategy');
+  });
+
+  it('throws for unsupported strategyType', () => {
+    expect(() =>
+      // @ts-expect-error testing unsupported value
+      QuotationParserFactory.create({ strategyType: 'unknown' }),
+    ).toThrow("unsupported strategyType 'unknown'");
+  });
+});

--- a/__tests__/unit/QuotationScreen.upload.test.tsx
+++ b/__tests__/unit/QuotationScreen.upload.test.tsx
@@ -11,7 +11,7 @@ import { useQuotations } from '../../src/hooks/useQuotations';
 import { IFilePickerAdapter, FilePickerResult } from '../../src/infrastructure/files/IFilePickerAdapter';
 import { IFileSystemAdapter } from '../../src/infrastructure/files/IFileSystemAdapter';
 import { IOcrAdapter } from '../../src/application/services/IOcrAdapter';
-import { IInvoiceNormalizer, NormalizedInvoice } from '../../src/application/ai/IInvoiceNormalizer';
+import { IQuotationParsingStrategy, NormalizedQuotation } from '../../src/application/ai/IQuotationParsingStrategy';
 
 jest.mock('../../src/hooks/useQuotations');
 // Mock pickers so SubcontractorPickerModal / ProjectPickerModal don't require
@@ -54,18 +54,26 @@ function makeFileSystem(): IFileSystemAdapter {
   };
 }
 
-function makeNormalizedInvoice(): NormalizedInvoice {
+function makeNormalizedQuotation(): NormalizedQuotation {
   return {
+    reference: 'Q-001',
     vendor: 'Builder Co',
-    invoiceNumber: 'Q-001',
-    invoiceDate: new Date('2026-03-01'),
-    dueDate: new Date('2026-04-01'),
+    vendorEmail: null,
+    vendorPhone: null,
+    vendorAddress: null,
+    taxId: null,
+    date: new Date('2026-03-01'),
+    expiryDate: new Date('2026-04-01'),
+    currency: 'AUD',
     subtotal: 1000,
     tax: 100,
     total: 1100,
-    currency: 'AUD',
     lineItems: [],
-    confidence: { overall: 0.9, vendor: 0.9, invoiceNumber: 0.8, invoiceDate: 0.9, total: 0.95 },
+    paymentTerms: null,
+    scope: null,
+    exclusions: null,
+    notes: null,
+    confidence: { overall: 0.9, vendor: 0.9, reference: 0.8, date: 0.9, total: 0.95 },
     suggestedCorrections: [],
   };
 }
@@ -80,20 +88,11 @@ function makeOcrAdapter(): IOcrAdapter {
   };
 }
 
-function makeInvoiceNormalizer(normalized?: NormalizedInvoice): IInvoiceNormalizer {
-  const n = normalized ?? makeNormalizedInvoice();
+function makeQuotationParser(normalized?: NormalizedQuotation): IQuotationParsingStrategy {
+  const n = normalized ?? makeNormalizedQuotation();
   return {
-    extractCandidates: jest.fn().mockReturnValue({
-      vendors: ['Builder Co'],
-      invoiceNumbers: ['Q-001'],
-      dates: [new Date('2026-03-01')],
-      dueDates: [],
-      amounts: [1100],
-      subtotals: [],
-      taxAmounts: [],
-      lineItems: [],
-    }),
-    normalize: jest.fn().mockResolvedValue(n),
+    strategyType: 'llm',
+    parse: jest.fn().mockResolvedValue(n),
   };
 }
 
@@ -226,7 +225,7 @@ describe('QuotationScreen — upload UX', () => {
       const filePicker = makeFilePicker({ type: 'image/jpeg', name: 'quote.jpg' });
     const fileSystem = makeFileSystem();
     const ocrAdapter = makeOcrAdapter();
-    const invoiceNormalizer = makeInvoiceNormalizer();
+    const parsingStrategy = makeQuotationParser();
 
     let tr: renderer.ReactTestRenderer | undefined;
     await act(async () => {
@@ -237,7 +236,7 @@ describe('QuotationScreen — upload UX', () => {
           filePickerAdapter={filePicker}
           fileSystemAdapter={fileSystem}
           ocrAdapter={ocrAdapter}
-          invoiceNormalizer={invoiceNormalizer}
+          parsingStrategy={parsingStrategy}
         />
       );
     });
@@ -258,7 +257,7 @@ describe('QuotationScreen — upload UX', () => {
     const ocrAdapter: IOcrAdapter = {
       extractText: jest.fn().mockRejectedValue(new Error('OCR service unavailable')),
     };
-    const invoiceNormalizer = makeInvoiceNormalizer();
+    const parsingStrategy = makeQuotationParser();
 
     let tr: renderer.ReactTestRenderer | undefined;
     await act(async () => {
@@ -269,7 +268,7 @@ describe('QuotationScreen — upload UX', () => {
           filePickerAdapter={filePicker}
           fileSystemAdapter={fileSystem}
           ocrAdapter={ocrAdapter}
-          invoiceNormalizer={invoiceNormalizer}
+          parsingStrategy={parsingStrategy}
         />
       );
     });

--- a/__tests__/unit/normalizedQuotationToFormValues.test.ts
+++ b/__tests__/unit/normalizedQuotationToFormValues.test.ts
@@ -1,0 +1,142 @@
+import { normalizedQuotationToFormValues } from '../../src/utils/normalizedQuotationToFormValues';
+import { NormalizedQuotation } from '../../src/application/ai/IQuotationParsingStrategy';
+
+function makeNormalizedQuotation(
+  overrides: Partial<NormalizedQuotation> = {},
+): NormalizedQuotation {
+  return {
+    reference: null,
+    vendor: null,
+    vendorEmail: null,
+    vendorPhone: null,
+    vendorAddress: null,
+    taxId: null,
+    date: null,
+    expiryDate: null,
+    currency: 'AUD',
+    subtotal: null,
+    tax: null,
+    total: null,
+    lineItems: [],
+    paymentTerms: null,
+    scope: null,
+    exclusions: null,
+    notes: null,
+    confidence: { overall: 0, vendor: 0, reference: 0, date: 0, total: 0 },
+    suggestedCorrections: [],
+    ...overrides,
+  };
+}
+
+describe('normalizedQuotationToFormValues', () => {
+  it('maps vendor to vendorName', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ vendor: 'Builder Co' }),
+    );
+    expect(result.vendorName).toBe('Builder Co');
+  });
+
+  it('maps reference', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ reference: 'QUO-001' }),
+    );
+    expect(result.reference).toBe('QUO-001');
+  });
+
+  it('maps date to ISO string', () => {
+    const date = new Date('2026-03-01T00:00:00.000Z');
+    const result = normalizedQuotationToFormValues(makeNormalizedQuotation({ date }));
+    expect(result.date).toBe(date.toISOString());
+  });
+
+  it('maps expiryDate to ISO string', () => {
+    const expiryDate = new Date('2026-04-01T00:00:00.000Z');
+    const result = normalizedQuotationToFormValues(makeNormalizedQuotation({ expiryDate }));
+    expect(result.expiryDate).toBe(expiryDate.toISOString());
+  });
+
+  it('maps total', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ total: 5500 }),
+    );
+    expect(result.total).toBe(5500);
+  });
+
+  it('maps subtotal', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ subtotal: 5000 }),
+    );
+    expect(result.subtotal).toBe(5000);
+  });
+
+  it('maps tax to taxTotal', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ tax: 500 }),
+    );
+    expect(result.taxTotal).toBe(500);
+  });
+
+  it('maps vendorEmail', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ vendorEmail: 'info@builder.co' }),
+    );
+    expect(result.vendorEmail).toBe('info@builder.co');
+  });
+
+  it('maps vendorAddress', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ vendorAddress: '1 Main St' }),
+    );
+    expect(result.vendorAddress).toBe('1 Main St');
+  });
+
+  it('maps notes', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ notes: 'Valid for 30 days' }),
+    );
+    expect(result.notes).toBe('Valid for 30 days');
+  });
+
+  it('always maps currency', () => {
+    const result = normalizedQuotationToFormValues(makeNormalizedQuotation());
+    expect(result.currency).toBe('AUD');
+  });
+
+  it('maps lineItems', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({
+        lineItems: [
+          { description: 'Tiling', quantity: 10, unitPrice: 100, total: 1000, tax: 100 },
+        ],
+      }),
+    );
+    expect(result.lineItems).toHaveLength(1);
+    expect(result.lineItems![0]).toMatchObject({
+      description: 'Tiling',
+      quantity: 10,
+      unitPrice: 100,
+      total: 1000,
+      tax: 100,
+    });
+  });
+
+  it('omits null fields (no vendorName key when vendor is null)', () => {
+    const result = normalizedQuotationToFormValues(makeNormalizedQuotation());
+    expect(result).not.toHaveProperty('vendorName');
+    expect(result).not.toHaveProperty('reference');
+    expect(result).not.toHaveProperty('date');
+    expect(result).not.toHaveProperty('expiryDate');
+    expect(result).not.toHaveProperty('total');
+    expect(result).not.toHaveProperty('subtotal');
+    expect(result).not.toHaveProperty('taxTotal');
+    expect(result).not.toHaveProperty('notes');
+    expect(result.lineItems).toBeUndefined();
+  });
+
+  it('does not include lineItems when list is empty', () => {
+    const result = normalizedQuotationToFormValues(
+      makeNormalizedQuotation({ lineItems: [] }),
+    );
+    expect(result.lineItems).toBeUndefined();
+  });
+});

--- a/progress.md
+++ b/progress.md
@@ -1,4 +1,66 @@
-# Project Progress — Summary (updated 2026-04-10)
+# Project Progress — Summary (updated 2026-04-20)
+
+## ✅ LLM Quotation Parser Feature — Enhanced Quotation Extraction & Form Population
+**Status**: COMPLETED  
+**Branch**: `feature/llm-quotation-parser`  
+**Date Completed**: 2026-04-20
+
+### Changes Made
+- **New Domain/Application Layer**:
+  - `src/application/ai/IQuotationParsingStrategy.ts`: Strategy interface + `NormalizedQuotation` type (supplier, items, totals)
+  - `src/application/ai/QuotationParserFactory.ts`: Config-driven factory for strategy creation (Groq LLM)
+  - `src/application/usecases/quotation/ProcessQuotationUploadUseCase.ts`: Quotation-specific upload pipeline (OCR → parsing → form mapping)
+
+- **New Infrastructure/Utils**:
+  - `src/infrastructure/ai/LlmQuotationParser.ts`: Groq-powered LLM parser (follows GroqTranscriptParser pattern)
+  - `src/utils/normalizedQuotationToFormValues.ts`: Maps `NormalizedQuotation` → `Partial<Quotation>` form values
+
+- **UI Integration**:
+  - `src/pages/quotations/QuotationScreen.tsx`: Replaced `IInvoiceNormalizer` with `IQuotationParsingStrategy`; uses `ProcessQuotationUploadUseCase` + form mapping
+  - `src/pages/dashboard/index.tsx`: Creates `LlmQuotationParser` via `useMemo` with `GROQ_API_KEY`; passes to `QuotationScreen` with OCR adapter + PDF converter
+
+- **Test Coverage**:
+  - **New Unit Tests**: `LlmQuotationParser.test.ts`, `QuotationParserFactory.test.ts`, `ProcessQuotationUploadUseCase.test.ts`, `normalizedQuotationToFormValues.test.ts` (36 new assertions)
+  - **Updated**: `QuotationScreen.upload.test.tsx` (mocks updated from `IInvoiceNormalizer` to `IQuotationParsingStrategy`)
+  - **Test Results**: 223 suites (+4 new), 1465 tests passed (+36 new), 0 failures
+
+- **Verification**:
+  - **ESLint**: `npm run lint` passes with **0 errors** (77 pre-existing warnings unchanged)
+  - **TypeScript**: `npx tsc --noEmit` passes (strict mode)
+  - **Test Suite**: All 1465 tests passing
+
+### Acceptance Criteria
+All criteria met:
+- ✅ `IQuotationParsingStrategy` interface defined with `parse()` method
+- ✅ `LlmQuotationParser` implements strategy using Groq API
+- ✅ `ProcessQuotationUploadUseCase` handles full quotation extraction pipeline
+- ✅ `normalizedQuotationToFormValues` maps extracted data to Quotation form
+- ✅ QuotationScreen integrates new strategy via dependency injection
+- ✅ Dashboard creates parser and injects dependencies correctly
+- ✅ All 36 new test assertions passing
+- ✅ ESLint: 0 errors; TypeScript: strict mode passes
+- ✅ 1465 tests passing (including 36 new test cases)
+
+### Files Added (9)
+- `src/application/ai/IQuotationParsingStrategy.ts`
+- `src/infrastructure/ai/LlmQuotationParser.ts`
+- `src/application/ai/QuotationParserFactory.ts`
+- `src/application/usecases/quotation/ProcessQuotationUploadUseCase.ts`
+- `src/utils/normalizedQuotationToFormValues.ts`
+- `__tests__/unit/LlmQuotationParser.test.ts`
+- `__tests__/unit/QuotationParserFactory.test.ts`
+- `__tests__/unit/ProcessQuotationUploadUseCase.test.ts`
+- `__tests__/unit/normalizedQuotationToFormValues.test.ts`
+
+### Files Modified (3)
+- `src/pages/quotations/QuotationScreen.tsx`
+- `src/pages/dashboard/index.tsx`
+- `__tests__/unit/QuotationScreen.upload.test.tsx`
+
+### Design Doc
+- `design/quotation-ocr-enhancement.md`
+
+---
 
 ## ✅ Issue #205 — Fix TimelineInvoiceCard / TimelinePaymentCard — Add Edit Button, Remove Card-tap, Rename CTA
 **Status**: COMPLETED  

--- a/src/application/ai/IQuotationParsingStrategy.ts
+++ b/src/application/ai/IQuotationParsingStrategy.ts
@@ -1,0 +1,45 @@
+import { OcrResult } from '../services/IOcrAdapter';
+
+export interface NormalizedQuotationLineItem {
+  description: string;
+  quantity: number;
+  unit?: string;
+  unitPrice: number;
+  total: number;
+  tax?: number;
+}
+
+export interface NormalizedQuotation {
+  reference: string | null;
+  vendor: string | null;
+  vendorEmail: string | null;
+  vendorPhone: string | null;
+  vendorAddress: string | null;
+  taxId: string | null;
+  date: Date | null;
+  expiryDate: Date | null;
+  currency: string; // Default: 'AUD'
+  subtotal: number | null;
+  tax: number | null;
+  total: number | null;
+  lineItems: NormalizedQuotationLineItem[];
+  paymentTerms: string | null;
+  scope: string | null;
+  exclusions: string | null;
+  notes: string | null;
+  confidence: {
+    overall: number;
+    vendor: number;
+    reference: number;
+    date: number;
+    total: number;
+  };
+  suggestedCorrections: string[];
+}
+
+export type QuotationParsingStrategyType = 'regex' | 'llm';
+
+export interface IQuotationParsingStrategy {
+  readonly strategyType: QuotationParsingStrategyType;
+  parse(ocrResult: OcrResult): Promise<NormalizedQuotation>;
+}

--- a/src/application/ai/QuotationParserFactory.ts
+++ b/src/application/ai/QuotationParserFactory.ts
@@ -1,0 +1,28 @@
+import {
+  IQuotationParsingStrategy,
+  QuotationParsingStrategyType,
+} from './IQuotationParsingStrategy';
+import { LlmQuotationParser } from '../../infrastructure/ai/LlmQuotationParser';
+
+export interface QuotationParserConfig {
+  strategyType: QuotationParsingStrategyType;
+  /** Required when strategyType is 'llm' */
+  groqApiKey?: string;
+}
+
+export class QuotationParserFactory {
+  static create(config: QuotationParserConfig): IQuotationParsingStrategy {
+    if (config.strategyType === 'llm') {
+      if (!config.groqApiKey) {
+        throw new Error(
+          'QuotationParserFactory: groqApiKey is required for llm strategy',
+        );
+      }
+      return new LlmQuotationParser(config.groqApiKey);
+    }
+
+    throw new Error(
+      `QuotationParserFactory: unsupported strategyType '${config.strategyType}'`,
+    );
+  }
+}

--- a/src/application/usecases/quotation/ProcessQuotationUploadUseCase.ts
+++ b/src/application/usecases/quotation/ProcessQuotationUploadUseCase.ts
@@ -1,0 +1,144 @@
+import { IOcrAdapter } from '../../services/IOcrAdapter';
+import { IQuotationParsingStrategy, NormalizedQuotation } from '../../ai/IQuotationParsingStrategy';
+import { IPdfConverter } from '../../../infrastructure/files/IPdfConverter';
+import { IOcrDocumentService, OcrDocumentService } from '../../services/IOcrDocumentService';
+
+export interface ProcessQuotationUploadInput {
+  /** App-private URI to the file (already copied by QuotationScreen) */
+  fileUri: string;
+  filename: string;
+  mimeType: string;
+  fileSize: number;
+}
+
+export interface QuotationDocumentRef {
+  localPath: string;
+  filename: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface ProcessQuotationUploadOutput {
+  normalized: NormalizedQuotation;
+  documentRef: QuotationDocumentRef;
+  /** Raw OCR text, preserved for storage in Document.metadata */
+  rawOcrText: string;
+}
+
+/**
+ * ProcessQuotationUploadUseCase
+ *
+ * Orchestrates the end-to-end pipeline after a file has been selected and
+ * copied to app private storage:
+ *   1. (PDF only) Convert PDF pages to images via IPdfConverter
+ *   2. OCR → extract raw text from the image(s)
+ *   3. parse → strategy parses OcrResult into NormalizedQuotation
+ *   4. Return normalized result + a QuotationDocumentRef ready for atomic save
+ */
+export class ProcessQuotationUploadUseCase {
+  constructor(
+    private readonly ocrAdapter: IOcrAdapter,
+    private readonly parsingStrategy: IQuotationParsingStrategy,
+    private readonly pdfConverter?: IPdfConverter,
+    private readonly ocrDocumentService: IOcrDocumentService = new OcrDocumentService(ocrAdapter),
+  ) {}
+
+  async execute(
+    input: ProcessQuotationUploadInput,
+  ): Promise<ProcessQuotationUploadOutput> {
+    const { fileUri, filename, mimeType, fileSize } = input;
+
+    const documentRef: QuotationDocumentRef = {
+      localPath: fileUri,
+      filename,
+      size: fileSize,
+      mimeType,
+    };
+
+    // ── PDF path ─────────────────────────────────────────────────────────────
+    if (mimeType === 'application/pdf') {
+      if (!this.pdfConverter) {
+        return {
+          normalized: emptyNormalizedQuotation(),
+          documentRef,
+          rawOcrText: '',
+        };
+      }
+
+      try {
+        return await this.processPdf(fileUri, documentRef);
+      } catch (err: any) {
+        throw new Error(
+          `Quotation processing failed: ${err?.message ?? 'Unknown error'}`,
+        );
+      }
+    }
+
+    // ── Image path ───────────────────────────────────────────────────────────
+    try {
+      const ocrResult = await this.ocrAdapter.extractText(fileUri);
+      const rawOcrText = ocrResult.fullText;
+
+      const normalized = await this.parsingStrategy.parse(ocrResult);
+
+      return { normalized, documentRef, rawOcrText };
+    } catch (err: any) {
+      throw new Error(
+        `Quotation processing failed: ${err?.message ?? 'Unknown error'}`,
+      );
+    }
+  }
+
+  private async processPdf(
+    pdfUri: string,
+    documentRef: QuotationDocumentRef,
+  ): Promise<ProcessQuotationUploadOutput> {
+    const pages = await this.pdfConverter!.convertToImages(pdfUri);
+
+    if (pages.length === 0) {
+      return {
+        normalized: emptyNormalizedQuotation(),
+        documentRef,
+        rawOcrText: '',
+      };
+    }
+
+    const pageImageUris = pages.map((page) => page.uri);
+    const documentOcrResult = await this.ocrDocumentService.extractFromPages(pageImageUris);
+    const rawOcrText = documentOcrResult.rawText;
+
+    const normalized = await this.parsingStrategy.parse(documentOcrResult.merged);
+
+    return { normalized, documentRef, rawOcrText };
+  }
+}
+
+function emptyNormalizedQuotation(): NormalizedQuotation {
+  return {
+    reference: null,
+    vendor: null,
+    vendorEmail: null,
+    vendorPhone: null,
+    vendorAddress: null,
+    taxId: null,
+    date: null,
+    expiryDate: null,
+    currency: 'AUD',
+    subtotal: null,
+    tax: null,
+    total: null,
+    lineItems: [],
+    paymentTerms: null,
+    scope: null,
+    exclusions: null,
+    notes: null,
+    confidence: {
+      overall: 0,
+      vendor: 0,
+      reference: 0,
+      date: 0,
+      total: 0,
+    },
+    suggestedCorrections: [],
+  };
+}

--- a/src/infrastructure/ai/LlmQuotationParser.ts
+++ b/src/infrastructure/ai/LlmQuotationParser.ts
@@ -1,0 +1,198 @@
+import { OcrResult } from '../../application/services/IOcrAdapter';
+import {
+  IQuotationParsingStrategy,
+  NormalizedQuotation,
+  NormalizedQuotationLineItem,
+  QuotationParsingStrategyType,
+} from '../../application/ai/IQuotationParsingStrategy';
+
+const GROQ_CHAT_URL = 'https://api.groq.com/openai/v1/chat/completions';
+
+const SYSTEM_PROMPT = `You are a document parser for a construction project management app.
+Extract structured quotation/estimate information from OCR text of a PDF document.
+Respond ONLY with a valid JSON object matching this schema:
+{
+  "reference": string | null,
+  "vendor": string | null,
+  "vendorEmail": string | null,
+  "vendorPhone": string | null,
+  "vendorAddress": string | null,
+  "taxId": string | null,
+  "date": string | null,
+  "expiryDate": string | null,
+  "currency": string,
+  "subtotal": number | null,
+  "tax": number | null,
+  "total": number | null,
+  "lineItems": [
+    {
+      "description": string,
+      "quantity": number,
+      "unit": string | null,
+      "unitPrice": number,
+      "total": number,
+      "tax": number | null
+    }
+  ],
+  "paymentTerms": string | null,
+  "scope": string | null,
+  "exclusions": string | null,
+  "notes": string | null
+}
+Omit fields that are not found in the document (set to null).
+Do not wrap in markdown or code blocks.
+For dates, convert to ISO 8601 format (YYYY-MM-DD).
+For currency, detect from symbols ($=AUD for Australian context, \u20ac=EUR, \u00a3=GBP) or text.
+Extract ALL line items found in the document, even if formatting varies.`;
+
+function emptyNormalizedQuotation(): NormalizedQuotation {
+  return {
+    reference: null,
+    vendor: null,
+    vendorEmail: null,
+    vendorPhone: null,
+    vendorAddress: null,
+    taxId: null,
+    date: null,
+    expiryDate: null,
+    currency: 'AUD',
+    subtotal: null,
+    tax: null,
+    total: null,
+    lineItems: [],
+    paymentTerms: null,
+    scope: null,
+    exclusions: null,
+    notes: null,
+    confidence: {
+      overall: 0,
+      vendor: 0,
+      reference: 0,
+      date: 0,
+      total: 0,
+    },
+    suggestedCorrections: [],
+  };
+}
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function confidenceFor(value: unknown): number {
+  return value != null ? 0.9 : 0.0;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseResponse(raw: any): NormalizedQuotation {
+  const lineItems: NormalizedQuotationLineItem[] = Array.isArray(raw.lineItems)
+    ? raw.lineItems.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (item: any): NormalizedQuotationLineItem => ({
+          description: String(item.description ?? ''),
+          quantity: Number(item.quantity ?? 0),
+          unit: item.unit ?? undefined,
+          unitPrice: Number(item.unitPrice ?? 0),
+          total: Number(item.total ?? 0),
+          tax: item.tax != null ? Number(item.tax) : undefined,
+        }),
+      )
+    : [];
+
+  const date = parseDate(raw.date);
+  const expiryDate = parseDate(raw.expiryDate);
+  const vendor = raw.vendor ?? null;
+  const reference = raw.reference ?? null;
+  const total = raw.total != null ? Number(raw.total) : null;
+
+  const overall =
+    (confidenceFor(vendor) * 0.3 +
+      confidenceFor(reference) * 0.2 +
+      confidenceFor(date) * 0.2 +
+      confidenceFor(total) * 0.3);
+
+  return {
+    reference,
+    vendor,
+    vendorEmail: raw.vendorEmail ?? null,
+    vendorPhone: raw.vendorPhone ?? null,
+    vendorAddress: raw.vendorAddress ?? null,
+    taxId: raw.taxId ?? null,
+    date,
+    expiryDate,
+    currency: raw.currency ?? 'AUD',
+    subtotal: raw.subtotal != null ? Number(raw.subtotal) : null,
+    tax: raw.tax != null ? Number(raw.tax) : null,
+    total,
+    lineItems,
+    paymentTerms: raw.paymentTerms ?? null,
+    scope: raw.scope ?? null,
+    exclusions: raw.exclusions ?? null,
+    notes: raw.notes ?? null,
+    confidence: {
+      overall,
+      vendor: confidenceFor(vendor),
+      reference: confidenceFor(reference),
+      date: confidenceFor(date),
+      total: confidenceFor(total),
+    },
+    suggestedCorrections: [],
+  };
+}
+
+export class LlmQuotationParser implements IQuotationParsingStrategy {
+  readonly strategyType: QuotationParsingStrategyType = 'llm';
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly timeoutMs = 30_000,
+  ) {}
+
+  async parse(ocrResult: OcrResult): Promise<NormalizedQuotation> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(GROQ_CHAT_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'llama-3.3-70b-versatile',
+          messages: [
+            { role: 'system', content: SYSTEM_PROMPT },
+            { role: 'user', content: ocrResult.fullText },
+          ],
+          temperature: 0,
+          max_tokens: 1024,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`Groq LLM failed: HTTP ${res.status}`);
+      }
+
+      const body = await res.json();
+      const content: string = body.choices?.[0]?.message?.content ?? '{}';
+
+      try {
+        const parsed = JSON.parse(content);
+        return parseResponse(parsed);
+      } catch {
+        return emptyNormalizedQuotation();
+      }
+    } catch (err: unknown) {
+      const isAbort = err instanceof Error && err.name === 'AbortError';
+      throw isAbort
+        ? new Error(`Groq LLM timed out after ${this.timeoutMs}ms`)
+        : err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -15,6 +15,8 @@ import { QuotationScreen } from '../quotations/QuotationScreen';
 import { MobileOcrAdapter } from '../../infrastructure/ocr/MobileOcrAdapter';
 import { InvoiceNormalizer } from '../../application/ai/InvoiceNormalizer';
 import { PdfThumbnailConverter } from '../../infrastructure/files/PdfThumbnailConverter';
+import { LlmQuotationParser } from '../../infrastructure/ai/LlmQuotationParser';
+import { GROQ_API_KEY } from '@env';
 
 type DashboardNavigationProp = any;
 
@@ -40,6 +42,10 @@ export default function DashboardScreen() {
   const invoiceOcrAdapter = useMemo(() => new MobileOcrAdapter(), []);
   const invoiceNormalizer = useMemo(() => new InvoiceNormalizer(), []);
   const invoicePdfConverter = useMemo(() => new PdfThumbnailConverter(), []);
+  const quotationParser = useMemo(
+    () => (GROQ_API_KEY ? new LlmQuotationParser(GROQ_API_KEY) : undefined),
+    [],
+  );
 
   const handleQuickAction = (actionId: string) => {
     setShowQuickActions(false);
@@ -221,6 +227,9 @@ export default function DashboardScreen() {
         visible={showQuotation}
         onClose={() => setShowQuotation(false)}
         onSuccess={() => {}}
+        ocrAdapter={invoiceOcrAdapter}
+        pdfConverter={invoicePdfConverter}
+        parsingStrategy={quotationParser}
       />
     </SafeAreaView>
   );

--- a/src/pages/quotations/QuotationScreen.tsx
+++ b/src/pages/quotations/QuotationScreen.tsx
@@ -13,12 +13,12 @@ import { MobileFileSystemAdapter } from '../../infrastructure/files/MobileFileSy
 import { validatePdfFile } from '../../utils/fileValidation';
 import { PdfFileMetadata } from '../../types/PdfFileMetadata';
 import { IOcrAdapter } from '../../application/services/IOcrAdapter';
-import { IInvoiceNormalizer } from '../../application/ai/IInvoiceNormalizer';
+import { IQuotationParsingStrategy } from '../../application/ai/IQuotationParsingStrategy';
 import {
-  ProcessInvoiceUploadUseCase,
-} from '../../application/usecases/invoice/ProcessInvoiceUploadUseCase';
+  ProcessQuotationUploadUseCase,
+} from '../../application/usecases/quotation/ProcessQuotationUploadUseCase';
 import { IPdfConverter } from '../../infrastructure/files/IPdfConverter';
-import { normalizedInvoiceToQuotationFormValues } from '../../utils/normalizedInvoiceToQuotationFormValues';
+import { normalizedQuotationToFormValues } from '../../utils/normalizedQuotationToFormValues';
 
 cssInterop(X, { className: { target: 'style', nativeStyleToProp: { color: true } } });
 
@@ -32,8 +32,8 @@ interface Props {
   filePickerAdapter?: IFilePickerAdapter;
   fileSystemAdapter?: IFileSystemAdapter;
   ocrAdapter?: IOcrAdapter;
-  invoiceNormalizer?: IInvoiceNormalizer;
   pdfConverter?: IPdfConverter;
+  parsingStrategy?: IQuotationParsingStrategy;
 }
 
 export const QuotationScreen: React.FC<Props> = ({
@@ -43,8 +43,8 @@ export const QuotationScreen: React.FC<Props> = ({
   filePickerAdapter,
   fileSystemAdapter,
   ocrAdapter,
-  invoiceNormalizer,
   pdfConverter,
+  parsingStrategy,
 }) => {
   const { createQuotation, loading } = useQuotations();
 
@@ -57,9 +57,9 @@ export const QuotationScreen: React.FC<Props> = ({
   const filePicker = filePickerAdapter ?? new MobileFilePickerAdapter();
   const fileSystem = fileSystemAdapter ?? new MobileFileSystemAdapter();
 
-  const buildUseCase = (): ProcessInvoiceUploadUseCase | null => {
-    if (ocrAdapter && invoiceNormalizer) {
-      return new ProcessInvoiceUploadUseCase(ocrAdapter, invoiceNormalizer, pdfConverter);
+  const buildUseCase = (): ProcessQuotationUploadUseCase | null => {
+    if (ocrAdapter && parsingStrategy) {
+      return new ProcessQuotationUploadUseCase(ocrAdapter, parsingStrategy, pdfConverter);
     }
     return null;
   };
@@ -83,7 +83,7 @@ export const QuotationScreen: React.FC<Props> = ({
         fileSize: pdfFile.size,
       });
 
-      const initialValues = normalizedInvoiceToQuotationFormValues(output.normalized);
+      const initialValues = normalizedQuotationToFormValues(output.normalized);
       setFormInitialValues(initialValues);
       setFormPdfFile(pdfFile);
       setProcessingStep('idle');

--- a/src/utils/normalizedQuotationToFormValues.ts
+++ b/src/utils/normalizedQuotationToFormValues.ts
@@ -1,0 +1,78 @@
+import { Quotation, QuotationLineItem } from '../domain/entities/Quotation';
+import {
+  NormalizedQuotation,
+  NormalizedQuotationLineItem,
+} from '../application/ai/IQuotationParsingStrategy';
+
+/**
+ * Maps a NormalizedQuotation (from the LLM/regex parsing strategy) to the
+ * subset of Quotation fields accepted as `initialValues` by QuotationForm.
+ *
+ * Rules:
+ * - null/undefined normalized fields are omitted (let QuotationForm defaults apply)
+ * - Dates are converted to ISO strings as expected by QuotationForm state
+ * - lineItems are converted from NormalizedQuotationLineItem → QuotationLineItem
+ * - currency is always mapped (NormalizedQuotation always has a default)
+ */
+export function normalizedQuotationToFormValues(
+  normalized: NormalizedQuotation,
+): Partial<Quotation> {
+  const values: Partial<Quotation> = {};
+
+  if (normalized.vendor != null) {
+    values.vendorName = normalized.vendor;
+  }
+
+  if (normalized.reference != null) {
+    values.reference = normalized.reference;
+  }
+
+  if (normalized.date != null) {
+    values.date = normalized.date.toISOString();
+  }
+
+  if (normalized.expiryDate != null) {
+    values.expiryDate = normalized.expiryDate.toISOString();
+  }
+
+  if (normalized.total != null) {
+    values.total = normalized.total;
+  }
+
+  if (normalized.subtotal != null) {
+    values.subtotal = normalized.subtotal;
+  }
+
+  if (normalized.tax != null) {
+    values.taxTotal = normalized.tax;
+  }
+
+  if (normalized.vendorEmail != null) {
+    values.vendorEmail = normalized.vendorEmail;
+  }
+
+  if (normalized.vendorAddress != null) {
+    values.vendorAddress = normalized.vendorAddress;
+  }
+
+  if (normalized.notes != null) {
+    values.notes = normalized.notes;
+  }
+
+  // currency always has a default value in NormalizedQuotation
+  values.currency = normalized.currency;
+
+  if (normalized.lineItems.length > 0) {
+    values.lineItems = normalized.lineItems.map(
+      (item: NormalizedQuotationLineItem): QuotationLineItem => ({
+        description: item.description,
+        quantity: item.quantity,
+        unitPrice: item.unitPrice,
+        total: item.total,
+        tax: item.tax,
+      }),
+    );
+  }
+
+  return values;
+}


### PR DESCRIPTION
## Summary

Implements an LLM-powered quotation document parser using the strategy pattern, replacing the reuse of `InvoiceNormalizer` for quotation OCR.

### New Files (9)
- `src/application/ai/IQuotationParsingStrategy.ts` — Strategy interface + `NormalizedQuotation` type (18 fields)
- `src/infrastructure/ai/LlmQuotationParser.ts` — Groq LLM parser (mirrors `GroqTranscriptParser` pattern)
- `src/application/ai/QuotationParserFactory.ts` — Config-based factory (`llm` → parser, `regex` → throws)
- `src/application/usecases/quotation/ProcessQuotationUploadUseCase.ts` — PDF/image → OCR → LLM → NormalizedQuotation pipeline
- `src/utils/normalizedQuotationToFormValues.ts` — Maps 13 fields incl. vendorEmail, vendorAddress, subtotal, tax
- `__tests__/unit/LlmQuotationParser.test.ts`
- `__tests__/unit/QuotationParserFactory.test.ts`
- `__tests__/unit/ProcessQuotationUploadUseCase.test.ts`
- `__tests__/unit/normalizedQuotationToFormValues.test.ts`

### Modified Files (3)
- `src/pages/quotations/QuotationScreen.tsx` — Swapped `IInvoiceNormalizer` → `IQuotationParsingStrategy`
- `src/pages/dashboard/index.tsx` — Wires `LlmQuotationParser` with `GROQ_API_KEY` via `useMemo`
- `__tests__/unit/QuotationScreen.upload.test.tsx` — Updated mocks for strategy pattern

### Validation
- [x] TypeScript: 0 errors (strict mode)
- [x] Tests: 223 suites, 1465 passed (+36 new), 0 failures
- [x] Lint: 0 errors

### Design Doc
See `design/quotation-ocr-enhancement.md` for full architecture details.